### PR TITLE
feat(NumberKeyboard): add number random prop

### DIFF
--- a/src/number-keyboard/README.md
+++ b/src/number-keyboard/README.md
@@ -111,34 +111,6 @@ Use `title` prop to set keyboard title.
 />
 ```
 
-### Bind Value
-
-```html
-<van-field
-  readonly
-  clickable
-  :value="value"
-  @touchstart.native.stop="show = true"
-/>
-<van-number-keyboard
-  v-model="value"
-  :show="show"
-  :maxlength="6"
-  @blur="show = false"
-/>
-```
-
-```js
-export default {
-  data() {
-    return {
-      show: false,
-      value: '',
-    };
-  },
-};
-```
-
 ### Number Random
 
 Use `number-random` prop to random sort number keypads.
@@ -174,6 +146,34 @@ export default {
 };
 ```
 
+
+### Bind Value
+
+```html
+<van-field
+  readonly
+  clickable
+  :value="value"
+  @touchstart.native.stop="show = true"
+/>
+<van-number-keyboard
+  v-model="value"
+  :show="show"
+  :maxlength="6"
+  @blur="show = false"
+/>
+```
+
+```js
+export default {
+  data() {
+    return {
+      show: false,
+      value: '',
+    };
+  },
+};
+```
 
 ## API
 

--- a/src/number-keyboard/README.md
+++ b/src/number-keyboard/README.md
@@ -113,13 +113,15 @@ Use `title` prop to set keyboard title.
 
 ### Number Random
 
-Use `number-random` prop to random sort number keypads.
+Use `random-key-order` prop to random sort number keypads.
 
 ```html
-<van-cell @touchstart.native.stop="show = true">弹出配置随机数字的键盘</van-cell>
+<van-cell @touchstart.native.stop="show = true"
+  >弹出配置随机数字的键盘</van-cell
+>
 <van-number-keyboard
   :show="show"
-  :number-random="true"
+  :random-key-order="true"
   @blur="show = false"
   @input="onInput"
   @delete="onDelete"
@@ -145,7 +147,6 @@ export default {
   },
 };
 ```
-
 
 ### Bind Value
 
