### PR TITLE
[bug fix] Steps 设置为 vertical 时 active-icon自定义图标样式错误

### DIFF
--- a/packages/step/index.less
+++ b/packages/step/index.less
@@ -124,7 +124,7 @@
     }
 
     &.van-step--process {
-      .van-icon-checked {
+      .van-icon {
         top: 12px;
         left: -20px;
         line-height: 1;


### PR DESCRIPTION
[bug fix] Steps 设置为 vertical 时 active-icon自定义图标样式错误

