### PR TITLE
fix(List): incorrect reaching edge condition

### DIFF
--- a/src/list/index.js
+++ b/src/list/index.js
@@ -95,7 +95,7 @@ export default createComponent({
         const placeholderRect = this.$refs.placeholder.getBoundingClientRect();
 
         if (direction === 'up') {
-          isReachEdge = placeholderRect.top - scrollerRect.top <= offset;
+          isReachEdge = scrollerRect.top - placeholderRect.top <= offset;
         } else {
           isReachEdge = placeholderRect.bottom - scrollerRect.bottom <= offset;
         }


### PR DESCRIPTION
As I understand it, the `offset` property of list component is always a positive number. The `scrollerRect.top` should be greater than `placeholderRect.top` with the `direction` as `up` under normal conditions.

For example, if the placeholder has been scrolled out of viewport, `scrollerRect.top` will not be changed but `placeholderRect.top` might be `-1000` or even less. Then `placeholderRect.top  -  scrollerRect.top` will be always less than `offset`. It will cause `isReachEdge` being equivalent to `true` constantly.