### PR TITLE
[typo] 修改了构建脚本里一处注释拼写错误

### DIFF
--- a/build/build-components.js
+++ b/build/build-components.js
@@ -28,7 +28,7 @@ function compile(dir) {
   files.forEach(file => {
     const filePath = path.join(dir, file);
 
-    // reomve unnecessary files
+    // remove unnecessary files
     if (!isCode(file)) {
       return fs.removeSync(filePath);
     }


### PR DESCRIPTION
Changes you made in this pull request:

- `build/build-components.js`中注释 `reomve unnecessary files`应该是`remove unnecessary files`