### PR TITLE
fix(Calendar): Calendar 日历 scrollToDate 方法问题#9377

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -197,6 +197,9 @@ export default createComponent({
 
     // @exposed-api
     scrollToDate(targetDate) {
+      this.type === 'single'
+        ? (this.currentDate = targetDate)
+        : (this.currentDate[0] = targetDate);
       raf(() => {
         const displayed = this.value || !this.poppable;
 
@@ -525,7 +528,6 @@ export default createComponent({
         </Popup>
       );
     }
-
     return this.genCalendar();
   },
 });


### PR DESCRIPTION
fix(Calendar): Calendar 日历 scrollToDate 方法问题#9377

在调用scrollToDate时，把当前日期设置为targeDate。 这样也符合调用的用意吧