### PR TITLE
[new feature]  Vue template language auto compeletion on vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ package-lock.json
 # dist file
 es
 lib
-docs/dist
+dist
 changelog.generated.md
 test/coverage
 packages/icon/svg

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ package-lock.json
 es
 lib
 dist
+docs/dist
 changelog.generated.md
 test/coverage
 packages/icon/svg

--- a/build/build-components.js
+++ b/build/build-components.js
@@ -5,10 +5,12 @@ const fs = require('fs-extra');
 const path = require('path');
 const babel = require('@babel/core');
 const compiler = require('vue-sfc-compiler');
+const markdownVetur = require('markdown-vetur');
 
 const esDir = path.join(__dirname, '../es');
 const libDir = path.join(__dirname, '../lib');
 const srcDir = path.join(__dirname, '../packages');
+const distDir = path.join(__dirname, '../dist');
 const compilerOption = {
   babel: {
     configFile: path.join(__dirname, '../babel.config.js')
@@ -68,3 +70,11 @@ compile(esDir);
 process.env.BABEL_MODULE = 'commonjs';
 fs.copySync(srcDir, libDir);
 compile(libDir);
+
+// generate vetur tags & attributes
+markdownVetur.parseAndWrite({
+  path: srcDir,
+  test: /zh-CN\.md/,
+  tagPrefix: 'van-',
+  outputDir: distDir
+});

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "less": "^3.8.1",
     "less-loader": "^4.1.0",
     "lint-staged": "^8.1.0",
+    "markdown-vetur": "0.0.2",
     "md5-file": "^4.0.0",
     "postcss": "^7.0.6",
     "postcss-loader": "^3.0.0",
@@ -122,5 +123,9 @@
     "webpack": "^4.26.1",
     "webpack-cli": "^3.1.2",
     "webpack-serve": "^2.0.3"
+  },
+  "vetur": {
+    "tags": "dist/tags.json",
+    "attributes": "dist/attributes.json"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6223,6 +6223,10 @@ markdown-table@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/markdown-table/-/markdown-table-1.1.2.tgz#c78db948fa879903a41bce522e3b96f801c63786"
 
+markdown-vetur@0.0.2:
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/markdown-vetur/-/markdown-vetur-0.0.2.tgz#1a05901a8e501171ebd625ae5cfaaaac05a66e3f"
+
 matcher@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/matcher/-/matcher-1.1.1.tgz#51d8301e138f840982b338b116bb0c09af62c1c2"


### PR DESCRIPTION
- Import markdown parser util
- Add build task which parse `.md` file to `tags.json` and `attributes.json`
- Declare vetur config in package.json