### PR TITLE
[Rendering is crashed while this.$vantMessages is undefined]i18n.js：修复逻辑不完善导致渲染崩溃问题

### DIFF
--- a/packages/mixins/i18n.js
+++ b/packages/mixins/i18n.js
@@ -7,8 +7,8 @@ export default {
       const { name } = this.$options;
       const prefix = name ? camelize(name) + '.' : '';
 
-      if (process.env.NODE_ENV !== 'production' && !this.$vantMessages) {
-        console.warn('[Vant] Locale not correctly registered.');
+      if (!this.$vantMessages) {
+        if(process.env.NODE_ENV !== 'production') console.warn('[Vant] Locale not correctly registered.');
         return () => '';
       }
 


### PR DESCRIPTION
i18n.js的代码中if判断有问题，当this.$vantMessages为undefined时，程序渲染失败而崩溃。导致页面白板或是部分组件渲染失败。
但这个问题再初次安装执行npm i 后的程序并不会出现。只在package.json中版本号前带^符号时，再次执行npm i后会重现，即不能写"vant": "^1.3.1"，必须写成"vant": "1.3.1"。这样才不会出现这个问题。推测可能是跟npm自动升级其他组件后影响所致。目前解决办法是去掉^符号，强制降级到1.3.0，执行npm i  ，再恢复为1.3.1。
目前已经在生产服务器出现过几次这个问题，原因难找每次反复调试压缩后的代码半天，影响很大，望修复。