### PR TITLE
[bug fix] 修复在windows上构建docs-entry.js错误的问题

### DIFF
--- a/build/build-entry.js
+++ b/build/build-entry.js
@@ -79,7 +79,7 @@ function buildDocsEntry() {
     ])
     .map(fullPath => {
       const name = getName(fullPath);
-      return `'${name}': () => import('${path.relative(join('docs/src'), fullPath)}')`;
+      return `'${name}': () => import('${path.relative(join('docs/src'), fullPath).replace(/\\/g, '/')}')`;
     });
 
   const content = `${tips}


### PR DESCRIPTION
Fixes #2228 

Changes you made in this pull request:

- `build/build-entry.js`中的 `buildDocsEntry` 函数中使用 `replace` 将 `windows` 系统中的 `\` 替换为 `/`