### PR TITLE
[bug fix]Fix `Popup` of setting `getContainer` when the parent component is destroyed and the DOM object is not destroyed

### DIFF
--- a/packages/mixins/popup/index.js
+++ b/packages/mixins/popup/index.js
@@ -83,6 +83,7 @@ export default {
 
   beforeDestroy() {
     this.close();
+    this.$el.remove();
   },
 
   deactivated() {

--- a/packages/mixins/popup/index.js
+++ b/packages/mixins/popup/index.js
@@ -83,7 +83,10 @@ export default {
 
   beforeDestroy() {
     this.close();
-    this.$el.remove();
+    
+    if (this.getContainer) {
+      this.$parent.$el.appendChild(this.$el);
+    }
   },
 
   deactivated() {


### PR DESCRIPTION
修复设置`getContainer`的`Popup`在父级组件销毁时DOM对象没有销毁