### PR TITLE
fix: update exports in package.json

### DIFF
--- a/packages/vant/package.json
+++ b/packages/vant/package.json
@@ -22,6 +22,8 @@
     "./lib": "./lib/vant.cjs.js",
     "./es/": "./es/",
     "./lib/": "./lib/",
+    "./lib/*": "./lib/*/vant.cjs.js",
+    "./es/*": "./es/*/vant.es.js",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
ref: https://github.com/vitejs/vite/pull/5886

vant@next use incorrect exports cause cannot import exactly in Nodejs environment at below code

```js
import Button from 'vant/lib/button'
```