### PR TITLE
[bug fix] #853 imagePreview的问题

### DIFF
--- a/packages/image-preview/image-preview.vue
+++ b/packages/image-preview/image-preview.vue
@@ -7,7 +7,7 @@
     @touchend="onTouchEnd"
     @touchcancel="onTouchEnd"
   >
-    <swipe :initial-swipe="startPosition">
+    <swipe :initial-swipe="startPosition" ref="swipe">
       <swipe-item v-for="(item, index) in images" :key="index">
         <img :class="b('image')" :src="item" >
       </swipe-item>
@@ -58,9 +58,12 @@ export default create({
 
     onTouchEnd(event) {
       event.preventDefault();
-      // prevent long tap to close component
+
       const deltaTime = new Date() - this.touchStartTime;
-      if (deltaTime < 100 && this.offsetX < 20 && this.offsetY < 20) {
+      const { offsetX, offsetY } = this.$refs.swipe;
+
+      // prevent long tap to close component
+      if (deltaTime < 100 && offsetX < 20 && offsetY < 20) {
         this.$emit('input', false);
       }
     }


### PR DESCRIPTION
原因是：touchend有一个逻辑，就是如果是短按（拖动偏移量小于20并且触碰时间小于100毫秒）的话，关闭组件；但是这里有个问题就是，this.offsetX, this.offsetY一直是0，因为触发touchMove的元素是swipe组件。

修复方式：
偏移量的值从swipe组件上获取即可