### PR TITLE
fix: corrected horizontal slip judgment

### DIFF
--- a/src/mixins/touch.js
+++ b/src/mixins/touch.js
@@ -29,7 +29,7 @@ export const TouchMixin = {
     touchMove(event) {
       const touch = event.touches[0];
       // Fix: Safari back will set clientX to negative number
-      this.deltaX = touch.screenX < 0 ? 0 : touch.clientX - this.startX;
+      this.deltaX = touch.clientX < 0 ? 0 : touch.clientX - this.startX;
       this.deltaY = touch.clientY - this.startY;
       this.offsetX = Math.abs(this.deltaX);
       this.offsetY = Math.abs(this.deltaY);

--- a/src/mixins/touch.js
+++ b/src/mixins/touch.js
@@ -28,7 +28,8 @@ export const TouchMixin = {
 
     touchMove(event) {
       const touch = event.touches[0];
-      this.deltaX = touch.clientX - this.startX;
+      // Fix: Safari back will set clientX to negative number
+      this.deltaX = touch.clientX < 0 ? 0 : touch.clientX - this.startX;
       this.deltaY = touch.clientY - this.startY;
       this.offsetX = Math.abs(this.deltaX);
       this.offsetY = Math.abs(this.deltaY);

--- a/src/mixins/touch.js
+++ b/src/mixins/touch.js
@@ -29,7 +29,7 @@ export const TouchMixin = {
     touchMove(event) {
       const touch = event.touches[0];
       // Fix: Safari back will set clientX to negative number
-      this.deltaX = touch.clientX < 0 ? 0 : touch.clientX - this.startX;
+      this.deltaX = touch.screenX < 0 ? 0 : touch.clientX - this.startX;
       this.deltaY = touch.clientY - this.startY;
       this.offsetX = Math.abs(this.deltaX);
       this.offsetY = Math.abs(this.deltaY);

--- a/test/event.ts
+++ b/test/event.ts
@@ -48,10 +48,22 @@ export function trigger(
 // simulate drag gesture
 export function triggerDrag(
   el: Wrapper<Vue> | HTMLElement,
-  x = 0,
-  y = 0
+  relativeX = 0,
+  relativeY = 0
 ): void {
-  trigger(el, 'touchstart', 0, 0);
+  let x = relativeX;
+  let y = relativeY;
+  let startX = 0;
+  let startY = 0;
+  if (relativeX < 0) {
+    startX = Math.abs(relativeX);
+    x = 0;
+  }
+  if (relativeY < 0) {
+    startY = Math.abs(relativeY);
+    y = 0;
+  }
+  trigger(el, 'touchstart', startX, startY);
   trigger(el, 'touchmove', x / 4, y / 4);
   trigger(el, 'touchmove', x / 3, y / 3);
   trigger(el, 'touchmove', x / 2, y / 2);


### PR DESCRIPTION
Closes #8386


修复在 ios safari 中「手势返回」误触「右滑操作」的 bug