### PR TITLE
fix(cli): 错误的直接引入less文件

### DIFF
--- a/packages/vant-cli/src/compiler/gen-site-mobile-shared.ts
+++ b/packages/vant-cli/src/compiler/gen-site-mobile-shared.ts
@@ -9,6 +9,7 @@ import {
   smartOutputFile,
   normalizePath,
 } from '../common';
+import { CSS_LANG } from '../common/css';
 
 type DemoItem = {
   name: string;
@@ -67,7 +68,7 @@ function genCode(components: string[]) {
     }))
     .filter((item) => existsSync(item.path));
 
-  return `import './package-style.less';
+  return `import './package-style.${CSS_LANG}';
 ${genImports(demos)}
 
 ${genExports(demos)}


### PR DESCRIPTION
还有这个判断css预处理器默认使用less是否不合理？

```javascript {.line-numbers}
// src/common/css.ts
const preprocessor = get(vantConfig, 'build.css.preprocessor', 'less');
```