### PR TITLE
fix(@vant/cli): explicitly write the description field

### DIFF
--- a/packages/vant-cli/site/index.html
+++ b/packages/vant-cli/site/index.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title><%= title %></title>
+    <% if (description) { %>
     <meta name="description" content="<%= description %>" />
+    <% } %>
     <link rel="icon" type="image/png" href="<%= logo %>" />
     <meta
       name="viewport"

--- a/packages/vant-cli/site/mobile.html
+++ b/packages/vant-cli/site/mobile.html
@@ -3,7 +3,9 @@
   <head>
     <meta charset="UTF-8" />
     <title><%- title %></title>
+    <% if (description) { %>
     <meta name="description" content="<%- description %>" />
+    <% } %>
     <link rel="icon" type="image/png" href="<%- logo %>" />
     <meta
       name="viewport"

--- a/packages/vant-cli/src/config/vite.site.ts
+++ b/packages/vant-cli/src/config/vite.site.ts
@@ -136,6 +136,9 @@ export function getViteConfigForSiteDev(): InlineConfig {
         data: {
           ...siteConfig,
           title,
+          // `description` is used by the HTML ejs template,
+          // so it needs to be written explicitly here to avoid error: description is not defined
+          description: siteConfig.description,
           baiduAnalytics,
           enableVConsole,
           meta: getHTMLMeta(vantConfig),


### PR DESCRIPTION
`description` is used by the HTML ejs template, so it needs to be written explicitly here to avoid ejs error:
```
description is not defined
```