### PR TITLE
fix(DatetimePicker): fix incorrect confirm value when v-model is not used

### DIFF
--- a/src/datetime-picker/TimePicker.js
+++ b/src/datetime-picker/TimePicker.js
@@ -109,6 +109,7 @@ export default createComponent({
       this.$nextTick(() => {
         this.$nextTick(() => {
           this.$emit('change', picker);
+          this.updateInnerValue();
         });
       });
     },

--- a/src/datetime-picker/TimePicker.js
+++ b/src/datetime-picker/TimePicker.js
@@ -108,8 +108,9 @@ export default createComponent({
 
       this.$nextTick(() => {
         this.$nextTick(() => {
-          this.$emit('change', picker);
+          // https://github.com/youzan/vant/issues/9775
           this.updateInnerValue();
+          this.$emit('change', picker);
         });
       });
     },


### PR DESCRIPTION
#### fix issue #9775

fix(DatetimePicker)：修复没有v-model的时候，DatetimePicker confirm value出错的问题
