### PR TITLE
docs: 修复Field 输入框组件自定义类型例子展示错误

### DIFF
--- a/packages/field/demo/index.vue
+++ b/packages/field/demo/index.vue
@@ -11,23 +11,27 @@
 
     <demo-block :title="$t('title2')">
       <van-cell-group>
-        <van-field
-          v-model="username"
-          :label="$t('username')"
-          :placeholder="$t('usernamePlaceholder')"
-          clearable
-          right-icon="question-o"
-          required
-          @click-right-icon="$toast('question')"
-        />
+        <van-cell>
+          <van-field
+            v-model="username"
+            :label="$t('username')"
+            :placeholder="$t('usernamePlaceholder')"
+            clearable
+            right-icon="question-o"
+            required
+            @click-right-icon="$toast('question')"
+          />
+        </van-cell>
 
-        <van-field
-          v-model="password"
-          type="password"
-          :label="$t('password')"
-          :placeholder="$t('passwordPlaceholder')"
-          required
-        />
+        <van-cell>
+          <van-field
+            v-model="password"
+            type="password"
+            :label="$t('password')"
+            :placeholder="$t('passwordPlaceholder')"
+            required
+          />
+        </van-cell>
       </van-cell-group>
     </demo-block>
 

--- a/packages/field/en-US.md
+++ b/packages/field/en-US.md
@@ -23,23 +23,27 @@ Use `type` prop to custom diffrent type fields.
 
 ```html
 <van-cell-group>
-  <van-field
-    v-model="username"
-    required
-    clearable
-    label="Username"
-    right-icon="question-o"
-    placeholder="Username"
-    @click-right-icon="$toast('question')"
-  />
+  <van-cell>
+    <van-field
+      v-model="username"
+      required
+      clearable
+      label="Username"
+      right-icon="question-o"
+      placeholder="Username"
+      @click-right-icon="$toast('question')"
+    />
+  </van-cell>
 
-  <van-field
-    v-model="password"
-    type="password"
-    label="Password"
-    placeholder="Password"
-    required
-  />
+  <van-cell>
+    <van-field
+      v-model="password"
+      type="password"
+      label="Password"
+      placeholder="Password"
+      required
+    />
+  </van-cell>
 </van-cell-group>
 ```
 


### PR DESCRIPTION
#### Title Format

type(ComponentName?)：commit message

Example：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

Allowed Types:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change
