### PR TITLE
fix: missing es、lib dir in exports field

### DIFF
--- a/packages/vant/package.json
+++ b/packages/vant/package.json
@@ -18,6 +18,8 @@
       "require": "./lib/vant.cjs.js",
       "types": "./lib/index.d.ts"
     },
+    "./es": "./lib/vant.es.js",
+    "./lib": "./lib/vant.cjs.js",
     "./es/*": "./es/*",
     "./lib/*": "./lib/*",
     "./package.json": "./package.json"


### PR DESCRIPTION
https://github.com/youzan/vant/issues/9980