### PR TITLE
fix(vant-markdown-loader): 修复 demo 组件和其他组件重名导致的渲染异常

### DIFF
--- a/packages/vant-markdown-loader/src/extract-demo.js
+++ b/packages/vant-markdown-loader/src/extract-demo.js
@@ -14,7 +14,7 @@ module.exports = function extraDemo(content) {
     /<demo-code([\s\S]*?)>([\s\S]*?)<\/demo-code>/g,
     function (_, attrs, link) {
       link = link.trim(); // 去换行符
-      const tag = hyphenate(path.basename(link, '.vue'));
+      const tag = 'demo-code-' + hyphenate(path.basename(link, '.vue'));
       const fullLink = path.join(markdownDir, link);
       demoLinks.indexOf(fullLink) === -1 && demoLinks.push(fullLink);
       const demoContent = fs.readFileSync(fullLink, { encoding: 'utf8' });

--- a/packages/vant-markdown-loader/src/index.js
+++ b/packages/vant-markdown-loader/src/index.js
@@ -27,13 +27,13 @@ function wrapper(content) {
 <script>
 ${demoLinks
   .map((link) => {
-    return `import ${camelize(path.basename(link, '.vue'))} from '${link}';`;
+    return `import DemoCode${camelize(path.basename(link, '.vue'))} from '${link}';`;
   })
   .join('\n')}
 
 export default {
   components: {
-    ${demoLinks.map((link) => camelize(path.basename(link, '.vue'))).join(',')}
+    ${demoLinks.map((link) => `DemoCode${camelize(path.basename(link, '.vue'))}`).join(',')}
   },
 
   mounted() {


### PR DESCRIPTION
RT