### PR TITLE
[bug fix] PullRefresh: 水平滑动时避免触发下拉刷新

### DIFF
--- a/packages/pull-refresh/index.vue
+++ b/packages/pull-refresh/index.vue
@@ -111,9 +111,9 @@ export default create({
 
       if (this.ceiling && this.deltaY >= 0) {
         if (this.direction === 'vertical') {
+          this.getStatus(this.ease(this.deltaY));
           event.preventDefault();
         }
-        this.getStatus(this.ease(this.deltaY));
       }
     },
 


### PR DESCRIPTION
有时我们想要使用下拉刷新的同时支持水平滑动，此次提交避免在水平滑动的时候触发下拉刷新
