### PR TITLE
fix(@vant/cli): set typographer to false for markdownItOptions

### DIFF
--- a/packages/vant-cli/src/config/vite.site.ts
+++ b/packages/vant-cli/src/config/vite.site.ts
@@ -113,6 +113,7 @@ export function getViteConfigForSiteDev(): InlineConfig {
           after: markdownCardWrapper,
         },
         markdownItOptions: {
+          typographer: false, // https://markdown-it.github.io/markdown-it/#MarkdownIt
           highlight: markdownHighlight,
         },
         markdownItSetup(md: MarkdownIt) {


### PR DESCRIPTION
[https://github.com/youzan/vant/issues/9626](https://github.com/youzan/vant/issues/9626)





