### PR TITLE
fix:actionsheet的标题div没有值设置具体值导致rem布局不自适应

### DIFF
--- a/packages/vant-css/src/actionsheet.css
+++ b/packages/vant-css/src/actionsheet.css
@@ -43,7 +43,7 @@
   }
 
   &__header {
-    font-size:16px;
+    font-size: 16px;
     line-height: 44px;
     text-align: center;
 

--- a/packages/vant-css/src/actionsheet.css
+++ b/packages/vant-css/src/actionsheet.css
@@ -43,9 +43,10 @@
   }
 
   &__header {
+    font-size:16px;
     line-height: 44px;
     text-align: center;
-    font-size:18px;
+
     .van-icon-close {
       top: 0;
       right: 0;

--- a/packages/vant-css/src/actionsheet.css
+++ b/packages/vant-css/src/actionsheet.css
@@ -45,7 +45,9 @@
   &__header {
     line-height: 44px;
     text-align: center;
-
+		div{
+			font-size:16px;
+		}
     .van-icon-close {
       top: 0;
       right: 0;

--- a/packages/vant-css/src/actionsheet.css
+++ b/packages/vant-css/src/actionsheet.css
@@ -45,9 +45,7 @@
   &__header {
     line-height: 44px;
     text-align: center;
-		div{
-			font-size:16px;
-		}
+    font-size:18px;
     .van-icon-close {
       top: 0;
       right: 0;


### PR DESCRIPTION
### actionsheet的标题div没有值设置具体值导致rem布局不自适应

* [bug fix] div: 修改css

![场景截图](http://oetrwxnhv.bkt.clouddn.com/vant-actionsheet.png)

- smallwei
