### PR TITLE
fix: 修复popup和dialog同时出现时，几率出现dialog被挡住的情况

### DIFF
--- a/packages/dialog/src/dialog.vue
+++ b/packages/dialog/src/dialog.vue
@@ -37,6 +37,10 @@ export default {
     },
     lockOnScroll: {
       default: true
+    },
+    zIndex: {
+      type: [String, Number],
+      default: 2500
     }
   },
 


### PR DESCRIPTION
1. 将dialog的基础z-index设置为2500
popup 2000+
dialog 2500+
toast 3000+