### PR TITLE
fix(List): 重复渲染

### DIFF
--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -1,4 +1,4 @@
-import { ref, watch, nextTick, onUpdated, onMounted, PropType } from 'vue';
+import { ref, watch, nextTick, computed, onMounted, PropType } from 'vue';
 
 // Utils
 import { isHidden, createNamespace } from '../utils';
@@ -37,8 +37,12 @@ export default createComponent({
   emits: ['load', 'update:error', 'update:loading'],
 
   setup(props, { emit, slots }) {
-    // use sync innerLoading state to avoid repeated loading in some edge cases
-    const loading = ref(false);
+    const loading = computed<boolean>({
+      get: () => props.loading,
+      set(val: boolean) {
+        emit('update:loading', val);
+      },
+    });
     const root = ref<HTMLElement>();
     const placeholder = ref<HTMLElement>();
     const scrollParent = useScrollParent(root);
@@ -68,7 +72,6 @@ export default createComponent({
 
         if (isReachEdge) {
           loading.value = true;
-          emit('update:loading', true);
           emit('load');
         }
       });
@@ -116,10 +119,6 @@ export default createComponent({
     };
 
     watch([() => props.loading, () => props.finished], check);
-
-    onUpdated(() => {
-      loading.value = props.loading!;
-    });
 
     onMounted(() => {
       if (props.immediateCheck) {


### PR DESCRIPTION
当使用者在加载完数据后将loading设为false时 组件将更新 而又因为List组件内部使用onUpdated执行了本地loading=false 所以List组件会再次更新 导致slots.default()再次调用 造成无谓的性能开销