### PR TITLE
fix: useHeight may get the wrong height

### DIFF
--- a/packages/vant/src/composables/use-height.ts
+++ b/packages/vant/src/composables/use-height.ts
@@ -4,11 +4,15 @@ import { Ref, ref, onMounted, nextTick } from 'vue';
 export const useHeight = (element: Element | Ref<Element | undefined>) => {
   const height = ref<number>();
 
-  onMounted(() =>
+  onMounted(() => {
     nextTick(() => {
       height.value = useRect(element).height;
-    })
-  );
+    });
+    // https://github.com/youzan/vant/issues/10131
+    setTimeout(() => {
+      height.value = useRect(element).height;
+    }, 100);
+  });
 
   return height;
 };


### PR DESCRIPTION
使用到useHeight的组件，在IOS（高概率）和安卓（低概率）可能获取到错误的高度，设计到的组件有NavBar, TabBar中的usePlaceholder hooks。
