### PR TITLE
fix(Field): incorrect disabled color in iOS 14

### DIFF
--- a/src/field/index.less
+++ b/src/field/index.less
@@ -58,7 +58,7 @@
       cursor: not-allowed;
       opacity: 1;
       // fix disabled color in mobile safari
-      -webkit-text-fill-color: currentColor;
+      -webkit-text-fill-color: @field-input-disabled-text-color;
     }
 
     &:read-only {

--- a/src/field/index.less
+++ b/src/field/index.less
@@ -55,10 +55,10 @@
 
     &:disabled {
       color: @field-input-disabled-text-color;
-      background-color: transparent;
       cursor: not-allowed;
       opacity: 1;
-      -webkit-text-fill-color: currentColor; // fix disabled color in iOS
+      // fix disabled color in mobile safari
+      -webkit-text-fill-color: currentColor;
     }
 
     &:read-only {


### PR DESCRIPTION
https://github.com/youzan/vant/issues/7194

The text color become invisible when using `background-color: transparent;` and `-webkit-text-fill-color: currentColor;` in iOS 14