### PR TITLE
[bugfix] Button: 修改方形细边框按钮边框半径

### DIFF
--- a/packages/button/index.less
+++ b/packages/button/index.less
@@ -175,5 +175,9 @@
     &.van-button--round::after {
       border-radius: @button-round-border-radius;
     }
+    
+    &.van-button--square::after {
+      border-radius: 0;
+    }
   }
 }


### PR DESCRIPTION
修复方形细边框按钮边框半径不为 0 的问题