### PR TITLE
[bugfix] 内置样式：修复部分浏览器点击、触碰事件无法响应

### DIFF
--- a/packages/style/mixins/hairline.less
+++ b/packages/style/mixins/hairline.less
@@ -1,7 +1,6 @@
 .hairline-common() {
   content: ' ';
   position: absolute;
-  pointer-events: none;
   box-sizing: border-box;
 }
 


### PR DESCRIPTION
pointer-events属性导致使用了hairline样式的组件在部分浏览器（例如UC）触碰事件无法响应
- 去除了pointer-events: none
