### PR TITLE
feat(TabbarItem): add @tabbar-item-active-background-color less var

### DIFF
--- a/src/style/var.less
+++ b/src/style/var.less
@@ -754,6 +754,7 @@
 @tabbar-item-font-size: @font-size-sm;
 @tabbar-item-text-color: @gray-7;
 @tabbar-item-active-color: @blue;
+@tabbar-item-active-background-color: @tabbar-background-color;
 @tabbar-item-line-height: 1;
 @tabbar-item-icon-size: 22px;
 @tabbar-item-margin-bottom: 4px;

--- a/src/tabbar-item/index.less
+++ b/src/tabbar-item/index.less
@@ -28,6 +28,7 @@
   }
 
   &--active {
+    background-color: @tabbar-item-active-background-color;
     color: @tabbar-item-active-color;
   }
 


### PR DESCRIPTION
This adds the possibility of changing the background colour of the tab bar items. 

With this change it's possible to achieve the following:
<img width="455" alt="Screenshot 2020-09-11 at 11 36 32" src="https://user-images.githubusercontent.com/1453384/92904992-9770b480-f423-11ea-9dbc-46eb2e3e2f33.png">
