### PR TITLE
[new feature] Dialog: beforeClose Add callback parameters

### DIFF
--- a/packages/dialog/dialog.vue
+++ b/packages/dialog/dialog.vue
@@ -80,8 +80,10 @@ export default create({
     handleAction(action) {
       if (this.beforeClose) {
         this.loading[action] = true;
-        this.beforeClose(action, () => {
-          this.onClose(action);
+        this.beforeClose(action, state => {
+          if (state !== false) {
+            this.onClose(action);
+          }
           this.loading[action] = false;
         });
       } else {


### PR DESCRIPTION
 [new feature] Dialog: 给beforeClose添加回调参数 当done回调false时弹层不关闭，停止loading滚动

实际使用中需要用到beforeClose的情景下存在用户输入不符合规范必须停止下一步操作的情况。
不执行done按钮 loading会一直滚动，执行done弹层又会被关闭，只能通过`this.$refs.dialog.loading.confirm = false`来停止loading滚动，这显然是不科学的。

