### PR TITLE
[bug fix] PullRefreash: when $parents.$el scrollable, pull refreash trigger error

### DIFF
--- a/packages/pull-refresh/index.vue
+++ b/packages/pull-refresh/index.vue
@@ -28,6 +28,7 @@
 
 <script>
 import Loading from '../loading';
+import Utils from '../utils/scroll';
 
 export default {
   name: 'van-pull-refresh',
@@ -140,7 +141,7 @@ export default {
     },
 
     getCeiling() {
-      this.ceiling = (window.scrollY || window.pageYOffset) === 0;
+      this.ceiling = Utils.getScrollTop(Utils.getScrollEventTarget(this.$el)) === 0;
       return this.ceiling;
     },
 


### PR DESCRIPTION
当下拉刷新元素的父级（非window）有可滚动元素的时候，刷新触发时机错误，下拉刷新不可用