### PR TITLE
[new feature] 给`picker`添加一个配置项`toolbar-position`，决定`toolbar`位置

### DIFF
--- a/packages/picker/index.js
+++ b/packages/picker/index.js
@@ -16,6 +16,10 @@ export default sfc({
       type: Number,
       default: 0
     },
+    toolbarPosition: {
+      type: String,
+      default: 'top'
+    },
     valueKey: {
       type: String,
       default: 'text'
@@ -176,7 +180,7 @@ export default sfc({
 
     return (
       <div class={bem()}>
-        {Toolbar}
+        {this.toolbarPosition === 'top' ? Toolbar : h()}
         {this.loading ? <Loading class={bem('loading')} color={BLUE} /> : h()}
         <div class={bem('columns')} style={columnsStyle} onTouchmove={preventDefault}>
           {columns.map((item, index) => (
@@ -195,6 +199,7 @@ export default sfc({
           <div class={bem('mask')} style={maskStyle} />
           <div class={['van-hairline--top-bottom', bem('frame')]} style={frameStyle} />
         </div>
+        {this.toolbarPosition === 'bottom' ? Toolbar : h()}
       </div>
     );
   }


### PR DESCRIPTION
将`picker`或基于`picker`的`datetime-picker`与`dropdown-menu`结合使用时，`toolbar`的最佳位置是底部，目前`toolbar`固定在顶部导致想更好的配合使用必须关闭`showToolbar`另外写自定义按钮，添加这个配置项可以解决这个问题
### Props

| 参数 | 说明 | 类型 | 默认值 | 版本 |
|------|------|------|------|------|
| columns | 对象数组，配置每一列显示的数据 | `Array` | `[]` | - |
| show-toolbar | 是否显示工具栏 | `Boolean` | `false` | - |
| title | 顶部栏标题 | `String` | `''` | - |
| toolbar-position | 工具栏的位置，可选值为 bottom | `String` | `top` | - |
| loading | 是否显示加载状态 | `Boolean` | `false` | - |
| value-key | 选项对象中，文字对应的 key | `String` | `text` | - |
| item-height | 选项高度 | `Number` | `44` | - |
| confirm-button-text | 确认按钮文字 | `String` | `确认` | - |
| cancel-button-text | 取消按钮文字 | `String` | `取消` | - |
| visible-item-count | 可见的选项个数 | `Number` | `5` | - |
| default-index | 单列选择器的默认选中项索引，<br>多列选择器请参考下方的 Columns 配置 | `Number` | `0` | 1.6.9 |
