### PR TITLE
fix(number-keyboard): fix hide-on-click-outside prop not working

### DIFF
--- a/src/number-keyboard/index.js
+++ b/src/number-keyboard/index.js
@@ -223,7 +223,9 @@ export default createComponent({
       }
     );
 
-    useClickAway(root, onClose, { eventName: 'touchstart' });
+    if (props.hideOnClickOutside) {
+      useClickAway(root, onClose, { eventName: 'touchstart' });
+    }
 
     return () => {
       const Title = renderTitle();


### PR DESCRIPTION
fix #7667

- [x] hide-on-click-outside prop not working
- [ ]  hide-on-click-outside prop supports responsive
- [ ] useClickAway should return the cancel listening function
