### PR TITLE
[Doc] 修正文档错别字“阙值、阀值”为阈值

### DIFF
--- a/packages/tab/zh-CN.md
+++ b/packages/tab/zh-CN.md
@@ -33,7 +33,7 @@ export default {
 
 #### 横向滚动
 
-默认情况下多于4个tab时，可以横向滚动tab。可以通过设置`swipe-threshold`这个阙值，多于这个阙值时，tab就会支持横向滚动。
+默认情况下多于4个tab时，可以横向滚动tab。可以通过设置`swipe-threshold`这个阈值，多于这个阈值时，tab就会支持横向滚动。
 
 ```html
 <van-tabs>
@@ -144,7 +144,7 @@ export default {
 | type | 样式类型，可选值为 `line` `card` | `String` | `line` |
 | duration | 切换 tab 的动画时间 | `Number` | `0.2` |
 | line-width | 底部条宽度 (px) | `Number` | 与当前标签等宽 |
-| swipe-threshold | 滚动阀值，设置 Tab 超过多少个可滚动 | `Number` | `4` |
+| swipe-threshold | 滚动阈值，设置 Tab 超过多少个可滚动 | `Number` | `4` |
 | sticky | 是否使用粘性定位布局 | `Boolean` | `false` |
 | offset-top | 粘性定位布局下与顶部的最小距离 (px) | `Number` | `0` |
 | swipeable | 是否可以滑动内容切换 | `Boolean` | `false` |


### PR DESCRIPTION
Changes you made in this pull request:

修正 van-tab 组件内说明文档的错别字“阙值、阀值”为阈值
