### PR TITLE
fix(Swipe): `overflow` lose efficacy in  iOS safari (#9933)

### DIFF
--- a/packages/vant/src/swipe/index.less
+++ b/packages/vant/src/swipe/index.less
@@ -12,6 +12,8 @@
 .van-swipe {
   position: relative;
   overflow: hidden;
+  // https://github.com/youzan/vant/issues/9931
+  transform: translateZ(0);
   cursor: grab;
   user-select: none;
 


### PR DESCRIPTION
fix(Swipe): `overflow` lose efficacy in  iOS safari (#9933)