### PR TITLE
[Improvement] package.json: include "types" in "files" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "typings": "types/index.d.ts",
   "files": [
     "lib",
-    "packages"
+    "packages",
+    "types"
   ],
   "scripts": {
     "bootstrap": "yarn || npm i && cd ./packages/vant-css/ && yarn || npm i && cd ../../",


### PR DESCRIPTION
Changes you made in this pull request:

- add "types" in "files" field of package.json to deliver types in npm package