### PR TITLE
fix(NavBar): Component renders blank left/right.

### DIFF
--- a/src/nav-bar/index.js
+++ b/src/nav-bar/index.js
@@ -67,13 +67,13 @@ export default createComponent({
           style={{ zIndex: this.zIndex }}
           class={[bem({ fixed: this.fixed }), { [BORDER_BOTTOM]: this.border }]}
         >
-          {this.hasLeft && <div class={bem('left')} onClick={this.onClickLeft}>
+          {this.hasLeft() && <div class={bem('left')} onClick={this.onClickLeft}>
             {this.genLeft()}
           </div>}
           <div class={[bem('title'), 'van-ellipsis']}>
             {this.slots('title') || this.title}
           </div>
-          {this.hasRight && <div class={bem('right')} onClick={this.onClickRight}>
+          {this.hasRight() && <div class={bem('right')} onClick={this.onClickRight}>
             {this.genRight()}
           </div>}
         </div>
@@ -81,11 +81,11 @@ export default createComponent({
     },
 
     hasLeft() {
-      return this.leftArrow || this.leftText || this.leftSlot;
+      return this.leftArrow || this.leftText || this.slots('left');
     },
 
     hasRight() {
-      return this.rightArrow || this.rightText || this.rightSlot;
+      return this.rightText || this.slots('right');
     },
 
     onClickLeft(event) {

--- a/src/nav-bar/index.js
+++ b/src/nav-bar/index.js
@@ -67,17 +67,25 @@ export default createComponent({
           style={{ zIndex: this.zIndex }}
           class={[bem({ fixed: this.fixed }), { [BORDER_BOTTOM]: this.border }]}
         >
-          <div class={bem('left')} onClick={this.onClickLeft}>
+          {this.hasLeft && <div class={bem('left')} onClick={this.onClickLeft}>
             {this.genLeft()}
-          </div>
+          </div>}
           <div class={[bem('title'), 'van-ellipsis']}>
             {this.slots('title') || this.title}
           </div>
-          <div class={bem('right')} onClick={this.onClickRight}>
+          {this.hasRight && <div class={bem('right')} onClick={this.onClickRight}>
             {this.genRight()}
-          </div>
+          </div>}
         </div>
       );
+    },
+
+    hasLeft() {
+      return this.leftArrow || this.leftText || this.leftSlot;
+    },
+
+    hasRight() {
+      return this.rightArrow || this.rightText || this.rightSlot;
     },
 
     onClickLeft(event) {

--- a/src/nav-bar/test/__snapshots__/index.spec.js.snap
+++ b/src/nav-bar/test/__snapshots__/index.spec.js.snap
@@ -3,9 +3,7 @@
 exports[`placeholder prop 1`] = `
 <div class="van-nav-bar__placeholder" style="height: 50px;">
   <div class="van-nav-bar van-nav-bar--fixed van-hairline--bottom">
-    <div class="van-nav-bar__left"></div>
     <div class="van-nav-bar__title van-ellipsis"></div>
-    <div class="van-nav-bar__right"></div>
   </div>
 </div>
 `;
@@ -20,8 +18,6 @@ exports[`render left & right slot 1`] = `
 
 exports[`render title slot 1`] = `
 <div class="van-nav-bar van-hairline--bottom">
-  <div class="van-nav-bar__left"></div>
   <div class="van-nav-bar__title van-ellipsis">Custom Title</div>
-  <div class="van-nav-bar__right"></div>
 </div>
 `;


### PR DESCRIPTION
### Notes

- The navbar can render an empty `<div class="van-nav-bar__left"></div>` which shows a pointer cursor when hovered on desktop. 
  - This may also be picked up by screen readers and any other assistive technologies. 
- The blank left/right elements can also be clicked so if you parse `:left-text="leftTextMethod" @click-left="someMethod"` and `leftTextMethod` returns null/false; `someMethod` can get invoked when clicking the white space.

<img width="521" alt="Screenshot 2020-10-21 at 12 01 25" src="https://user-images.githubusercontent.com/1453384/96705141-2f53ad80-1395-11eb-9ee2-1cdd216890c2.png">
