### PR TITLE
[new feature]Popup: 增加遮罩层overlayClass和overlayStyle属性，以提供遮罩层自定义样式

### DIFF
--- a/packages/mixins/popup/index.js
+++ b/packages/mixins/popup/index.js
@@ -28,7 +28,15 @@ export default {
     preventScroll: {
       type: Boolean,
       default: false
-    }
+    },
+    overlayClass: {
+      type: String,
+      default: ''
+    },
+    overlayStyle: {
+      type: String,
+      default: ''
+    },
   },
 
   watch: {
@@ -104,6 +112,8 @@ export default {
         }
       }
 
+      this.$el.style.cssText = this.$el.style.cssText + ` ${this.overlayStyle}`;
+      this.$el.className = this.$el.className + ` ${this.overlayClass}`;
       this.$el.style.zIndex = context.plusKeyByOne('zIndex');
       this.opened = true;
 


### PR DESCRIPTION
给mixins里popup增加了两个props，overlayClass和overlayStyle，并赋值到创建的dom里，以便自定义遮罩层的样式。