### PR TITLE
fix(Tabs): incorrect active tab when active is zero

### DIFF
--- a/src/tabs/index.js
+++ b/src/tabs/index.js
@@ -372,7 +372,7 @@ export default createComponent({
       () => children.length,
       () => {
         if (state.inited) {
-          setCurrentIndexByName(props.active || currentName.value);
+          setCurrentIndexByName((props.active || props.active === 0) ? props.active : currentName.value);
           setLine();
           nextTick(() => {
             scrollIntoView(true);
@@ -397,7 +397,7 @@ export default createComponent({
     );
 
     const init = () => {
-      setCurrentIndexByName(props.active || currentName.value);
+      setCurrentIndexByName((props.active || props.active === 0) ? props.active : currentName.value);
       nextTick(() => {
         state.inited = true;
         tabHeight = getVisibleHeight(wrapRef.value);


### PR DESCRIPTION
修改文件: tabs/index.js
问题：文档里tabs 组件可设置name 属性  取值类型为 string 或 number 然而当 我们去设置 v-model为0 运用 vfor 去渲染时，某一项的 name 也存在为 0 的，一切操作都没啥毛病， 呢么在渲染时 v-model的值会被改成 1，这显然不是我们想要的结果。
原因： 在赋值呢里 运用的是短路运算   props.active||currentName  如果我设置的默认值是数字类型的0  呢么就直接忽略，然后赋 currentName 了(虽然我的active 是已经赋值的了)
解决方案： 在开始赋值时 进行判断一下 active 为 0 的情况。

