### PR TITLE
docs: add router err catch

### DIFF
--- a/docs/site/utils/iframe-router.js
+++ b/docs/site/utils/iframe-router.js
@@ -34,7 +34,7 @@ export function initIframeRouter() {
 
     // should preserve hash for anchor
     if (window.vueRouter.currentRoute.path !== path) {
-      window.vueRouter.replace(path);
+      window.vueRouter.replace(path).catch(() => {});
     }
   };
 }


### PR DESCRIPTION
add error catch in changePath method
>The jump link in the development guide will cause the routing prompt "NavigationDuplicated" error message 
>eg: (jump) quickstart page ---> changelog page,the mobile page matching route  ↓↓↓
```js
const route = [
    {
      path: '*',
      redirect: () => `/${Vue.prototype.$vantLang}/`
    }
  ];
```
reference: https://github.com/vuejs/vue-router/issues/2881