### PR TITLE
feat(@vant/cli): suport modify internal webpack config

### DIFF
--- a/packages/vant-cli/src/common/index.ts
+++ b/packages/vant-cli/src/common/index.ts
@@ -6,12 +6,14 @@ import {
   readFileSync,
   outputFileSync,
 } from 'fs-extra';
+import merge from 'webpack-merge';
 import {
   SRC_DIR,
   getVantConfig,
   ROOT_WEBPACK_CONFIG_FILE,
   ROOT_POSTCSS_CONFIG_FILE,
 } from './constant';
+import { WebpackConfig } from './types';
 
 export const EXT_REGEXP = /\.\w+$/;
 export const SFC_REGEXP = /\.(vue)$/;
@@ -37,9 +39,9 @@ export function getComponents() {
   const EXCLUDES = ['.DS_Store'];
   const dirs = readdirSync(SRC_DIR);
   return dirs
-    .filter(dir => !EXCLUDES.includes(dir))
-    .filter(dir =>
-      ENTRY_EXTS.some(ext => {
+    .filter((dir) => !EXCLUDES.includes(dir))
+    .filter((dir) =>
+      ENTRY_EXTS.some((ext) => {
         const path = join(SRC_DIR, dir, `index.${ext}`);
         if (existsSync(path)) {
           return hasDefaultExport(readFileSync(path, 'utf-8'));
@@ -99,18 +101,20 @@ export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
 }
 
-export function getWebpackConfig(): object {
+export function getWebpackConfig(defaultWebpackCfg: WebpackConfig): object {
   if (existsSync(ROOT_WEBPACK_CONFIG_FILE)) {
     const config = require(ROOT_WEBPACK_CONFIG_FILE);
 
+    // 如果是函数形式，可能并不仅仅是添加额外的处理流程，而是在原有流程上进行修改
+    // 比如修改markdown-loader,添加options.enableMetaData
     if (typeof config === 'function') {
-      return config();
+      return config(defaultWebpackCfg);
     }
 
-    return config;
+    return merge(defaultWebpackCfg, config);
   }
 
-  return {};
+  return defaultWebpackCfg;
 }
 
 export function getPostcssConfig(): object {

--- a/packages/vant-cli/src/common/index.ts
+++ b/packages/vant-cli/src/common/index.ts
@@ -101,20 +101,20 @@ export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
 }
 
-export function getWebpackConfig(defaultWebpackCfg: WebpackConfig): object {
+export function getWebpackConfig(defaultConfig: WebpackConfig): object {
   if (existsSync(ROOT_WEBPACK_CONFIG_FILE)) {
     const config = require(ROOT_WEBPACK_CONFIG_FILE);
 
     // 如果是函数形式，可能并不仅仅是添加额外的处理流程，而是在原有流程上进行修改
     // 比如修改markdown-loader,添加options.enableMetaData
     if (typeof config === 'function') {
-      return config(defaultWebpackCfg);
+      return config(defaultConfig);
     }
 
-    return merge(defaultWebpackCfg, config);
+    return merge(defaultConfig, config);
   }
 
-  return defaultWebpackCfg;
+  return defaultConfig;
 }
 
 export function getPostcssConfig(): object {

--- a/packages/vant-cli/src/config/webpack.package.ts
+++ b/packages/vant-cli/src/config/webpack.package.ts
@@ -10,9 +10,8 @@ export function getPackageConfig(isMinify: boolean): WebpackConfig {
 
   setBuildTarget('package');
 
-  return merge(
-    baseConfig as any,
-    {
+  return getWebpackConfig(
+    merge(baseConfig as any, {
       mode: 'production',
       entry: {
         [name]: join(ES_DIR, 'index.js'),
@@ -39,7 +38,6 @@ export function getPackageConfig(isMinify: boolean): WebpackConfig {
       optimization: {
         minimize: isMinify,
       },
-    },
-    getWebpackConfig()
+    })
   );
 }

--- a/packages/vant-cli/src/config/webpack.site.dev.ts
+++ b/packages/vant-cli/src/config/webpack.site.dev.ts
@@ -103,5 +103,5 @@ export function getSiteDevBaseConfig(): WebpackConfig {
 }
 
 export function getSiteDevConfig(): WebpackConfig {
-  return merge(getSiteDevBaseConfig(), getWebpackConfig());
+  return getWebpackConfig(getSiteDevBaseConfig());
 }

--- a/packages/vant-cli/src/config/webpack.site.prd.ts
+++ b/packages/vant-cli/src/config/webpack.site.prd.ts
@@ -10,9 +10,8 @@ const outputDir = get(vantConfig, 'build.site.outputDir', SITE_DIST_DIR);
 const publicPath = get(vantConfig, 'build.site.publicPath', '/');
 
 export function getSitePrdConfig(): WebpackConfig {
-  return merge(
-    getSiteDevBaseConfig(),
-    {
+  return getWebpackConfig(
+    merge(getSiteDevBaseConfig(), {
       mode: 'production',
       stats: 'none',
       performance: {
@@ -25,7 +24,6 @@ export function getSitePrdConfig(): WebpackConfig {
         filename: '[name].[hash:8].js',
         chunkFilename: 'async_[name].[chunkhash:8].js',
       },
-    },
-    getWebpackConfig()
+    })
   );
 }

--- a/packages/vant-cli/yarn.lock
+++ b/packages/vant-cli/yarn.lock
@@ -1962,8 +1962,8 @@
 
 "@vant/markdown-loader@^2.3.0":
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@vant/markdown-loader/-/markdown-loader-2.3.0.tgz#ea8ab4d8d41609839b40b817bc3a598cf13f9920"
-  integrity sha512-efNAnJMQbX3yP0+/zvnlYda+xIATLl+T9BXOB179M8KkS3hKk0b8tYHYVeLmdCLbJFeVd8bVXICILIplOYQJ5A==
+  resolved "https://registry.npm.taobao.org/@vant/markdown-loader/download/@vant/markdown-loader-2.3.0.tgz#ea8ab4d8d41609839b40b817bc3a598cf13f9920"
+  integrity sha1-6oq02NQWCYObQLgXvDpZjPE/mSA=
   dependencies:
     front-matter "^3.0.2"
     highlight.js "^9.16.2"
@@ -5895,9 +5895,9 @@ he@^1.2.0:
   integrity sha1-hK5l+n6vsWX922FWauFLrwVmTw8=
 
 highlight.js@^9.16.2:
-  version "9.18.1"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.18.1.tgz#ed21aa001fe6252bb10a3d76d47573c6539fe13c"
-  integrity sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg==
+  version "9.18.3"
+  resolved "https://registry.npm.taobao.org/highlight.js/download/highlight.js-9.18.3.tgz#a1a0a2028d5e3149e2380f8a865ee8516703d634"
+  integrity sha1-oaCiAo1eMUniOA+Khl7oUWcD1jQ=
 
 hmac-drbg@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
## 修改获取webpack config的方法

### 问题描述

@vant/cli中，使用者无法修改cli的webpackConfig，导致使用者如果想要修改原有loader的默认行为或者是参数，都无法做到；比如场景：需要过滤Markdown文件的frontMeta头信息，但是没有办法修改@vant/markdown-loader的options，所以导致`enableMetaData`属性是无效的，所以如果在markdown文件中添加yaml头，就会导致文档展示中出现这个yaml头信息（不是预期内的结果）。

### 解决方式

修改cli中获取webpackConfig的函数，使用webpackBaseConfig作为入参，允许使用者从webpack.config.js文件导出一个函数修改baseConfig。

![webpack.config.js](https://user-images.githubusercontent.com/23733347/93872387-a6e4dd00-fd02-11ea-8d8c-487197005ddd.png)
