### PR TITLE
fix(NumberKeyboard): incorrect key height on legacy safari

### DIFF
--- a/src/number-keyboard/index.less
+++ b/src/number-keyboard/index.less
@@ -86,7 +86,14 @@
   cursor: pointer;
 
   &--large {
-    height: 100%;
+    // height: 100% can't fill flex parent on legacy safari
+    // see: https://stackoverflow.com/questions/33636796
+    position: absolute;
+    top: 0;
+    right: 6px;
+    bottom: 6px;
+    left: 0;
+    height: auto;
   }
 
   &--blue,
@@ -108,6 +115,7 @@
   }
 
   &__wrapper {
+    position: relative;
     flex: 1;
     flex-basis: 33%;
     box-sizing: border-box;


### PR DESCRIPTION
https://github.com/youzan/vant/issues/6823