### PR TITLE
[Improvement] Mixins: treat empty string as true for boolean props

### DIFF
--- a/packages/actionsheet/index.vue
+++ b/packages/actionsheet/index.vue
@@ -51,9 +51,11 @@ export default create({
       default: () => []
     },
     overlay: {
+      type: Boolean,
       default: true
     },
     closeOnClickOverlay: {
+      type: Boolean,
       default: true
     }
   },

--- a/packages/dialog/dialog.vue
+++ b/packages/dialog/dialog.vue
@@ -59,12 +59,15 @@ export default create({
       default: false
     },
     overlay: {
+      type: Boolean,
       default: true
     },
     closeOnClickOverlay: {
+      type: Boolean,
       default: false
     },
     lockOnScroll: {
+      type: Boolean,
       default: true
     }
   },

--- a/packages/image-preview/image-preview.vue
+++ b/packages/image-preview/image-preview.vue
@@ -12,7 +12,7 @@
         <img class="van-image-preview__image" :src="item" >
       </swipe-item>
     </swipe>
-  </div>  
+  </div>
 </template>
 
 <script>
@@ -33,9 +33,11 @@ export default create({
 
   props: {
     overlay: {
+      type: Boolean,
       default: true
     },
     closeOnClickOverlay: {
+      type: Boolean,
       default: true
     }
   },

--- a/packages/popup/index.vue
+++ b/packages/popup/index.vue
@@ -18,12 +18,15 @@ export default create({
   props: {
     transition: String,
     overlay: {
+      type: Boolean,
       default: true
     },
     lockOnScroll: {
+      type: Boolean,
       default: false
     },
     closeOnClickOverlay: {
+      type: Boolean,
       default: true
     },
     position: {

--- a/test/unit/specs/popup.spec.js
+++ b/test/unit/specs/popup.spec.js
@@ -113,4 +113,16 @@ describe('Popup', () => {
       }, 300);
     }, 300);
   });
+
+  it('treat empty string as true for boolean props', () => {
+    wrapper = mount(Popup, {
+      propsData: {
+        overlay: '',
+        lockOnScroll: '',
+        closeOnClickOverlay: ''
+      }
+    });
+
+    expect(wrapper.vm.lockOnScroll).to.be.true;
+  });
 });


### PR DESCRIPTION
Fixes #466

Changes you made in this pull request:

- treat the empty string as true for boolean props

Enable the syntax suger `<van-popup lock-on-scroll />`, other than boolean binding `<van-popup :lock-on-scroll="true" />`;