### PR TITLE
fix(vant-markdown-loader): 更换新的api

### DIFF
--- a/packages/vant-markdown-loader/src/highlight.js
+++ b/packages/vant-markdown-loader/src/highlight.js
@@ -2,7 +2,8 @@ const hljs = require('highlight.js');
 
 module.exports = function highlight(str, lang) {
   if (lang && hljs.getLanguage(lang)) {
-    return hljs.highlight(lang, str, true).value;
+    // https://github.com/highlightjs/highlight.js/issues/2277
+    return hljs.highlight(str, { language: lang, ignoreIllegals: true }).value;
   }
 
   return '';


### PR DESCRIPTION
更换新的api，原api项目启动一直循环警告

https://github.com/highlightjs/highlight.js/issues/2277
Deprecated as of 10.7.0. highlight(lang, code, ...args) has been deprecated.
Deprecated as of 10.7.0. Please use highlight(code, options) instead.