### PR TITLE
feat(Dialog): pass dynamic component with props

### DIFF
--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -86,6 +86,24 @@ Dialog.confirm({
 });
 ```
 
+### Dynamic component
+
+```js
+
+Dialog.confirm({
+  title: 'Title',
+  component: defineComponent({...}),
+  componentProps: {
+    modelValue: this.value,
+    'onUpdate:modelValue': (val) => {
+      this.value = val;
+      Dialog.close();
+    }
+  }
+  beforeClose,
+});
+```
+
 ### Global Method
 
 After registering the Dialog component through `app.use`, the `$dialog` method will be automatically mounted on all subcomponents of the app.
@@ -160,6 +178,8 @@ export default {
 | beforeClose | Callback function before close | _(action) => boolean \| Promise_ | - |
 | transition | Transition, equivalent to `name` prop of [transtion](https://v3.vuejs.org/api/built-in-components.html#transition) | _string_ | - |
 | teleport | Return the mount node for Dialog | _string \| Element_ | `body` |
+| component | child dynamic component | _Component_ | - |
+| componentProps | child dynamic component props | _object_ | - |
 
 ### Props
 

--- a/src/dialog/README.zh-CN.md
+++ b/src/dialog/README.zh-CN.md
@@ -195,6 +195,8 @@ export default {
 | beforeClose | 关闭前的回调函数，返回 `false` 可阻止关闭，支持返回 Promise | _(action) => boolean \| Promise_ | - |
 | transition | 动画类名，等价于 [transtion](https://v3.cn.vuejs.org/api/built-in-components.html#transition) 的`name`属性 | _string_ | - |
 | teleport | 指定挂载的节点，[用法示例](#/zh-CN/popup#zhi-ding-gua-zai-wei-zhi) | _string \| Element_ | `body` |
+| component | child dynamic component | _Component_ | - |
+| componentProps | child dynamic component props | _object_ | - |
 
 ### Props
 

--- a/src/dialog/index.js
+++ b/src/dialog/index.js
@@ -8,7 +8,30 @@ function initInstance() {
   const Wrapper = {
     setup() {
       const { state, toggle } = usePopupState();
-      return () => <VanDialog {...{ ...state, 'onUpdate:show': toggle }} />;
+
+      return () => {
+        const DynamicComponent = state.component;
+        if (DynamicComponent) {
+          return (
+            <VanDialog
+              {...{
+                ...state,
+                'onUpdate:show': toggle,
+                component: undefined,
+                componentProps: undefined,
+              }}
+            >
+              <DynamicComponent
+                {...{ ...(state.componentProps || {}), is: state.component }}
+              />
+            </VanDialog>
+          );
+        }
+
+        return (
+          <VanDialog {...{ ...state, 'onUpdate:show': toggle }}></VanDialog>
+        );
+      };
     },
   };
 
@@ -60,6 +83,8 @@ Dialog.defaultOptions = {
   showCancelButton: false,
   closeOnPopstate: true,
   closeOnClickOverlay: false,
+  component: null, // child dynamic component defineComponent({...})
+  componentProps: null, // child dynamic component props and events {someProp:1, 'onUpdate:modelValue':func}
 };
 
 Dialog.alert = Dialog;

--- a/types/dialog.d.ts
+++ b/types/dialog.d.ts
@@ -1,5 +1,5 @@
 import { VanComponent } from './component';
-import { TeleportProps } from 'vue';
+import { TeleportProps, Component } from 'vue';
 
 type DialogAction = 'confirm' | 'cancel';
 type DialogDone = (close?: boolean) => void;
@@ -27,6 +27,8 @@ export type DialogOptions = {
   showCancelButton?: boolean;
   closeOnClickOverlay?: boolean;
   beforeClose?: (action: DialogAction, done: DialogDone) => void;
+  component?: Component;
+  componentProps?: any;
 };
 
 export interface Dialog {


### PR DESCRIPTION
feat(Dialog)：pass dynamic component with props

Now you can pass options `component` and `componentProps` to render child component by code.
This functionality is similar to [vue-js-modal](https://euvl.github.io/vue-js-modal/Usage.html#modal-show-component-componentprops-modalprops-modalevents)
