### PR TITLE
fix: 修复弹框组件内存泄漏问题

### DIFF
--- a/src/mixins/popup/context.ts
+++ b/src/mixins/popup/context.ts
@@ -13,4 +13,11 @@ export const context = {
   find(vm: any): StackItem | undefined {
     return this.stack.filter((item) => item.vm === vm)[0];
   },
+  remove: function remove(vm) {
+    const index = this.stack.findIndex(item  => item.vm === vm);
+    if(index > -1) {
+      this.stack[index].vm = null;
+      this.stack.splice(index, 1);
+    }
+  },
 };

--- a/src/mixins/popup/overlay.ts
+++ b/src/mixins/popup/overlay.ts
@@ -73,5 +73,6 @@ export function removeOverlay(vm: any) {
   const item = context.find(vm);
   if (item) {
     removeNode(item.overlay.$el);
+    context.remove(vm);
   }
 }


### PR DESCRIPTION
由于context中的stack维持了弹框实例子的引用，当项目中使用弹框组件，在路由切换等场景时，组件销毁却无法进行内存回收