### PR TITLE
Notice bar reset variable and scrollable method extraction

### DIFF
--- a/src/notice-bar/index.js
+++ b/src/notice-bar/index.js
@@ -39,8 +39,7 @@ export default createComponent({
   watch: {
     text: {
       handler() {
-        this.reset();
-        this.startScroll()
+        this.start();
       },
       immediate: true,
     },
@@ -69,7 +68,7 @@ export default createComponent({
       this.duration = 0;
     },
 
-    startScroll(){
+    start(){
       this.$nextTick(() => {
         const { wrap, content } = this.$refs;
         if (!wrap || !content) {
@@ -83,6 +82,8 @@ export default createComponent({
           this.offsetWidth = offsetWidth;
           this.duration = offsetWidth / this.speed;
           this.animationClass = bem('play');
+        } else{
+          this.reset();
         }
       });
     }

--- a/src/notice-bar/index.js
+++ b/src/notice-bar/index.js
@@ -82,7 +82,7 @@ export default createComponent({
           this.offsetWidth = offsetWidth;
           this.duration = offsetWidth / this.speed;
           this.animationClass = bem('play');
-        } else{
+        } else {
           this.reset();
         }
       });

--- a/src/notice-bar/index.js
+++ b/src/notice-bar/index.js
@@ -39,21 +39,8 @@ export default createComponent({
   watch: {
     text: {
       handler() {
-        this.$nextTick(() => {
-          const { wrap, content } = this.$refs;
-          if (!wrap || !content) {
-            return;
-          }
-
-          const wrapWidth = wrap.getBoundingClientRect().width;
-          const offsetWidth = content.getBoundingClientRect().width;
-          if (this.scrollable && offsetWidth > wrapWidth) {
-            this.wrapWidth = wrapWidth;
-            this.offsetWidth = offsetWidth;
-            this.duration = offsetWidth / this.speed;
-            this.animationClass = bem('play');
-          }
-        });
+        this.reset();
+        this.startScroll()
       },
       immediate: true,
     },
@@ -74,6 +61,31 @@ export default createComponent({
         this.animationClass = bem('play--infinite');
       });
     },
+
+    reset() {
+      this.wrapWidth = 0;
+      this.offsetWidth = 0;
+      this.animationClass = '';
+      this.duration = 0;
+    },
+
+    startScroll(){
+      this.$nextTick(() => {
+        const { wrap, content } = this.$refs;
+        if (!wrap || !content) {
+          return;
+        }
+
+        const wrapWidth = wrap.getBoundingClientRect().width;
+        const offsetWidth = content.getBoundingClientRect().width;
+        if (this.scrollable && offsetWidth > wrapWidth) {
+          this.wrapWidth = wrapWidth;
+          this.offsetWidth = offsetWidth;
+          this.duration = offsetWidth / this.speed;
+          this.animationClass = bem('play');
+        }
+      });
+    }
   },
 
   render() {


### PR DESCRIPTION
If the component is in a hidden state, the obtained width is 0, so please extract the scrolling method, which is easy to call in the displayed state. In addition, when the text content is replaced, it can be scrolled if it exceeds the length originally, but it can also be scrolled if it does not exceed the length now. Therefore, you need to reset the relevant variables, please adopt!