### PR TITLE
feat(markdown-vetur): 支持生成 attributes.json 的 options 属性

### DIFF
--- a/packages/vant-markdown-vetur/src/formatter.ts
+++ b/packages/vant-markdown-vetur/src/formatter.ts
@@ -1,6 +1,6 @@
 /* eslint-disable no-continue */
 import { Articals } from './parser';
-import { formatType, removeVersion, toKebabCase } from './utils';
+import { formatOptions, formatType, removeVersion, toKebabCase } from './utils';
 import { VueTag } from './type';
 
 function formatComponentName(name: string, tagPrefix: string) {
@@ -64,11 +64,12 @@ export function formatter(
       const tag = findTag(vueTags, name);
 
       table.body.forEach((line) => {
-        const [name, desc, type, defaultVal] = line;
+        const [name, desc, type, defaultVal, options] = line;
         tag.attributes!.push({
           name: removeVersion(name),
           default: defaultVal,
           description: desc,
+          options: formatOptions(options),
           value: {
             type: formatType(type),
             kind: 'expression',

--- a/packages/vant-markdown-vetur/src/type.ts
+++ b/packages/vant-markdown-vetur/src/type.ts
@@ -20,6 +20,7 @@ export type VueAttribute = {
   name: string;
   default: string;
   description: string;
+  options: string[]
   value: {
     kind: 'expression';
     type: string;
@@ -44,6 +45,7 @@ export type VeturTags = Record<string, VeturTag>;
 export type VeturAttribute = {
   type: string;
   description: string;
+  options: string[];
 };
 
 export type VeturAttributes = Record<string, VeturAttribute>;

--- a/packages/vant-markdown-vetur/src/type.ts
+++ b/packages/vant-markdown-vetur/src/type.ts
@@ -45,7 +45,7 @@ export type VeturTags = Record<string, VeturTag>;
 export type VeturAttribute = {
   type: string;
   description: string;
-  options: string[];
+  options?: string[];
 };
 
 export type VeturAttributes = Record<string, VeturAttribute>;

--- a/packages/vant-markdown-vetur/src/utils.ts
+++ b/packages/vant-markdown-vetur/src/utils.ts
@@ -20,3 +20,9 @@ export function formatType(type: string) {
 export function normalizePath(path: string): string {
   return path.replace(/\\/g, '/');
 }
+
+//  `default` `primary` -> ['default', 'primary']
+export function formatOptions(options?: string) {
+  if (!options) return []
+  return options.replace(/`/g, '').split(' ')
+}

--- a/packages/vant-markdown-vetur/src/vetur.ts
+++ b/packages/vant-markdown-vetur/src/vetur.ts
@@ -1,4 +1,4 @@
-import { VueTag, VeturTags, VeturAttributes } from './type';
+import { VueTag, VeturTags, VeturAttributes, VeturAttribute } from './type';
 
 export function genVeturTags(tags: VueTag[]) {
   const veturTags: VeturTags = {};
@@ -18,11 +18,16 @@ export function genVeturAttributes(tags: VueTag[]) {
   tags.forEach(tag => {
     if (tag.attributes) {
       tag.attributes.forEach(attr => {
-        veturAttributes[`${tag.name}/${attr.name}`] = {
+        let attribute: VeturAttribute = {
           type: attr.value.type,
-          description: `${attr.description}, 默认值: ${attr.default}`,
-          options: attr.options
-        };
+          description: `${attr.description}, 默认值: ${attr.default}`
+        }
+
+        if (attr.options.length > 0) {
+          attribute.options = attr.options
+        }
+
+        veturAttributes[`${tag.name}/${attr.name}`] = attribute;
       });
     }
   });

--- a/packages/vant-markdown-vetur/src/vetur.ts
+++ b/packages/vant-markdown-vetur/src/vetur.ts
@@ -21,6 +21,7 @@ export function genVeturAttributes(tags: VueTag[]) {
         veturAttributes[`${tag.name}/${attr.name}`] = {
           type: attr.value.type,
           description: `${attr.description}, 默认值: ${attr.default}`,
+          options: attr.options
         };
       });
     }


### PR DESCRIPTION
说明

**可选值用空格隔开**

示例

| 参数         | 说明 | 类型     | 默认值    | 可选值              |
| ------------ | ---- | -------- | --------- | ------------------- |
| type `1.0.0` | 类型 | _string_ | `primary` | `default` `primary`  `success` |

结果

```json
{
  "u-button/type": {
    "type": "string",
    "description": "类型, 默认值: `primary`",
    "options": ["default", "primary", "success"]
  }
}
```