### PR TITLE
fix(Calendar): change props.data to props.date to fix getDate bug #7837

### DIFF
--- a/src/calendar/components/Month.js
+++ b/src/calendar/components/Month.js
@@ -65,7 +65,7 @@ export default createComponent({
 
     const shouldRender = computed(() => visible.value || !props.lazyRender);
 
-    const getDate = () => props.data;
+    const getDate = () => props.date;
     const getTitle = () => title.value;
 
     const scrollIntoView = (body) => {


### PR DESCRIPTION
 #7837
# 问题描述
Calendar的month组件有一个getDate方法 [getDate](https://github.com/youzan/vant/blob/dev/src/calendar/components/Month.js#L68)，我的理解是该方法应该是用来获取`props`中的`date`，但是代码中却写成了`props.data`
# 解决方案
将`props.data`改成`props.date`



