### PR TITLE
fix: to avoid auto-installation if has Vue locally

### DIFF
--- a/packages/vant-cli/src/compiler/gen-package-entry.ts
+++ b/packages/vant-cli/src/compiler/gen-package-entry.ts
@@ -55,7 +55,7 @@ function install(Vue) {
   });
 }
 
-if (typeof window !== 'undefined' && window.Vue) {
+if (!Vue && typeof window !== 'undefined' && window.Vue) {
   install(window.Vue);
 }
 


### PR DESCRIPTION
When the global env has Vue and the I want to use local Vue to register component，like the code below:
```js
import { Tab, Tabs } from 'vue'
Vue.use(Tab)
Vue.use(Tabs)
```
I am sure something is registerd to global Vue,  it occur error below：
<img width="947" alt="WX20210519-213312@2x" src="https://user-images.githubusercontent.com/26403700/118821678-0de68000-b8ea-11eb-90dc-6582de43ba4d.png">

so I think add local Vue check will be better!

