### PR TITLE
[Improvement] Icon: align middle when inline with text

### DIFF
--- a/packages/vant-css/src/icon.css
+++ b/packages/vant-css/src/icon.css
@@ -13,6 +13,7 @@
   font: normal normal normal 14px/1 "vant-icon";
   font-size: inherit;
   text-rendering: auto;
+  vertical-align: -0.18em;
 
   &__info {
     color: #fff;


### PR DESCRIPTION
Fixes #469 

Changes you made in this pull request:

- add and adjust the vertical-align for the icon to make it look perfect when using inline with text.
