### PR TITLE
fix(Calendar): initial date incorrect

### DIFF
--- a/src/calendar/Calendar.tsx
+++ b/src/calendar/Calendar.tsx
@@ -88,13 +88,13 @@ export default defineComponent({
     minDate: {
       type: Date,
       validator: isDate,
-      default: () => new Date(),
+      default: () => new Date(new Date().setHours(0, 0, 0, 0)),
     },
     maxDate: {
       type: Date,
       validator: isDate,
       default: () => {
-        const now = new Date();
+        const now = new Date(new Date().setHours(0, 0, 0, 0));
         return new Date(now.getFullYear(), now.getMonth() + 6, now.getDate());
       },
     },
@@ -129,7 +129,7 @@ export default defineComponent({
         return defaultDate;
       }
 
-      const now = new Date();
+      const now = new Date(new Date().setHours(0, 0, 0, 0));
 
       if (type === 'range') {
         if (!Array.isArray(defaultDate)) {

--- a/src/calendar/Calendar.tsx
+++ b/src/calendar/Calendar.tsx
@@ -24,6 +24,7 @@ import {
   cloneDates,
   getPrevDay,
   getNextDay,
+  getToday,
   compareDay,
   calcDateNum,
   compareMonth,
@@ -88,13 +89,13 @@ export default defineComponent({
     minDate: {
       type: Date,
       validator: isDate,
-      default: () => new Date(new Date().setHours(0, 0, 0, 0)),
+      default: getToday,
     },
     maxDate: {
       type: Date,
       validator: isDate,
       default: () => {
-        const now = new Date(new Date().setHours(0, 0, 0, 0));
+        const now = getToday();
         return new Date(now.getFullYear(), now.getMonth() + 6, now.getDate());
       },
     },
@@ -129,7 +130,7 @@ export default defineComponent({
         return defaultDate;
       }
 
-      const now = new Date(new Date().setHours(0, 0, 0, 0));
+      const now = getToday();
 
       if (type === 'range') {
         if (!Array.isArray(defaultDate)) {

--- a/src/calendar/utils.ts
+++ b/src/calendar/utils.ts
@@ -46,6 +46,11 @@ export function getDayByOffset(date: Date, offset: number) {
 
 export const getPrevDay = (date: Date) => getDayByOffset(date, -1);
 export const getNextDay = (date: Date) => getDayByOffset(date, 1);
+export const getToday = () => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+};
 
 export function calcDateNum(date: [Date, Date]) {
   const day1 = date[0].getTime();


### PR DESCRIPTION
修复当直接点击确认按钮时，获取的时间与点击日期后确认时间不一致的问题

**复现步骤：**
使用一下demo，并打印onConfirm中获取的date
```vue
<van-calendar
  type='range'
  :poppable="false"
  @confirm='onConfirm'
/>
```

- 当我们直接点击，confirm时候，我们将收到带有时间的Date
- 当我们点击同样选中的日期范围后，点击confirm，我们将收到不带时间的Date

**原因**

是由于在`Calendar.tsx`中我们对`props.minDate`、`props.maxDate`、`getInitialDate()`中用到的`now`没有进行时间处理导致的

而在`CalendarMonth.tsx`中我们对`computed days`使用到的Date是进行过处理的，关注`line 211`


**影响**

- 不大不小的问题，这会导致不同的行为（是否手动点击日期）点击确认后获取的日期不一致：）
- 单测过不了~由于vant3单测直接对Date进行比较，而不是像vant2一样format之后再进行比较，所以部分单测会一直failed