### PR TITLE
docs:fix the Grid doc to be consistent with the example.

### DIFF
--- a/src/grid/README.md
+++ b/src/grid/README.md
@@ -73,7 +73,7 @@ app.use(GridItem);
 ### Horizontal
 
 ```html
-<van-grid direction="horizontal" :column-num="2">
+<van-grid direction="horizontal" :column-num="3">
   <van-grid-item icon="photo-o" text="文字" />
   <van-grid-item icon="photo-o" text="文字" />
   <van-grid-item icon="photo-o" text="文字" />

--- a/src/grid/README.zh-CN.md
+++ b/src/grid/README.zh-CN.md
@@ -85,7 +85,7 @@ app.use(GridItem);
 将 `direction` 属性设置为 `horizontal`，可以让宫格的内容呈横向排列。
 
 ```html
-<van-grid direction="horizontal" :column-num="2">
+<van-grid direction="horizontal" :column-num="3">
   <van-grid-item icon="photo-o" text="文字" />
   <van-grid-item icon="photo-o" text="文字" />
   <van-grid-item icon="photo-o" text="文字" />


### PR DESCRIPTION
修复 Grid 文档和示例保持一致
否则在使用的时候造成困惑，误以为是整个row是处于横排。

![image](https://user-images.githubusercontent.com/4987317/114121425-e8e11380-9920-11eb-85f7-a877711f237e.png)
