### PR TITLE
fix(cli): change site header'width

### DIFF
--- a/packages/vant-cli/site/desktop/components/Header.vue
+++ b/packages/vant-cli/site/desktop/components/Header.vue
@@ -142,6 +142,10 @@ export default {
   width: 100%;
   user-select: none;
 
+  .van-doc-row {
+    width: 100%;
+  }
+
   &__top {
     display: flex;
     align-items: center;

--- a/packages/vant-cli/site/desktop/components/Header.vue
+++ b/packages/vant-cli/site/desktop/components/Header.vue
@@ -140,11 +140,8 @@ export default {
 
 .van-doc-header {
   width: 100%;
+  background-color: #001938;
   user-select: none;
-
-  .van-doc-row {
-    width: 100%;
-  }
 
   &__top {
     display: flex;
@@ -152,7 +149,6 @@ export default {
     height: @van-doc-header-top-height;
     padding: 0 @van-doc-padding;
     line-height: @van-doc-header-top-height;
-    background-color: #001938;
 
     &-nav {
       flex: 1;


### PR DESCRIPTION
## 问题
vant-cli项目里，桌面网站样式在大屏显示器上会出现 **header左右留白的情况**，不够完美。如下图：

![](https://s1.ax1x.com/2020/03/27/GPsXE4.png)

## 解决

设置`.van-doc-header`下`.van-doc-row`宽度100%，以覆盖原样式：
```css
media (min-width: 1680px)
.van-doc-row {
    width: 1680px;
    margin: 0 auto;
}
```
