### PR TITLE
[bug fix] #930 tabs组件，不同tabs下的swiper组件错误

### DIFF
--- a/packages/tab/index.vue
+++ b/packages/tab/index.vue
@@ -1,6 +1,6 @@
 <template>
   <div :class="b('pane', { select: index === parent.curActive })">
-    <slot />
+    <slot v-if="index === parent.curActive" />
   </div>
 </template>
 


### PR DESCRIPTION
原因：
tabContent未激活的时候，里面的内容也会进行初始化；由于swiper会动态获取内容宽高，所以导致swipe错误；

修复方式：
在tabContent未激活的情况下，slot内容不进行初始化，并且更加符合按需加载的逻辑。