### PR TITLE
fix(@vant/cli): support importing less styles on demand

### DIFF
--- a/packages/vant-cli/src/compiler/gen-component-style.ts
+++ b/packages/vant-cli/src/compiler/gen-component-style.ts
@@ -91,7 +91,7 @@ export function genComponentStyle(
     genEntry({
       baseFile,
       component,
-      filename: 'index.js',
+      filename: 'css.js',
       ext: '.css',
     });
 
@@ -99,7 +99,7 @@ export function genComponentStyle(
       genEntry({
         baseFile,
         component,
-        filename: CSS_LANG + '.js',
+        filename: 'index.js',
         ext: '.' + CSS_LANG,
       });
     }


### PR DESCRIPTION
resolve the problem that importing less styles failed by:
- build component style file index.js for less styles
- build component style file css.js for css styles

Issue #7658

### Before submitting a pull request, please make sure the following is done:

1. Read the [contributing guide](https://github.com/youzan/vant/blob/dev/.github/CONTRIBUTING.md).
2. If you've added code that should be tested, add tests.
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).

#### Title Format

type(ComponentName?)：commit message

Example：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

Allowed Types:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change
