### PR TITLE
[bugfix]  Picker:多列时,第一列onChange后,setColumnValues导致的数据不正确问题

### DIFF
--- a/packages/picker/index.js
+++ b/packages/picker/index.js
@@ -99,6 +99,7 @@ export default sfc({
       if (column && JSON.stringify(column.options) !== JSON.stringify(options)) {
         column.options = options;
         column.setIndex(0);
+        this.onChange(index);
       }
     },
 


### PR DESCRIPTION
#2804 