### PR TITLE
add beforeChoose for Uploader

### DIFF
--- a/src/uploader/index.js
+++ b/src/uploader/index.js
@@ -79,6 +79,10 @@ export default createComponent({
       type: String,
       default: 'photograph',
     },
+    beforeChoose: {
+      type: [String, Function],
+      default: ''
+    }
   },
 
   computed: {
@@ -391,7 +395,15 @@ export default createComponent({
 
       const slot = this.slots();
 
-      const Input = (
+      const propBeforeChoose = this.beforeChoose;
+      const hasPropBeforeChoose = typeof propBeforeChoose === 'function';
+      const beforeChoose = (event) => {
+        event.preventDefault();
+        typeof propBeforeChoose === 'function' &&
+          propBeforeChoose(event, this.onChange);
+      };
+
+      const OriginInput = (
         <input
           {...{ attrs: this.$attrs }}
           ref="input"
@@ -401,6 +413,12 @@ export default createComponent({
           disabled={this.disabled}
           onChange={this.onChange}
         />
+      );
+
+      const Input = hasPropBeforeChoose ? (
+        <span onClick={beforeChoose}>{OriginInput}</span>
+      ) : (
+        OriginInput
       );
 
       if (slot) {


### PR DESCRIPTION
-feat(Uploader): add beforeChoose callback
添加 `beforeChoose` 回调到 `Uploader` 组件中，用于点击拍摄时进行自定义处理
像 https://github.com/youzan/vant/issues/6015 中提到的设置`capture="camera"` 
在某些机型下不生效的情况，可以通过 `beforeChoose` 拦截 input 的点击事件，
通过别的方式(html5+/uni-app/原生)的方式来调起摄像头。

使用示例：
```js
<van-uploader
  accept="image/*"
  :after-read="afterRead"
  :before-choose="beforeChoose"
/>

// event 是外层span的点击事件
// onChange 为自定义处理后的回调方法，比如拍摄图片后，需要
// 在图片组件中显示当前图片，需要调用 onChange 回调并回传图
// 片，对象为: {target: {files: [file]}}，file 为自定义获取
// 后的图片
async beforeChoose(event, onChange) {
  const file = await openCamera()
  console.log('before choose', file)
  onChange({
    target: {
      files: [file]
    }
  })
}
```