### PR TITLE
fix(Swipe): `overflow` lose efficacy in  iOS safari

### DIFF
--- a/src/swipe/index.less
+++ b/src/swipe/index.less
@@ -3,6 +3,7 @@
 .van-swipe {
   position: relative;
   overflow: hidden;
+  // https://github.com/youzan/vant/issues/9931
   transform: translateZ(0);
   cursor: grab;
   user-select: none;

--- a/src/swipe/index.less
+++ b/src/swipe/index.less
@@ -3,6 +3,7 @@
 .van-swipe {
   position: relative;
   overflow: hidden;
+  transform: translateZ(0);
   cursor: grab;
   user-select: none;
 


### PR DESCRIPTION
issue #9931