### PR TITLE
fix(List): should emit load event when parent tab is activated

### DIFF
--- a/src/list/List.tsx
+++ b/src/list/List.tsx
@@ -139,6 +139,14 @@ export default defineComponent({
       check
     );
 
+    if (tabStatus) {
+      watch(tabStatus, (tabActive) => {
+        if (tabActive) {
+          check();
+        }
+      });
+    }
+
     onUpdated(() => {
       loading.value = props.loading!;
     });

--- a/src/list/test/index.spec.js
+++ b/src/list/test/index.spec.js
@@ -158,3 +158,38 @@ test('should not emit load event when inside an inactive tab', async () => {
   expect(onLoad1).toHaveBeenCalledTimes(1);
   expect(onLoad2).toHaveBeenCalledTimes(0);
 });
+
+// https://github.com/youzan/vant/issues/9017
+test('should emit load event when parent tab is activated', async () => {
+  const onLoad1 = jest.fn();
+  const onLoad2 = jest.fn();
+
+  const wrapper = mount({
+    data() {
+      return {
+        active: 0,
+      };
+    },
+    render() {
+      return (
+        <Tabs active={this.active} swipeable>
+          <Tab>
+            <List onLoad={onLoad1} />
+          </Tab>
+          <Tab>
+            <List onLoad={onLoad2} />
+          </Tab>
+        </Tabs>
+      );
+    },
+  });
+
+  await later();
+  expect(onLoad1).toHaveBeenCalledTimes(1);
+  expect(onLoad2).toHaveBeenCalledTimes(0);
+
+  await wrapper.setData({ active: 1 });
+  await later();
+  expect(onLoad1).toHaveBeenCalledTimes(1);
+  expect(onLoad2).toHaveBeenCalledTimes(1);
+});


### PR DESCRIPTION
https://github.com/youzan/vant/issues/9017