### PR TITLE
fix(PullRefresh): fix overflow for ios13 safari

### DIFF
--- a/packages/vant/src/pull-refresh/index.less
+++ b/packages/vant/src/pull-refresh/index.less
@@ -8,7 +8,6 @@
 }
 
 .van-pull-refresh {
-  overflow: hidden;
   user-select: none;
 
   &__track {


### PR DESCRIPTION
ios13系统中，pull-refresh + list配合使用时，
即使列表在已经分页加载完成的情况下，
正常上下滑动页面，大概率会出现页面绘制不完全，导致页面中部分白屏。
