### PR TITLE
[bugfix] Utils: <is-src> data URLs should be prefixed with the data:image

### DIFF
--- a/packages/utils/test/index.spec.js
+++ b/packages/utils/test/index.spec.js
@@ -88,4 +88,5 @@ test('is-src', () => {
   expect(isSrc('')).toBeFalsy();
   expect(isSrc('blob:http://img.cdn.com')).toBeTruthy();
   expect(isSrc('blob:https://img.cdn.com')).toBeTruthy();
+  expect(isSrc('xdata:image/jpeg;base64,/9j/4AAQSkZ')).toBeFalsy();
 });

--- a/packages/utils/validate/src.ts
+++ b/packages/utils/validate/src.ts
@@ -2,5 +2,5 @@
  * Is image source
  */
 export function isSrc(url: string): boolean {
-  return /^((blob:)?https?:)?\/\/|data:image/.test(url);
+  return /^(((blob:)?https?:)?\/\/|data:image)/.test(url);
 }


### PR DESCRIPTION
Data URLs isn't prefixed with data:image
example:
'xdata:image/jpeg;base64,/9j/4AAQSkZ' return true in the test, but this is wrong