### PR TITLE
fix(Calendar): incorrect month title after auto scroll

### DIFF
--- a/src/calendar/components/Month.js
+++ b/src/calendar/components/Month.js
@@ -80,6 +80,10 @@ export default createComponent({
   },
 
   methods: {
+    scrollIntoView() {
+      this.$refs.days.scrollIntoView();
+    },
+
     getDayType(day) {
       const { type, minDate, maxDate, currentDate } = this;
 
@@ -166,12 +170,14 @@ export default createComponent({
     genDays() {
       if (this.visible) {
         return (
-          <div class={bem('days')}>
+          <div ref="days" class={bem('days')}>
             {this.genMark()}
             {this.days.map(this.genDay)}
           </div>
         );
       }
+
+      return <div ref="days" />;
     },
 
     genDay(item, index) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -158,7 +158,7 @@ export default createComponent({
 
         this.months.some((month, index) => {
           if (compareMonth(month, targetDate) === 0) {
-            this.$refs.months[index].$el.scrollIntoView();
+            this.$refs.months[index].scrollIntoView();
             return true;
           }
 

--- a/src/calendar/test/index.spec.js
+++ b/src/calendar/test/index.spec.js
@@ -419,7 +419,7 @@ test('should scroll to current month when show', async done => {
   });
 
   Element.prototype.scrollIntoView = function() {
-    expect(this).toEqual(wrapper.findAll('.van-calendar__month').at(3).element);
+    expect(this.parentNode).toEqual(wrapper.findAll('.van-calendar__month').at(3).element);
     done();
   };
 


### PR DESCRIPTION
https://github.com/youzan/vant/issues/5552