### PR TITLE
fix(ActionSheet): The height of the flex container is lost under ios 10.

### DIFF
--- a/src/action-sheet/index.less
+++ b/src/action-sheet/index.less
@@ -9,7 +9,7 @@
   color: @action-sheet-item-text-color;
 
   &__content {
-    flex: 1;
+    flex: 1 auto;
     overflow-y: auto;
     -webkit-overflow-scrolling: touch;
   }


### PR DESCRIPTION
After testing, the `ActionSheet` component has no height in the pop-up content under the iOS 10 version. This patch can fix this problem.