@@ -196,7 +197,7 @@ export default {
 | hide-on-click-outside | Whether to hide keyboard when outside is clicked | _boolean_ | `true` |
 | get-container `v2.10.0` | Return the mount node for NumberKeyboard | _string \| () => Element_ | - |
 | safe-area-inset-bottom | Whether to enable bottom safe area adaptation | _boolean_ | `true` |
-| number-random | whether to enable random sort number keypads | _boolean_ | `false` |
+| random-key-order | whether to enable random sort number keypads | _boolean_ | `false` |
 
 ### Events
 

--- a/src/number-keyboard/README.md
+++ b/src/number-keyboard/README.md
@@ -139,6 +139,42 @@ export default {
 };
 ```
 
+### Number Random
+
+Use `number-random` prop to random sort number keypads.
+
+```html
+<van-cell @touchstart.native.stop="show = true">弹出配置随机数字的键盘</van-cell>
+<van-number-keyboard
+  :show="show"
+  :number-random="true"
+  @blur="show = false"
+  @input="onInput"
+  @delete="onDelete"
+/>
+```
+
+```js
+import { Toast } from 'vant';
+
+export default {
+  data() {
+    return {
+      show: true,
+    };
+  },
+  methods: {
+    onInput(value) {
+      Toast(value);
+    },
+    onDelete() {
+      Toast('删除');
+    },
+  },
+};
+```
+
+
 ## API
 
 ### Props
@@ -160,6 +196,7 @@ export default {
 | hide-on-click-outside | Whether to hide keyboard when outside is clicked | _boolean_ | `true` |
 | get-container `v2.10.0` | Return the mount node for NumberKeyboard | _string \| () => Element_ | - |
 | safe-area-inset-bottom | Whether to enable bottom safe area adaptation | _boolean_ | `true` |
+| number-random | whether to enable random sort number keypads | _boolean_ | `false` |
 
 ### Events
 

--- a/src/number-keyboard/README.zh-CN.md
+++ b/src/number-keyboard/README.zh-CN.md
@@ -122,6 +122,42 @@ export default {
 />
 ```
 
+### 随机数字键盘
+
+通过 `number-random` 属性可以随机排序数字键盘，常用于安全等级较高的场景
+
+```html
+<van-cell @touchstart.native.stop="show = true">弹出配置随机数字的键盘</van-cell>
+<van-number-keyboard
+  :show="show"
+  :number-random="true"
+  @blur="show = false"
+  @input="onInput"
+  @delete="onDelete"
+/>
+```
+
+```js
+import { Toast } from 'vant';
+
+export default {
+  data() {
+    return {
+      show: true,
+    };
+  },
+  methods: {
+    onInput(value) {
+      Toast(value);
+    },
+    onDelete() {
+      Toast('删除');
+    },
+  },
+};
+```
+
+
 ### 双向绑定
 
 可以通过 `v-model` 绑定键盘当前输入值。
@@ -173,6 +209,7 @@ export default {
 | hide-on-click-outside | 点击外部时是否收起键盘 | _boolean_ | `true` |
 | get-container `v2.10.0` | 指定挂载的节点，[用法示例](#/zh-CN/popup#zhi-ding-gua-zai-wei-zhi) | _string \| () => Element_ | - |
 | safe-area-inset-bottom | 是否开启[底部安全区适配](#/zh-CN/advanced-usage#di-bu-an-quan-qu-gua-pei) | _boolean_ | `true` |
+| number-random | 是否随机键盘数字 | _boolean_ | `false` |
 
 ### Events
 

--- a/src/number-keyboard/README.zh-CN.md
+++ b/src/number-keyboard/README.zh-CN.md
@@ -124,13 +124,15 @@ export default {
 
 ### 随机数字键盘
 
-通过 `number-random` 属性可以随机排序数字键盘，常用于安全等级较高的场景
+通过 `random-key-order` 属性可以随机排序数字键盘，常用于安全等级较高的场景
 
 ```html
-<van-cell @touchstart.native.stop="show = true">弹出配置随机数字的键盘</van-cell>
+<van-cell @touchstart.native.stop="show = true"
+  >弹出配置随机数字的键盘</van-cell
+>
 <van-number-keyboard
   :show="show"
-  :number-random="true"
+  :random-key-order="true"
   @blur="show = false"
   @input="onInput"
   @delete="onDelete"
@@ -156,7 +158,6 @@ export default {
   },
 };
 ```
-
 
 ### 双向绑定
 
@@ -209,7 +210,7 @@ export default {
 | hide-on-click-outside | 点击外部时是否收起键盘 | _boolean_ | `true` |
 | get-container `v2.10.0` | 指定挂载的节点，[用法示例](#/zh-CN/popup#zhi-ding-gua-zai-wei-zhi) | _string \| () => Element_ | - |
 | safe-area-inset-bottom | 是否开启[底部安全区适配](#/zh-CN/advanced-usage#di-bu-an-quan-qu-gua-pei) | _boolean_ | `true` |
-| number-random | 是否随机键盘数字 | _boolean_ | `false` |
+| random-key-order | 是否随机键盘数字 | _boolean_ | `false` |
 
 ### Events
 

--- a/src/number-keyboard/demo/index.vue
+++ b/src/number-keyboard/demo/index.vue
@@ -15,9 +15,6 @@
     <van-cell is-link @touchstart.native.stop="keyboard = 'multiExtraKey'">
       {{ t('button5') }}
     </van-cell>
-    <van-cell is-link @touchstart.native.stop="keyboard = 'numberRandom'">
-      {{ t('button6') }}
-    </van-cell>
 
     <van-field
       readonly
@@ -81,13 +78,6 @@
       @blur="keyboard = ''"
     />
 
-    <van-number-keyboard
-      :show="keyboard === 'numberRandom'"
-      :number-random="true"
-      @blur="keyboard = ''"
-      @input="onInput"
-      @delete="onDelete"
-    />
   </demo-section>
 </template>
 
@@ -103,7 +93,6 @@ export default {
       button3: '弹出身份证号键盘',
       button4: '弹出带标题的键盘',
       button5: '弹出配置多个按键的键盘',
-      button6: '弹出配置随机数字的键盘',
       bindValue: '双向绑定',
       clickToInput: '点此输入',
       extraKey: '左下角按键内容',
@@ -118,7 +107,6 @@ export default {
       button3: 'Show IdNumber Keyboard',
       button4: 'Show Keyboard With Title',
       button5: 'Show Keyboard With Multiple ExtraKey',
-      button6: 'Show Keyboard With Number Random',
       bindValue: 'Bind Value',
       clickToInput: 'Click To Input',
       extraKey: 'IdNumber Keyboard',

--- a/src/number-keyboard/demo/index.vue
+++ b/src/number-keyboard/demo/index.vue
@@ -15,6 +15,10 @@
     <van-cell is-link @touchstart.native.stop="keyboard = 'multiExtraKey'">
       {{ t('button5') }}
     </van-cell>
+    <van-cell is-link @touchstart.native.stop="keyboard = 'numberRandom'">
+      {{ t('button6') }}
+    </van-cell>
+
     <van-field
       readonly
       clickable
@@ -76,6 +80,14 @@
       maxlength="6"
       @blur="keyboard = ''"
     />
+
+    <van-number-keyboard
+      :show="keyboard === 'numberRandom'"
+      :number-random="true"
+      @blur="keyboard = ''"
+      @input="onInput"
+      @delete="onDelete"
+    />
   </demo-section>
 </template>
 
@@ -91,6 +103,7 @@ export default {
       button3: '弹出身份证号键盘',
       button4: '弹出带标题的键盘',
       button5: '弹出配置多个按键的键盘',
+      button6: '弹出配置随机数字的键盘',
       bindValue: '双向绑定',
       clickToInput: '点此输入',
       extraKey: '左下角按键内容',
@@ -105,6 +118,7 @@ export default {
       button3: 'Show IdNumber Keyboard',
       button4: 'Show Keyboard With Title',
       button5: 'Show Keyboard With Multiple ExtraKey',
+      button6: 'Show Keyboard With Number Random',
       bindValue: 'Bind Value',
       clickToInput: 'Click To Input',
       extraKey: 'IdNumber Keyboard',

--- a/src/number-keyboard/index.js
+++ b/src/number-keyboard/index.js
@@ -59,10 +59,10 @@ export default createComponent({
       type: Boolean,
       default: true,
     },
-    numberRandom: {
+    randomKeyOrder: {
       type: Boolean,
       default: false,
-    }
+    },
   },
 
   watch: {
@@ -89,8 +89,8 @@ export default createComponent({
         keys.push({ text: i });
       }
 
-      if (this.numberRandom) {
-        keys.sort(() => Math.random() > 0.5 ? 1 : -1)
+      if (this.randomKeyOrder) {
+        keys.sort(() => (Math.random() > 0.5 ? 1 : -1));
       }
 
       return keys;

--- a/src/number-keyboard/index.js
+++ b/src/number-keyboard/index.js
@@ -59,6 +59,10 @@ export default createComponent({
       type: Boolean,
       default: true,
     },
+    numberRandom: {
+      type: Boolean,
+      default: false,
+    }
   },
 
   watch: {
@@ -84,6 +88,11 @@ export default createComponent({
       for (let i = 1; i <= 9; i++) {
         keys.push({ text: i });
       }
+
+      if (this.numberRandom) {
+        keys.sort(() => Math.random() > 0.5 ? 1 : -1)
+      }
+
       return keys;
     },
 

--- a/src/number-keyboard/test/__snapshots__/demo.spec.js.snap
+++ b/src/number-keyboard/test/__snapshots__/demo.spec.js.snap
@@ -32,12 +32,6 @@ exports[`renders demo correctly 1`] = `
     </div><i class="van-icon van-icon-arrow van-cell__right-icon">
       <!----></i>
   </div>
-  <div role="button" tabindex="0" class="van-cell van-cell--clickable">
-    <div class="van-cell__value van-cell__value--alone">
-      弹出配置随机数字的键盘
-    </div><i class="van-icon van-icon-arrow van-cell__right-icon">
-      <!----></i>
-  </div>
   <div role="button" tabindex="0" class="van-cell van-cell--clickable van-field">
     <div class="van-cell__title van-field__label"><span>双向绑定</span></div>
     <div class="van-cell__value van-field__value">
@@ -312,52 +306,6 @@ exports[`renders demo correctly 1`] = `
         </div>
         <div class="van-key__wrapper">
           <div role="button" tabindex="0" class="van-key">9</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key"><svg viewBox="0 0 30 24" xmlns="http://www.w3.org/2000/svg" class="van-key__collapse-icon">
-              <path d="M25.877 12.843h-1.502c-.188 0-.188 0-.188.19v1.512c0 .188 0 .188.188.188h1.5c.187 0 .187 0 .187-.188v-1.511c0-.19 0-.191-.185-.191zM17.999 10.2c0 .188 0 .188.188.188h1.687c.188 0 .188 0 .188-.188V8.688c0-.187.004-.187-.186-.19h-1.69c-.187 0-.187 0-.187.19V10.2zm2.25-3.967h1.5c.188 0 .188 0 .188-.188v-1.7c0-.19 0-.19-.188-.19h-1.5c-.189 0-.189 0-.189.19v1.7c0 .188 0 .188.19.188zm2.063 4.157h3.563c.187 0 .187 0 .187-.189V4.346c0-.19.004-.19-.185-.19h-1.69c-.187 0-.187 0-.187.188v4.155h-1.688c-.187 0-.187 0-.187.189v1.514c0 .19 0 .19.187.19zM14.812 24l2.812-3.4H12l2.813 3.4zm-9-11.157H4.31c-.188 0-.188 0-.188.19v1.512c0 .188 0 .188.188.188h1.502c.187 0 .187 0 .187-.188v-1.511c0-.19.01-.191-.189-.191zm15.937 0H8.25c-.188 0-.188 0-.188.19v1.512c0 .188 0 .188.188.188h13.5c.188 0 .188 0 .188-.188v-1.511c0-.19 0-.191-.188-.191zm-11.438-2.454h1.5c.188 0 .188 0 .188-.188V8.688c0-.187 0-.187-.188-.189h-1.5c-.187 0-.187 0-.187.189V10.2c0 .188 0 .188.187.188zM27.94 0c.563 0 .917.21 1.313.567.518.466.748.757.748 1.51v14.92c0 .567-.188 1.134-.562 1.512-.376.378-.938.566-1.313.566H2.063c-.563 0-.938-.188-1.313-.566-.562-.378-.75-.945-.75-1.511V2.078C0 1.51.188.944.562.567.938.189 1.5 0 1.875 0zm-.062 2H2v14.92h25.877V2zM5.81 4.157c.19 0 .19 0 .19.189v1.762c-.003.126-.024.126-.188.126H4.249c-.126-.003-.126-.023-.126-.188v-1.7c-.187-.19 0-.19.188-.19zm10.5 2.077h1.503c.187 0 .187 0 .187-.188v-1.7c0-.19 0-.19-.187-.19h-1.502c-.188 0-.188.001-.188.19v1.7c0 .188 0 .188.188.188zM7.875 8.5c.187 0 .187.002.187.189V10.2c0 .188 0 .188-.187.188H4.249c-.126-.002-.126-.023-.126-.188V8.625c.003-.126.024-.126.188-.126zm7.875 0c.19.002.19.002.19.189v1.575c-.003.126-.024.126-.19.126h-1.563c-.126-.002-.126-.023-.126-.188V8.625c.002-.126.023-.126.189-.126zm-6-4.342c.187 0 .187 0 .187.189v1.7c0 .188 0 .188-.187.188H8.187c-.126-.003-.126-.023-.126-.188V4.283c.003-.126.024-.126.188-.126zm3.94 0c.185 0 .372 0 .372.189v1.762c-.002.126-.023.126-.187.126h-1.75C12 6.231 12 6.211 12 6.046v-1.7c0-.19.187-.19.187-.19z" fill="currentColor"></path>
-            </svg></div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">0</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key van-key--delete"><svg viewBox="0 0 32 22" xmlns="http://www.w3.org/2000/svg" class="van-key__delete-icon">
-              <path d="M28.016 0A3.991 3.991 0 0132 3.987v14.026c0 2.2-1.787 3.987-3.98 3.987H10.382c-.509 0-.996-.206-1.374-.585L.89 13.09C.33 12.62 0 11.84 0 11.006c0-.86.325-1.62.887-2.08L9.01.585A1.936 1.936 0 0110.383 0zm0 1.947H10.368L2.24 10.28c-.224.226-.312.432-.312.73 0 .287.094.51.312.729l8.128 8.333h17.648a2.041 2.041 0 002.037-2.04V3.987c0-1.127-.915-2.04-2.037-2.04zM23.028 6a.96.96 0 01.678.292.95.95 0 01-.003 1.377l-3.342 3.348 3.326 3.333c.189.188.292.43.292.679 0 .248-.103.49-.292.679a.96.96 0 01-.678.292.959.959 0 01-.677-.292L18.99 12.36l-3.343 3.345a.96.96 0 01-.677.292.96.96 0 01-.678-.292.962.962 0 01-.292-.68c0-.248.104-.49.292-.679l3.342-3.348-3.342-3.348A.963.963 0 0114 6.971c0-.248.104-.49.292-.679A.96.96 0 0114.97 6a.96.96 0 01.677.292l3.358 3.348 3.345-3.348A.96.96 0 0123.028 6z" fill="currentColor"></path>
-            </svg></div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div class="van-number-keyboard" style="display: none;" name="van-slide-up">
-    <div class="van-number-keyboard__body">
-      <div class="van-number-keyboard__keys">
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">1</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">2</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">9</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">3</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">5</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">4</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">8</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">6</div>
-        </div>
-        <div class="van-key__wrapper">
-          <div role="button" tabindex="0" class="van-key">7</div>
         </div>
         <div class="van-key__wrapper">
           <div role="button" tabindex="0" class="van-key"><svg viewBox="0 0 30 24" xmlns="http://www.w3.org/2000/svg" class="van-key__collapse-icon">

--- a/src/number-keyboard/test/__snapshots__/demo.spec.js.snap
+++ b/src/number-keyboard/test/__snapshots__/demo.spec.js.snap
@@ -32,6 +32,12 @@ exports[`renders demo correctly 1`] = `
     </div><i class="van-icon van-icon-arrow van-cell__right-icon">
       <!----></i>
   </div>
+  <div role="button" tabindex="0" class="van-cell van-cell--clickable">
+    <div class="van-cell__value van-cell__value--alone">
+      弹出配置随机数字的键盘
+    </div><i class="van-icon van-icon-arrow van-cell__right-icon">
+      <!----></i>
+  </div>
   <div role="button" tabindex="0" class="van-cell van-cell--clickable van-field">
     <div class="van-cell__title van-field__label"><span>双向绑定</span></div>
     <div class="van-cell__value van-field__value">
@@ -306,6 +312,52 @@ exports[`renders demo correctly 1`] = `
         </div>
         <div class="van-key__wrapper">
           <div role="button" tabindex="0" class="van-key">9</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key"><svg viewBox="0 0 30 24" xmlns="http://www.w3.org/2000/svg" class="van-key__collapse-icon">
+              <path d="M25.877 12.843h-1.502c-.188 0-.188 0-.188.19v1.512c0 .188 0 .188.188.188h1.5c.187 0 .187 0 .187-.188v-1.511c0-.19 0-.191-.185-.191zM17.999 10.2c0 .188 0 .188.188.188h1.687c.188 0 .188 0 .188-.188V8.688c0-.187.004-.187-.186-.19h-1.69c-.187 0-.187 0-.187.19V10.2zm2.25-3.967h1.5c.188 0 .188 0 .188-.188v-1.7c0-.19 0-.19-.188-.19h-1.5c-.189 0-.189 0-.189.19v1.7c0 .188 0 .188.19.188zm2.063 4.157h3.563c.187 0 .187 0 .187-.189V4.346c0-.19.004-.19-.185-.19h-1.69c-.187 0-.187 0-.187.188v4.155h-1.688c-.187 0-.187 0-.187.189v1.514c0 .19 0 .19.187.19zM14.812 24l2.812-3.4H12l2.813 3.4zm-9-11.157H4.31c-.188 0-.188 0-.188.19v1.512c0 .188 0 .188.188.188h1.502c.187 0 .187 0 .187-.188v-1.511c0-.19.01-.191-.189-.191zm15.937 0H8.25c-.188 0-.188 0-.188.19v1.512c0 .188 0 .188.188.188h13.5c.188 0 .188 0 .188-.188v-1.511c0-.19 0-.191-.188-.191zm-11.438-2.454h1.5c.188 0 .188 0 .188-.188V8.688c0-.187 0-.187-.188-.189h-1.5c-.187 0-.187 0-.187.189V10.2c0 .188 0 .188.187.188zM27.94 0c.563 0 .917.21 1.313.567.518.466.748.757.748 1.51v14.92c0 .567-.188 1.134-.562 1.512-.376.378-.938.566-1.313.566H2.063c-.563 0-.938-.188-1.313-.566-.562-.378-.75-.945-.75-1.511V2.078C0 1.51.188.944.562.567.938.189 1.5 0 1.875 0zm-.062 2H2v14.92h25.877V2zM5.81 4.157c.19 0 .19 0 .19.189v1.762c-.003.126-.024.126-.188.126H4.249c-.126-.003-.126-.023-.126-.188v-1.7c-.187-.19 0-.19.188-.19zm10.5 2.077h1.503c.187 0 .187 0 .187-.188v-1.7c0-.19 0-.19-.187-.19h-1.502c-.188 0-.188.001-.188.19v1.7c0 .188 0 .188.188.188zM7.875 8.5c.187 0 .187.002.187.189V10.2c0 .188 0 .188-.187.188H4.249c-.126-.002-.126-.023-.126-.188V8.625c.003-.126.024-.126.188-.126zm7.875 0c.19.002.19.002.19.189v1.575c-.003.126-.024.126-.19.126h-1.563c-.126-.002-.126-.023-.126-.188V8.625c.002-.126.023-.126.189-.126zm-6-4.342c.187 0 .187 0 .187.189v1.7c0 .188 0 .188-.187.188H8.187c-.126-.003-.126-.023-.126-.188V4.283c.003-.126.024-.126.188-.126zm3.94 0c.185 0 .372 0 .372.189v1.762c-.002.126-.023.126-.187.126h-1.75C12 6.231 12 6.211 12 6.046v-1.7c0-.19.187-.19.187-.19z" fill="currentColor"></path>
+            </svg></div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">0</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key van-key--delete"><svg viewBox="0 0 32 22" xmlns="http://www.w3.org/2000/svg" class="van-key__delete-icon">
+              <path d="M28.016 0A3.991 3.991 0 0132 3.987v14.026c0 2.2-1.787 3.987-3.98 3.987H10.382c-.509 0-.996-.206-1.374-.585L.89 13.09C.33 12.62 0 11.84 0 11.006c0-.86.325-1.62.887-2.08L9.01.585A1.936 1.936 0 0110.383 0zm0 1.947H10.368L2.24 10.28c-.224.226-.312.432-.312.73 0 .287.094.51.312.729l8.128 8.333h17.648a2.041 2.041 0 002.037-2.04V3.987c0-1.127-.915-2.04-2.037-2.04zM23.028 6a.96.96 0 01.678.292.95.95 0 01-.003 1.377l-3.342 3.348 3.326 3.333c.189.188.292.43.292.679 0 .248-.103.49-.292.679a.96.96 0 01-.678.292.959.959 0 01-.677-.292L18.99 12.36l-3.343 3.345a.96.96 0 01-.677.292.96.96 0 01-.678-.292.962.962 0 01-.292-.68c0-.248.104-.49.292-.679l3.342-3.348-3.342-3.348A.963.963 0 0114 6.971c0-.248.104-.49.292-.679A.96.96 0 0114.97 6a.96.96 0 01.677.292l3.358 3.348 3.345-3.348A.96.96 0 0123.028 6z" fill="currentColor"></path>
+            </svg></div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div class="van-number-keyboard" style="display: none;" name="van-slide-up">
+    <div class="van-number-keyboard__body">
+      <div class="van-number-keyboard__keys">
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">1</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">2</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">9</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">3</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">5</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">4</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">8</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">6</div>
+        </div>
+        <div class="van-key__wrapper">
+          <div role="button" tabindex="0" class="van-key">7</div>
         </div>
         <div class="van-key__wrapper">
           <div role="button" tabindex="0" class="van-key"><svg viewBox="0 0 30 24" xmlns="http://www.w3.org/2000/svg" class="van-key__collapse-icon">

--- a/src/number-keyboard/test/index.spec.js
+++ b/src/number-keyboard/test/index.spec.js
@@ -238,3 +238,22 @@ test('close-button-loading prop', () => {
 
   expect(wrapper.contains('.van-key__loading-icon')).toBeTruthy();
 });
+test('number-random prop', () => {
+  const wrapper = mount(NumberKeyboard, {
+    propsData: {
+      show: true,
+      numberRandom: true,
+    },
+  });
+
+  const keys = [];
+  const clickKeys = [];
+  for (let i = 0; i < 9; i++) {
+    keys.push(i+1);
+
+    clickKey(wrapper.findAll('.van-key').at(i));
+    clickKeys.push(wrapper.emitted('input')[i][0])
+  }
+
+  expect(keys.every((v, k) => keys[k] === clickKeys[k])).toEqual(false);
+});

--- a/src/number-keyboard/test/index.spec.js
+++ b/src/number-keyboard/test/index.spec.js
@@ -238,21 +238,21 @@ test('close-button-loading prop', () => {
 
   expect(wrapper.contains('.van-key__loading-icon')).toBeTruthy();
 });
-test('number-random prop', () => {
+test('random-key-order prop', () => {
   const wrapper = mount(NumberKeyboard, {
     propsData: {
       show: true,
-      numberRandom: true,
+      randomKeyOrder: true,
     },
   });
 
   const keys = [];
   const clickKeys = [];
   for (let i = 0; i < 9; i++) {
-    keys.push(i+1);
+    keys.push(i + 1);
 
     clickKey(wrapper.findAll('.van-key').at(i));
-    clickKeys.push(wrapper.emitted('input')[i][0])
+    clickKeys.push(wrapper.emitted('input')[i][0]);
   }
 
   expect(keys.every((v, k) => keys[k] === clickKeys[k])).toEqual(false);


### PR DESCRIPTION
#7831 

通过 `number-random` 属性可以随机排序数字键盘，常用于安全等级较高的场景
Use `number-random` prop to random sort number keypads.

### Before submitting a pull request, please make sure the following is done:

1. Read the [contributing guide](https://github.com/youzan/vant/blob/dev/.github/CONTRIBUTING.md).
2. If you've added code that should be tested, add tests.
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).

#### Title Format

type(ComponentName?)：commit message

Example：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

Allowed Types:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change
