### PR TITLE
ci: revert to pull_request

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,6 +1,6 @@
 name: 🔂 Surge PR Preview
 
-on: pull_request_target
+on: pull_request
 
 jobs:
   preview:
@@ -9,8 +9,6 @@ jobs:
       PUBLIC_PATH: '/'
     steps:
       - uses: actions/checkout@v2
-        with:
-          ref: refs/pull/${{ github.event.pull_request.number }}/merge
       - uses: afc163/surge-preview@v1
         with:
           surge_token: ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
`pull_request_target`  配合 `refs/pull/${{ github.event.pull_request.number }}/merge` 有安全隐患，先回滚到 `pull_request`