### PR TITLE
[bug fix]Stepper: 修复IOS 11.4.1下小数无法输入

### DIFF
--- a/docs/src/components/DemoPages.vue
+++ b/docs/src/components/DemoPages.vue
@@ -6,6 +6,7 @@
       <div
         :class="['van-doc-demo-pages__item', { 'van-doc-demo-pages__item--active': index === currentDemo }]"
         v-for="(demo, index) in demos"
+        :key="index"
       >
         <h4>{{ demo.title }}</h4>
         <a :href="demo.source" target="_blank">{{ $t('source') }}</a>

--- a/packages/stepper/index.vue
+++ b/packages/stepper/index.vue
@@ -99,9 +99,14 @@ export default create({
     },
 
     onInput(event) {
-      const { value } = event.target;
-      this.currentValue = Math.min(this.max, value);
-      event.target.value = this.currentValue;
+      const { value: _value } = event.target;
+      const value = +this.max > +_value ? _value : this.max;
+      if (typeof value === 'string' && value.endsWith('.')) {
+        event.target.value = value;
+      } else {
+        event.target.value = +value;
+      }
+      this.currentValue = +value;
       this.emitInput();
     },
 


### PR DESCRIPTION
bug 复现环境: 
 IOS safari 或者微信内打开stepper基础示例，输入小数例如2.5，得到结果25。


