### PR TITLE
style(Field): default label align should be left

### DIFF
--- a/src/field/index.less
+++ b/src/field/index.less
@@ -5,6 +5,7 @@
     flex: none;
     box-sizing: border-box;
     width: @field-label-width;
+    text-align: left;
 
     &--center {
       text-align: center;


### PR DESCRIPTION
https://github.com/youzan/vant/issues/6452