### PR TITLE
[optimize & bug fix] Button: 优化layer, 修复滚动时, gpu占用过高情况

### DIFF
--- a/packages/vant-css/src/button.css
+++ b/packages/vant-css/src/button.css
@@ -11,6 +11,7 @@
   font-size: 16px;
   text-align: center;
   -webkit-appearance: none;
+  z-index: 0;
 
   &::before {
     content: " ";
@@ -24,7 +25,7 @@
     border-color: $black;
     background-color: $black;
     border-radius: inherit;/* inherit parent's border radius */
-    transform: translate3d(-50%, -50%, 0); 
+    transform: translate(-50%, -50%); 
   }
 
   &:not([disabled]):active::before {

--- a/packages/vant-css/src/button.css
+++ b/packages/vant-css/src/button.css
@@ -11,7 +11,6 @@
   font-size: 16px;
   text-align: center;
   -webkit-appearance: none;
-  z-index: 0;
 
   &::before {
     content: " ";

--- a/packages/vant-css/src/loading.css
+++ b/packages/vant-css/src/loading.css
@@ -28,6 +28,8 @@
   &__spinner {
     width: 100%;
     height: 100%;
+    position: relative;
+    z-index: -1;
     display: inline-block;
     animation: van-loading 0.8s linear infinite;
 

--- a/packages/vant-css/src/loading.css
+++ b/packages/vant-css/src/loading.css
@@ -12,6 +12,8 @@
 .van-loading {
   font-size: 0;
   line-height: 0;
+  z-index: 0;
+  position: relative;
 
   &--circle {
     width: 16px;


### PR DESCRIPTION
### 优化Button的Layer

问题页面: [https://www.youzanyun.com/zanui/vant/examples#/zh-CN/component/button](https://www.youzanyun.com/zanui/vant/examples#/zh-CN/component/button)

#### 优化前Layer

![vant-buttom-layer-0](https://user-images.githubusercontent.com/12824616/33082137-fbd8a52a-cf16-11e7-90da-bea8c016dc9e.png)

#### 优化后Layer

因为spinner有旋转的动画所以需要独立的layer~, 其他的不需要~

![vant-buttom-layer-1](https://user-images.githubusercontent.com/12824616/33082143-00a3e826-cf17-11e7-9252-c5c5e3557966.png)

#### 优化前滚动占用GPU的情况
![vant-bottom-layer-1](https://user-images.githubusercontent.com/12824616/33082221-331a52fe-cf17-11e7-862c-fdc9861b3cc4.gif)


#### 优化后滚动GPU占用正常

![vant-bottom-layer-0](https://user-images.githubusercontent.com/12824616/33082247-42546430-cf17-11e7-8733-f412fbb381ec.gif)


