### PR TITLE
[bugfix] Locale: should install locale to external Vue's prototype

### DIFF
--- a/docs/demos/common.js
+++ b/docs/demos/common.js
@@ -24,6 +24,7 @@ const demoBaseMixin = {
 
 window.Toast = Toast;
 window.Dialog = Dialog;
+Vue.use(Locale);
 Vue.mixin(i18n);
 Vue.mixin(demoBaseMixin);
 Vue.component('demo-block', DemoBlock);

--- a/docs/markdown/en-US/i18n.md
+++ b/docs/markdown/en-US/i18n.md
@@ -5,8 +5,11 @@ The default language of Vant is Chinese. If you want to use other languages, you
 Vant supports multiple languages with the Locale component, and the `Locale.use` method allows you to switch to diffrent languages.
 
 ```js
+import Vue from 'vue';
 import { Locale } from 'vant';
 import enUS from 'vant/lib/locale/lang/en-US';
+
+Vue.use(Locale);
 
 Locale.use('en-US', enUS);
 ```
@@ -15,7 +18,10 @@ Locale.use('en-US', enUS);
 Use `Locale.add` method to modify the default configs.
 
 ```js
+import Vue from 'vue';
 import { Locale } from 'vant';
+
+Vue.use(Locale);
 
 const messages = {
   'en-US': {

--- a/docs/markdown/zh-CN/i18n.md
+++ b/docs/markdown/zh-CN/i18n.md
@@ -5,8 +5,11 @@ Vant 默认采用中文作为语言，如果需要使用其他语言，可以参
 Vant 通过 Locale 组件实现多语言支持，使用 `Locale.use` 方法可以切换当前使用的语言。
 
 ```js
+import Vue from 'vue';
 import { Locale } from 'vant';
 import enUS from 'vant/lib/locale/lang/en-US';
+
+Vue.use(Locale);
 
 Locale.use('en-US', enUS);
 ```
@@ -15,7 +18,10 @@ Locale.use('en-US', enUS);
 通过 `Locale.add` 方法可以实现文案的修改和扩展，示例如下：
 
 ```js
+import Vue from 'vue';
 import { Locale } from 'vant';
+
+Vue.use(Locale);
 
 const messages = {
   'zh-CN': {

--- a/packages/locale/index.js
+++ b/packages/locale/index.js
@@ -1,28 +1,39 @@
-import Vue from 'vue';
 import deepAssign from '../utils/deep-assign';
 import defaultMessages from './lang/zh-CN';
 
-const proto = Vue.prototype;
-const defaultLang = 'zh-CN';
+const defaults = {
+  root: null,
+  lang: 'zh-CN'
+};
+
 const locale = {
-  install() {
-    if (proto.$vantLang) {
+  install(Vue) {
+    const { root, lang } = defaults;
+
+    if (root && root.$vantLang) {
       return;
     }
-    Vue.util.defineReactive(proto, '$vantLang', defaultLang);
-    Vue.util.defineReactive(proto, '$vantMessages', { [defaultLang]: defaultMessages });
+    defaults.root = Vue.prototype;
+    Vue.util.defineReactive(defaults.root, '$vantLang', lang);
+    Vue.util.defineReactive(defaults.root, '$vantMessages', { [lang]: defaultMessages });
   },
 
   use(lang, messages) {
-    proto.$vantLang = lang;
-    this.add({ [lang]: messages });
+    const { root } = defaults;
+
+    if (root) {
+      root.$vantLang = lang;
+      this.add({ [lang]: messages });
+    }
   },
 
   add(messages = {}) {
-    deepAssign(proto.$vantMessages, messages);
+    const { root } = defaults;
+
+    if (root) {
+      deepAssign(root.$vantMessages, messages);
+    }
   }
 };
-
-locale.install();
 
 export default locale;


### PR DESCRIPTION
问题描述：

当用**parcel**或**webpack**对代码打包后，凡是有`$t('xxx')`的地方都会报错。

因为`locale.install()`里面没有将`$vantLang`设置到外部Vue原型上，导致在`$t()`里面取`this.$vantMessages[this.$vantLang]`时产生`Can not read property 'undefined' of  'undefined'`错误。