### PR TITLE
feat(ActionSheet): add closeable prop

### DIFF
--- a/src/action-sheet/README.md
+++ b/src/action-sheet/README.md
@@ -155,6 +155,7 @@ export default {
 | title | Title | _string_ | - |
 | cancel-text | Text of cancel button | _string_ | - |
 | description `v2.2.8` | Description above the options | _string_ | - |
+| closeable `v2.10.5` | Whether to show close icon | _boolean_ | `true` |
 | close-icon `v2.2.13` | Close icon name | _string_ | `cross` |
 | duration `v2.0.3` | Transition duration, unit second | _number \| string_ | `0.3` |
 | round `v2.0.9` | Whether to show round corner | _boolean_ | `true` |

--- a/src/action-sheet/README.zh-CN.md
+++ b/src/action-sheet/README.zh-CN.md
@@ -161,6 +161,7 @@ export default {
 | title | 顶部标题 | _string_ | - |
 | cancel-text | 取消按钮文字 | _string_ | - |
 | description `v2.2.8` | 选项上方的描述信息 | _string_ | - |
+| closeable `v2.10.5` | 是否显示关闭图标 | _boolean_ | `true` |
 | close-icon `v2.2.13` | 关闭[图标名称](#/zh-CN/icon)或图片链接 | _string_ | `cross` |
 | duration `v2.0.3` | 动画时长，单位秒 | _number \| string_ | `0.3` |
 | round `v2.0.9` | 是否显示圆角 | _boolean_ | `true` |

--- a/src/action-sheet/index.tsx
+++ b/src/action-sheet/index.tsx
@@ -184,7 +184,7 @@ ActionSheet.props = {
   },
   closeable: {
     type: Boolean,
-    default: false,
+    default: true,
   },
   closeIcon: {
     type: String,

--- a/src/action-sheet/index.tsx
+++ b/src/action-sheet/index.tsx
@@ -30,6 +30,7 @@ export type ActionSheetProps = PopupMixinProps & {
   title?: string;
   actions?: ActionSheetItem[];
   duration: number | string;
+  closeable?: boolean;
   closeIcon: string;
   cancelText?: string;
   description?: string;
@@ -50,7 +51,7 @@ function ActionSheet(
   slots: ActionSheetSlots,
   ctx: RenderContext<ActionSheetProps>
 ) {
-  const { title, cancelText } = props;
+  const { title, cancelText, closeable } = props;
 
   function onCancel() {
     emit(ctx, 'input', false);
@@ -62,11 +63,13 @@ function ActionSheet(
       return (
         <div class={bem('header')}>
           {title}
-          <Icon
-            name={props.closeIcon}
-            class={bem('close')}
-            onClick={onCancel}
-          />
+          {closeable && (
+            <Icon
+              name={props.closeIcon}
+              class={bem('close')}
+              onClick={onCancel}
+            />
+          )}
         </div>
       );
     }
@@ -178,6 +181,10 @@ ActionSheet.props = {
   round: {
     type: Boolean,
     default: true,
+  },
+  closeable: {
+    type: Boolean,
+    default: false,
   },
   closeIcon: {
     type: String,

--- a/src/action-sheet/test/index.spec.js
+++ b/src/action-sheet/test/index.spec.js
@@ -198,3 +198,15 @@ test('close-icon prop', () => {
 
   expect(wrapper).toMatchSnapshot();
 });
+
+test('closeable prop', () => {
+  const wrapper = mount(ActionSheet, {
+    propsData: {
+      value: true,
+      title: 'Title',
+      closeable: false,
+    },
+  });
+
+  expect(wrapper).toMatchSnapshot();
+});


### PR DESCRIPTION
使用 `ActionSheet` 的时候如果设置了 `title` ，此时会默认显示关闭图标，以便于自定义面板时关闭窗口。
但是当设置 `title` 的同时，还设置了 `cancel-text` ，关闭图标就有些多余了，所以想添加一个显示隐藏关闭图标的 prop。
不知这样是否可行呢？