### PR TITLE
fix(Field): incorrect label length when label-align is right

### DIFF
--- a/src/field/index.less
+++ b/src/field/index.less
@@ -15,7 +15,6 @@
     }
 
     &--right {
-      padding-right: @padding-md;
       text-align: right;
     }
   }


### PR DESCRIPTION
https://github.com/youzan/vant/issues/7343