### PR TITLE
feat(Field): fix render error when value is null or undefined

### DIFF
--- a/src/field/index.js
+++ b/src/field/index.js
@@ -491,7 +491,7 @@ export default createComponent({
 
     genWordLimit() {
       if (this.showWordLimit && this.maxlength) {
-        const count = this.value.length;
+        const count = (this.value || '').length;
         const full = count >= this.maxlength;
 
         return (

--- a/src/field/test/__snapshots__/index.spec.js.snap
+++ b/src/field/test/__snapshots__/index.spec.js.snap
@@ -79,6 +79,24 @@ exports[`reach max word-limit 1`] = `
 </div>
 `;
 
+exports[`reach max word-limit null 1`] = `
+<div class="van-cell van-field">
+  <div class="van-cell__value van-cell__value--alone van-field__value">
+    <div class="van-field__body"><input type="text" class="van-field__control"></div>
+    <div class="van-field__word-limit"><span class="van-field__word-num">0</span>/3</div>
+  </div>
+</div>
+`;
+
+exports[`reach max word-limit undefined 1`] = `
+<div class="van-cell van-field">
+  <div class="van-cell__value van-cell__value--alone van-field__value">
+    <div class="van-field__body"><input type="text" class="van-field__control"></div>
+    <div class="van-field__word-limit"><span class="van-field__word-num">0</span>/3</div>
+  </div>
+</div>
+`;
+
 exports[`render extra slot 1`] = `
 <div class="van-cell van-field">
   <div class="van-cell__value van-cell__value--alone van-field__value">

--- a/src/field/test/index.spec.js
+++ b/src/field/test/index.spec.js
@@ -310,6 +310,17 @@ test('reach max word-limit', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+test('reach max word-limit undefined', () => {
+  const wrapper = mount(Field, {
+    propsData: {
+      value: undefined,
+      maxlength: 3,
+      showWordLimit: true,
+    },
+  });
+  expect(wrapper).toMatchSnapshot();
+});
+
 test('name prop', () => {
   const wrapper = mount(Field, {
     propsData: {

--- a/src/field/test/index.spec.js
+++ b/src/field/test/index.spec.js
@@ -321,6 +321,17 @@ test('reach max word-limit undefined', () => {
   expect(wrapper).toMatchSnapshot();
 });
 
+test('reach max word-limit null', () => {
+  const wrapper = mount(Field, {
+    propsData: {
+      value: null,
+      maxlength: 3,
+      showWordLimit: true,
+    },
+  });
+  expect(wrapper).toMatchSnapshot();
+});
+
 test('name prop', () => {
   const wrapper = mount(Field, {
     propsData: {


### PR DESCRIPTION
修复设置了 maxlength 同时 value 为 undefined 或者 null 时，组件报错无法渲染的问题

### Before submitting a pull request, please make sure the following is done:

1. Read the [contributing guide](https://github.com/youzan/vant/blob/dev/.github/CONTRIBUTING.md).
2. If you've added code that should be tested, add tests.
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).

#### Title Format

type(ComponentName?)：commit message

Example：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

Allowed Types:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change
