### PR TITLE
[Doc] 补全 van-pagination 组件文档中缺少的 total-items 属性和 page-count 属性的说明

### DIFF
--- a/packages/pagination/en-US.md
+++ b/packages/pagination/en-US.md
@@ -56,7 +56,9 @@ export default {
 |-----------|-----------|-----------|-------------|
 | v-model | Current page number | `Number` | - |
 | mode | Mode, can be set to `simple` `multi` | `String` | `multi` |
+| total-items | Total items | `Number` | `0` |
 | items-per-page | Item number per page | `Number` | `10` |
+| page-count | The total number of pages, if not set, will be calculated based on `total-items` and `items-per-page` | `Number` | `-` |
 | prev-text | Previous text | `String` | `Previous` |
 | next-text | Next text | `String` | `Next` |
 | show-page-size | Count of page size to show | `Number` | `5` |

--- a/packages/pagination/zh-CN.md
+++ b/packages/pagination/zh-CN.md
@@ -58,7 +58,9 @@ export default {
 |-----------|-----------|-----------|-------------|
 | v-model | 当前页码 | `Number` | - |
 | mode | 显示模式，可选值为 `simple` `multi` | `String` | `multi` |
+| total-items | 总记录数 | `Number` | `0` |
 | items-per-page | 每页记录数 | `Number` | `10` |
+| page-count | 总页数，如果不设置将以 `total-items` 和 `items-per-page` 为准进行计算 | `Number` | `-` |
 | prev-text | 上一页 | `String` | `上一页` |
 | next-text | 下一页 | `String` | `下一页` |
 | show-page-size | 显示的页码个数 | `Number` | `5` |


### PR DESCRIPTION
补全 van-pagination 组件文档中缺少的 total-items 属性和 page-count 属性的说明