### PR TITLE
[Doc] Popup: fix typo

### DIFF
--- a/packages/popup/en-US.md
+++ b/packages/popup/en-US.md
@@ -13,7 +13,7 @@ Vue.use(Popup);
 ### Basic Usage
 
 ```html
-<van-botton type="primary" @click="showPopup">
+<van-button type="primary" @click="showPopup">
   Show Popup
 </van-button>
 

--- a/packages/popup/zh-CN.md
+++ b/packages/popup/zh-CN.md
@@ -19,7 +19,7 @@ Vue.use(Popup);
 通过`v-model`控制弹出层是否展示
 
 ```html
-<van-botton type="primary" @click="showPopup">
+<van-button type="primary" @click="showPopup">
   展示弹出层
 </van-button>
 


### PR DESCRIPTION
修改popup组件的描述文件
```
<van-botton type="primary" @click="showPopup">
  展示弹出层
</van-button>
改为
<van-button type="primary" @click="showPopup">
  展示弹出层
</van-button>
```