### PR TITLE
docs: update calendar examples

### DIFF
--- a/src/calendar/README.zh-CN.md
+++ b/src/calendar/README.zh-CN.md
@@ -35,16 +35,15 @@ export default {
   },
 
   methods: {
-    formatDate() {
+    formatDate(date) {
       return `${date.getMonth() + 1}/${date.getDate()}`;
     },
     onConfirm(date) {
-      const [start, end] = date;
       this.show = false;
-      this.date = `${this.formatDate(start)} - ${this.formatDate(end)}`;
+      this.date = this.formatDate(date);
     }
   }
-}
+};
 ```
 
 ### 选择日期区间
@@ -61,17 +60,22 @@ export default {
 export default {
   data() {
     return {
-      show: false,
-      date: []
+      date: '',
+      show: false
     };
   },
+
   methods: {
+    formatDate(date) {
+      return `${date.getMonth() + 1}/${date.getDate()}`;
+    },
     onConfirm(date) {
+      const [start, end] = date;
       this.show = false;
-      this.date = date;
+      this.date = `${this.formatDate(start)} - ${this.formatDate(end)}`;
     }
   }
-}
+};
 ```
 
 ### 快捷选择


### PR DESCRIPTION
第一种方式我是打算:value="formateDate(date)"来展示，这样的话date默认要给一个new Date()而不是字符串''。
然后区间选择的时候默认值是数组[]，这样的话就需要再写一个formateRangeDate(date)来进行展示，这样显然是最好的。使用者不用再声明保存时间的变量。
第二种方式，就是拿到时间戳，格式化之后赋值给它本身。由于我不打算改动变量的类型，这样做并不好。
考虑到只是demo示例，我pull request最好是最小改动，就用了第三种方式。
value只是最为展示的字符串，而不是保存所选的时间或时间区间的变量。
