### PR TITLE
[bugfix] Cell: fix required style

### DIFF
--- a/packages/vant-css/src/cell.css
+++ b/packages/vant-css/src/cell.css
@@ -72,7 +72,7 @@
     &::before {
       content: '*';
       position: absolute;
-      left: -7px;
+      left: 7px;
       font-size: 14px;
       color: $red;
     }


### PR DESCRIPTION
修复 
> ^0.12.0  版本更新内容
> CellGroup 左内边距移至 Cell 内 

导致 `.van-cell--required::before`  绝对定位 ` left ` 的错位。