### PR TITLE
NumberKeyBoard：Fix using extra-key is Array

### DIFF
--- a/src/number-keyboard/NumberKeyboardKey.tsx
+++ b/src/number-keyboard/NumberKeyboardKey.tsx
@@ -30,7 +30,7 @@ export default defineComponent({
 
   props: {
     type: String as PropType<KeyType>,
-    text: [Number, String],
+    text: [Number, String , Array],
     color: String,
     wider: Boolean,
     large: Boolean,


### PR DESCRIPTION
Fix using extra-key is Array
error message：
 “Invalid prop: type check failed for prop "text". Expected Number, String, got Array“


