### PR TITLE
fix(DatetimePicker): fix incorrect confirm value when v-model is not used

### DIFF
--- a/src/datetime-picker/DatePicker.js
+++ b/src/datetime-picker/DatePicker.js
@@ -268,6 +268,8 @@ export default createComponent({
 
       this.$nextTick(() => {
         this.$nextTick(() => {
+          // https://github.com/youzan/vant/issues/9775
+          this.updateInnerValue();
           this.$emit('change', picker);
         });
       });


### PR DESCRIPTION
fix(DatetimePicker): fix incorrect confirm value when v-model is not used (#9913）
