### PR TITLE
fix(Field): can't display six characters in iOS

### DIFF
--- a/src/field/README.md
+++ b/src/field/README.md
@@ -243,7 +243,7 @@ Use `input-align` prop to align the input value.
 | format-trigger `v2.8.7` | When to format value，can be set to `onBlur` | _string_ | `onChange` |
 | arrow-direction `v2.0.4` | Can be set to `left` `up` `down` | _string_ | `right` |
 | label-class | Label className | _any_ | - |
-| label-width | Label width | _number \| string_ | `6em` |
+| label-width | Label width | _number \| string_ | `6.2em` |
 | label-align | Label align, can be set to `center` `right` | _string_ | `left` |
 | input-align | Input align, can be set to `center` `right` | _string_ | `left` |
 | error-message-align | Error message align, can be set to `center` `right` | _string_ | `left` |

--- a/src/field/README.zh-CN.md
+++ b/src/field/README.zh-CN.md
@@ -268,7 +268,7 @@ export default {
 | format-trigger `v2.8.7` | 格式化函数触发的时机，可选值为 `onBlur` | _string_ | `onChange` |
 | arrow-direction `v2.0.4` | 箭头方向，可选值为 `left` `up` `down` | _string_ | `right` |
 | label-class | 左侧文本额外类名 | _any_ | - |
-| label-width | 左侧文本宽度，默认单位为`px` | _number \| string_ | `6em` |
+| label-width | 左侧文本宽度，默认单位为`px` | _number \| string_ | `6.2em` |
 | label-align | 左侧文本对齐方式，可选值为 `center` `right` | _string_ | `left` |
 | input-align | 输入框对齐方式，可选值为 `center` `right` | _string_ | `left` |
 | error-message-align | 错误提示文案对齐方式，可选值为 `center` `right` | _string_ | `left` |

--- a/src/form/README.md
+++ b/src/form/README.md
@@ -424,7 +424,7 @@ export default {
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| label-width | Field label width | _number \| string_ | `6em` |
+| label-width | Field label width | _number \| string_ | `6.2em` |
 | label-align | Field label align, can be set to `center` `right` | _string_ | `left` |
 | input-align | Field input align, can be set to `center` `right` | _string_ | `left` |
 | error-message-align | Error message align, can be set to `center` `right` | _string_ | `left` |

--- a/src/form/README.zh-CN.md
+++ b/src/form/README.zh-CN.md
@@ -459,7 +459,7 @@ export default {
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| label-width | 表单项 label 宽度，默认单位为`px` | _number \| string_ | `6em` |
+| label-width | 表单项 label 宽度，默认单位为`px` | _number \| string_ | `6.2em` |
 | label-align |  表单项 label 对齐方式，可选值为 `center` `right` | _string_ | `left` |
 | input-align | 输入框对齐方式，可选值为 `center` `right` | _string_ | `left` |
 | error-message-align | 错误提示文案对齐方式，可选值为 `center` `right` | _string_ | `left` |

--- a/src/style/var.less
+++ b/src/style/var.less
@@ -343,7 +343,7 @@
 @empty-bottom-margin-top: 24px;
 
 // Field
-@field-label-width: 6em;
+@field-label-width: 6.2em;
 @field-label-color: @gray-7;
 @field-label-margin-right: @padding-sm;
 @field-input-text-color: @text-color;


### PR DESCRIPTION
在 iOS 上，14px 的汉字实际宽度为 14.2645833333px，因此 6em 宽度无法保证一行能显示六个汉字