### PR TITLE
feat(Area):适配8位,10位,12位等地区码,及处理东莞市等没有第三级区域码的问题

### DIFF
--- a/src/area/index.js
+++ b/src/area/index.js
@@ -137,6 +137,10 @@ export default createComponent({
 
       code = code.slice(0, compareNum);
 
+      if(type === 'county') {
+        compareNum = code.length
+      }
+
       for (let i = 0; i < list.length; i++) {
         if (list[i].code.slice(0, compareNum) === code) {
           return i;


### PR DESCRIPTION
已测试
![image](https://user-images.githubusercontent.com/5674953/105793266-c6975500-5fc3-11eb-8ba4-30c090bea5d4.png)

当前版本省市区选择器只能使用6位地区码，对于东莞市等只有2、4级地址的区域不太友好。
以及有些同学使用的8位，10位或12位的4级以上地区码，如果想用省市区选择器还得另行处理地区码.

于是对`getIndex`函数加一层判断。当`type`为"county"时不做地区码长度限制，就能更好的兼容各种地区码了。