### PR TITLE
fix(cli): fix webpackpack config value duplication caused by origin m…

### DIFF
--- a/packages/vant-cli/package.json
+++ b/packages/vant-cli/package.json
@@ -106,7 +106,7 @@
     "vue-router": "^3.3.1",
     "webpack": "^4.43.0",
     "webpack-dev-server": "3.11.0",
-    "webpack-merge": "^4.2.2",
+    "webpack-merge": "^5.8.0",
     "webpackbar": "^4.0.0"
   },
   "release-it": {

--- a/packages/vant-cli/src/common/index.ts
+++ b/packages/vant-cli/src/common/index.ts
@@ -6,9 +6,10 @@ import {
   readFileSync,
   outputFileSync,
 } from 'fs-extra';
-import merge from 'webpack-merge';
+import { mergeWithCustomize } from 'webpack-merge';
 import { SRC_DIR, getVantConfig, ROOT_WEBPACK_CONFIG_FILE } from './constant';
 import { WebpackConfig } from './types';
+import _ from 'lodash';
 
 export const EXT_REGEXP = /\.\w+$/;
 export const SFC_REGEXP = /\.(vue)$/;
@@ -104,14 +105,19 @@ export function normalizePath(path: string): string {
 export function getWebpackConfig(defaultConfig: WebpackConfig): object {
   if (existsSync(ROOT_WEBPACK_CONFIG_FILE)) {
     const config = require(ROOT_WEBPACK_CONFIG_FILE);
+    const customMerge = mergeWithCustomize({
+      customizeArray(arr1, arr2) {
+        return _.uniqWith([...arr1, ...arr2], _.isEqual);
+      }
+    })
 
     // 如果是函数形式，可能并不仅仅是添加额外的处理流程，而是在原有流程上进行修改
     // 比如修改markdown-loader,添加options.enableMetaData
     if (typeof config === 'function') {
-      return merge(defaultConfig, config(defaultConfig));
+      return customMerge(defaultConfig, config(defaultConfig));
     }
 
-    return merge(defaultConfig, config);
+    return customMerge(defaultConfig, config);
   }
 
   return defaultConfig;

--- a/packages/vant-cli/src/config/webpack.package.ts
+++ b/packages/vant-cli/src/config/webpack.package.ts
@@ -1,4 +1,4 @@
-import merge from 'webpack-merge';
+import { merge } from 'webpack-merge';
 import { join } from 'path';
 import { baseConfig } from './webpack.base';
 import { WebpackConfig } from '../common/types';

--- a/packages/vant-cli/src/config/webpack.site.dev.ts
+++ b/packages/vant-cli/src/config/webpack.site.dev.ts
@@ -1,4 +1,4 @@
-import merge from 'webpack-merge';
+import { merge } from 'webpack-merge';
 import WebpackBar from 'webpackbar';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import { get } from 'lodash';

--- a/packages/vant-cli/src/config/webpack.site.prd.ts
+++ b/packages/vant-cli/src/config/webpack.site.prd.ts
@@ -1,4 +1,4 @@
-import merge from 'webpack-merge';
+import { merge } from 'webpack-merge';
 import { get } from 'lodash';
 import { WebpackConfig } from '../common/types';
 import { getVantConfig, getWebpackConfig } from '../common';

--- a/packages/vant-cli/yarn.lock
+++ b/packages/vant-cli/yarn.lock
@@ -12247,12 +12247,13 @@ webpack-log@^2.0.0:
     ansi-colors "^3.0.0"
     uuid "^3.3.2"
 
-webpack-merge@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/webpack-merge/-/webpack-merge-4.2.2.tgz#a27c52ea783d1398afd2087f547d7b9d2f43634d"
-  integrity sha512-TUE1UGoTX2Cd42j3krGYqObZbOD+xF7u28WB7tfUordytSjbWTIjK/8V0amkBfTYN4/pB/GIDlJZZ657BGG19g==
+webpack-merge@^5.8.0:
+  version "5.8.0"
+  resolved "http://registry.npm.qima-inc.com/webpack-merge/download/webpack-merge-5.8.0.tgz#2b39dbf22af87776ad744c390223731d30a68f61"
+  integrity sha1-Kznb8ir4d3atdEw5AiNzHTCmj2E=
   dependencies:
-    lodash "^4.17.15"
+    clone-deep "^4.0.1"
+    wildcard "^2.0.0"
 
 webpack-sources@^1.4.0, webpack-sources@^1.4.1:
   version "1.4.3"
@@ -12377,6 +12378,11 @@ widest-line@^3.1.0:
   integrity sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
   dependencies:
     string-width "^4.0.0"
+
+wildcard@^2.0.0:
+  version "2.0.0"
+  resolved "http://registry.npm.qima-inc.com/wildcard/download/wildcard-2.0.0.tgz#a77d20e5200c6faaac979e4b3aadc7b3dd7f8fec"
+  integrity sha1-p30g5SAMb6qsl55LOq3Hs91/j+w=
 
 window-size@1.1.1:
   version "1.1.1"


### PR DESCRIPTION
## 背景
vant-cli在合并用户webpack配置时没有去除重复元素，可能会造成引入多个重复entry的问题等值webpack配置校验失败

## 方案
通过lodash去除数组重复元素，这样用户不必关心是否引入重复的配置