### PR TITLE
build: remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: monthly
-  open-pull-requests-limit: 20


### PR DESCRIPTION
dependabot not support pnpm yet.

https://github.com/dependabot/dependabot-core/issues/1736