### PR TITLE
types(Toast): incorrect definition of 'setDefaultOptions' method

### DIFF
--- a/types/toast.d.ts
+++ b/types/toast.d.ts
@@ -41,7 +41,7 @@ export interface Toast {
   fail(options?: ToastOptions | ToastMessage): VanToast;
   clear(all?: boolean): void;
   install(): void;
-  setDefaultOptions(options: string | ToastOptions): void;
+  setDefaultOptions(type: ToastType | ToastOptions, options?: ToastOptions): void;
   resetDefaultOptions(options?: string): void;
   allowMultiple(allow: boolean): void;
 }


### PR DESCRIPTION
Refer to the source code of toast component.