### PR TITLE
fix(tabbar-item): route NavigationFailure

### DIFF
--- a/src/tabbar-item/index.js
+++ b/src/tabbar-item/index.js
@@ -45,9 +45,18 @@ export default createComponent({
 
   methods: {
     onClick(event) {
+      const { errorFunc } = this;
       this.parent.onChange(this.name || this.index);
       this.$emit('click', event);
-      route(this.$router, this);
+      if (errorFunc) {
+        try {
+          route(this.$router, this);
+        } catch {
+          errorFunc();
+        }
+      } else {
+        route(this.$router, this);
+      }
     },
 
     genIcon(active) {

--- a/src/utils/router.ts
+++ b/src/utils/router.ts
@@ -45,10 +45,12 @@ export type RouteProps = {
   url?: string;
   replace?: boolean;
   to?: RawLocation;
+  errorFunc: Function;
 };
 
 export const routeProps = {
   url: String,
   replace: Boolean,
   to: [String, Object],
+  errorFunc: Function,
 };


### PR DESCRIPTION
关于问题描述：我在tabbar中利用路由模式的to进行路由跳转，但在vue-router 3.1版本后增加了NavigationFailure，使得在我使用to时不能进行手动捕获错误而在控制台中显示了错误,是否可以提供一个props来直接自定义的错误捕获函数？
![acbb8921aac3ddc8350a707a2679ad3](https://user-images.githubusercontent.com/45839282/85942009-2b6ccd00-b959-11ea-8fc3-435b7c8cbf76.png)


