### PR TITLE
[bugfix] Button: vertical align incorrect when loading and loading no in center

### DIFF
--- a/packages/vant-css/src/button.css
+++ b/packages/vant-css/src/button.css
@@ -11,6 +11,7 @@
   font-size: 16px;
   text-align: center;
   -webkit-appearance: none;
+  vertical-align: middle;
 
   &::before {
     content: " ";
@@ -74,7 +75,7 @@
 
   &--loading {
     .van-loading {
-      display: inline-block;
+      margin: 0 auto;
     }
 
     .van-button__text {


### PR DESCRIPTION
Fixes #850 

Changes you made in this pull request:

- packages/vant-css/src/button.css
use vertical-align:middle ; in vant-button

