### PR TITLE
fix(Calendar): date is empty when `poppable = fasle` in dialog (#9845)

### DIFF
--- a/src/calendar/components/Month.js
+++ b/src/calendar/components/Month.js
@@ -103,10 +103,7 @@ export default createComponent({
 
   methods: {
     getHeight() {
-      if (!this.height) {
-        this.height = this.$el.getBoundingClientRect().height;
-      }
-      return this.height;
+      return this.$el?.getBoundingClientRect().height || 0;
     },
 
     scrollIntoView(body) {

--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -108,6 +108,12 @@ export default createComponent({
     },
   },
 
+  inject: {
+    vanPopup: {
+      default: null,
+    },
+  },
+
   data() {
     return {
       subtitle: '',
@@ -165,6 +171,8 @@ export default createComponent({
 
   mounted() {
     this.init();
+    // https://github.com/youzan/vant/issues/9845
+    this.vanPopup?.$on('opened', this.onScroll);
   },
 
   /* istanbul ignore next */


### PR DESCRIPTION
fix(Calendar): date is empty when `poppable = fasle` in dialog (#9845)