### PR TITLE
[bug fix] Stepper: not fire event on changing the value prop

### DIFF
--- a/packages/stepper/index.vue
+++ b/packages/stepper/index.vue
@@ -77,11 +77,6 @@ export default create({
   },
 
   watch: {
-    currentValue(val) {
-      this.$emit('input', val);
-      this.$emit('change', val);
-    },
-
     value(val) {
       val = this.correctValue(+val);
       if (val !== this.currentValue) {
@@ -105,6 +100,7 @@ export default create({
     onInput(event) {
       const val = +event.target.value;
       this.currentValue = this.correctValue(val);
+      this.emitInput();
     },
 
     onChange(type) {
@@ -116,7 +112,13 @@ export default create({
       const step = +this.step;
       const currentValue = +this.currentValue;
       this.currentValue = type === 'minus' ? (currentValue - step) : (currentValue + step);
+      this.emitInput();
       this.$emit(type);
+    },
+
+    emitInput() {
+      this.$emit('input', this.currentValue);
+      this.$emit('change', this.currentValue);
     }
   }
 });

--- a/test/unit/specs/stepper.spec.js
+++ b/test/unit/specs/stepper.spec.js
@@ -79,13 +79,11 @@ describe('Stepper', () => {
     });
 
     expect(wrapper.hasClass('van-stepper')).to.be.true;
-    const eventStub = sinon.stub(wrapper.vm, '$emit');
 
     wrapper.vm.value = 2;
     wrapper.update();
     wrapper.vm.$nextTick(() => {
-      expect(eventStub.calledWith('input'));
-      expect(eventStub.calledWith('change'));
+      expect(wrapper.vm.currentValue).to.equal(2);
       done();
     });
   });
@@ -132,6 +130,22 @@ describe('Stepper', () => {
     wrapper.update();
     wrapper.vm.$nextTick(() => {
       expect(wrapper.data().currentValue).to.equal(2);
+      done();
+    });
+  });
+
+  it('should not fire any event on props changed', (done) => {
+    wrapper = mount(Stepper, {
+      propsData: {
+        value: 1
+      }
+    });
+    const eventStub = sinon.stub(wrapper.vm, '$emit');
+
+    wrapper.vm.value = 2;
+    wrapper.update();
+    wrapper.vm.$nextTick(() => {
+      expect(eventStub.called).to.be.false;
       done();
     });
   });


### PR DESCRIPTION
Fixes #545

Changes you made in this pull request:

- stop firing events by watching the value prop
- fire events in the callbacks `onInput` and `onChange`
