### PR TITLE
fix(Notify): Type 'Timeout' is not assignable to type 'number'

### DIFF
--- a/src/notify/function-call.tsx
+++ b/src/notify/function-call.tsx
@@ -59,7 +59,7 @@ function Notify(options: NotifyMessage | NotifyOptions) {
   clearTimeout(timer);
 
   if (options.duration! > 0) {
-    timer = setTimeout(Notify.clear, options.duration);
+    timer = window.setTimeout(Notify.clear, options.duration);
   }
 
   return instance;


### PR DESCRIPTION
启动之后ts类型校验失败，报错信息Type 'Timeout' is not assignable to type 'number'
可以运行但是控制台一直有报错信息。所以修改为window.setTimeout(Notify.clear, options.duration);