### PR TITLE
fix: #9043 compatible with win path

### DIFF
--- a/packages/vant-markdown-loader/src/index.js
+++ b/packages/vant-markdown-loader/src/index.js
@@ -11,6 +11,17 @@ function camelize(str) {
   return `-${str}`.replace(/-(\w)/g, (_, c) => (c ? c.toUpperCase() : ''));
 }
 
+function winPath(path) {
+  const isExtendedLengthPath = /^\\\\\?\\/.test(path);
+  const hasNonAscii = /[^\u0000-\u0080]+/.test(path); // eslint-disable-line no-control-regex
+
+  if (isExtendedLengthPath || hasNonAscii) {
+    return path;
+  }
+
+  return path.replace(/\\/g, '/');
+}
+
 const sharedVueOptions = `mounted() {
     const anchors = [].slice.call(this.$el.querySelectorAll('h2, h3, h4, h5'));
     anchors.forEach(anchor => {
@@ -63,7 +74,8 @@ ${demoLinks
   .map((link) => {
     return `import DemoCode${camelize(
       path.basename(link, '.vue')
-    )} from '${link}';`;
+      // 需要对win path进行处理
+    )} from '${winPath(link)}';`;
   })
   .join('\n')}
 export default {


### PR DESCRIPTION
处理win 下路径反斜杆导致报错, 反斜杆会被转译

from `\src\demo-button\demo\index.vue` to  from `/src/demo-button/demo/index.vue`

