### PR TITLE
[bugfix] Step: step 销毁之前从父 steps 中移除

### DIFF
--- a/packages/step/index.js
+++ b/packages/step/index.js
@@ -7,7 +7,7 @@ export default sfc({
   beforeCreate() {
     this.$parent.steps.push(this);
   },
-  
+
   beforeDestroy() {
     const index = this.$parent.steps.indexOf(this);
     if (index > -1) {

--- a/packages/step/index.js
+++ b/packages/step/index.js
@@ -7,6 +7,13 @@ export default sfc({
   beforeCreate() {
     this.$parent.steps.push(this);
   },
+  
+  beforeDestroy() {
+    const index = this.$parent.steps.indexOf(this);
+    if (index > -1) {
+      this.$parent.steps.splice(index, 1);
+    }
+  },
 
   computed: {
     status() {


### PR DESCRIPTION
如果`step`是通过`v-for`动态生成，数据动态变更重新渲染下父`steps`只添加不减少，导致通过`avtive`计算的`status`出错

