### PR TITLE
fix(DatetimePicker): fixed incorrect value when dynamic set min/max

### DIFF
--- a/src/datetime-picker/DatePicker.js
+++ b/src/datetime-picker/DatePicker.js
@@ -30,7 +30,11 @@ export default createComponent({
 
   watch: {
     filter: 'updateInnerValue',
-    minDate: 'updateInnerValue',
+    minDate() {
+      this.$nextTick(() => {
+        this.updateInnerValue();
+      });
+    },
     maxDate: 'updateInnerValue',
 
     value(val) {

--- a/src/datetime-picker/TimePicker.js
+++ b/src/datetime-picker/TimePicker.js
@@ -45,7 +45,11 @@ export default createComponent({
 
   watch: {
     filter: 'updateInnerValue',
-    minHour: 'updateInnerValue',
+    minHour() {
+      this.$nextTick(() => {
+        this.updateInnerValue();
+      });
+    },
     maxHour: 'updateInnerValue',
     minMinute: 'updateInnerValue',
     maxMinute: 'updateInnerValue',

--- a/src/datetime-picker/test/date-picker.spec.js
+++ b/src/datetime-picker/test/date-picker.spec.js
@@ -215,7 +215,7 @@ test('use min-date with filter', async () => {
 
 test('v-model', async () => {
   const minDate = new Date(2030, 0, 0, 0, 3);
-  
+
   const wrapper = mount({
     template: `
       <van-datetime-picker
@@ -232,7 +232,7 @@ test('v-model', async () => {
   });
 
   await later();
-  
+
   wrapper.find('.van-picker__confirm').trigger('click');
   expect(wrapper.vm.date).toEqual(minDate);
 });
@@ -245,6 +245,32 @@ test('value has an inital value', () => {
     },
   });
 
+  wrapper.find('.van-picker__confirm').trigger('click');
+  expect(wrapper.emitted('confirm')[0][0]).toEqual(defaultValue);
+});
+
+test('change min-date and emit correct value', async () => {
+  const defaultValue = new Date(2020, 10, 2, 10, 30);
+  const wrapper = mount({
+    template: `
+    <van-datetime-picker
+      v-model="date"
+      :min-date="minDate"
+      @confirm="value => this.$emit('confirm', value)"
+    />
+    `,
+    data() {
+      return {
+        date: defaultValue,
+        minDate: new Date(2010, 0, 1, 10, 30),
+      }
+    },
+    mounted() {
+      this.minDate = defaultValue;
+    },
+  })
+
+  await later();
   wrapper.find('.van-picker__confirm').trigger('click');
   expect(wrapper.emitted('confirm')[0][0]).toEqual(defaultValue);
 });

--- a/src/datetime-picker/test/time-picker.spec.js
+++ b/src/datetime-picker/test/time-picker.spec.js
@@ -150,3 +150,29 @@ test('set min-minute dynamically', async () => {
   wrapper.find('.van-picker__confirm').trigger('click');
   expect(wrapper.emitted('confirm')[0][0]).toEqual('13:00');
 });
+
+test('change min-hour and emit correct value', async () => {
+  const wrapper = mount({
+    template: `
+    <van-datetime-picker
+      v-model="time"
+      type="time"
+      :min-hour="minHour"
+      @confirm="value => this.$emit('confirm', value)"
+    />
+    `,
+    data() {
+      return {
+        time: '10:30',
+        minHour: 1,
+      }
+    },
+    mounted() {
+      this.minHour = 11;
+    },
+  })
+
+  await later();
+  wrapper.find('.van-picker__confirm').trigger('click');
+  expect(wrapper.emitted('confirm')[0][0]).toEqual('11:30');
+});


### PR DESCRIPTION
#7253 

- 原因应该是在`updateColumnValue`方法里存在`nextTick`，导致如果在`updateInnerValue`里面直接去取的话取的index会不正确
- DatePicker和TimePicker都存在相同问题
- 原先的测试用例没有覆盖到类似的情况
