### PR TITLE
fix(vant-cli): pnpm compatibility

### DIFF
--- a/packages/vant-cli/src/common/constant.ts
+++ b/packages/vant-cli/src/common/constant.ts
@@ -37,11 +37,7 @@ export const SITE_SRC_DIR = join(__dirname, '..', '..', 'site');
 // Dist files
 export const PACKAGE_ENTRY_FILE = join(DIST_DIR, 'package-entry.js');
 export const PACKAGE_STYLE_FILE = join(DIST_DIR, 'package-style.css');
-export const SITE_MOBILE_SHARED_FILE = join(DIST_DIR, 'site-mobile-shared.js');
-export const SITE_DESKTOP_SHARED_FILE = join(
-  DIST_DIR,
-  'site-desktop-shared.js'
-);
+
 export const STYLE_DEPS_JSON_FILE = join(DIST_DIR, 'style-deps.json');
 
 // Config files

--- a/packages/vant-cli/src/compiler/compile-site.ts
+++ b/packages/vant-cli/src/compiler/compile-site.ts
@@ -5,27 +5,18 @@ import {
   getViteConfigForSiteDev,
   getViteConfigForSiteProd,
 } from '../config/vite.site.js';
-import { mergeCustomViteConfig, replaceExt } from '../common/index.js';
-import { CSS_LANG } from '../common/css.js';
+import { mergeCustomViteConfig } from '../common/index.js';
 import { genPackageEntry } from './gen-package-entry.js';
-import { genPackageStyle } from './gen-package-style.js';
-import { genSiteMobileShared } from './gen-site-mobile-shared.js';
-import { genSiteDesktopShared } from './gen-site-desktop-shared.js';
 import { genStyleDepsMap } from './gen-style-deps-map.js';
-import { PACKAGE_ENTRY_FILE, PACKAGE_STYLE_FILE } from '../common/constant.js';
+import { PACKAGE_ENTRY_FILE } from '../common/constant.js';
 
-export async function genSiteEntry(): Promise<void> {
+export function genSiteEntry(): Promise<void> {
   return new Promise((resolve, reject) => {
     genStyleDepsMap()
       .then(() => {
         genPackageEntry({
           outputPath: PACKAGE_ENTRY_FILE,
         });
-        genPackageStyle({
-          outputPath: replaceExt(PACKAGE_STYLE_FILE, `.${CSS_LANG}`),
-        });
-        genSiteMobileShared();
-        genSiteDesktopShared();
         resolve();
       })
       .catch((err) => {

--- a/packages/vant-cli/src/compiler/gen-package-style.ts
+++ b/packages/vant-cli/src/compiler/gen-package-style.ts
@@ -6,11 +6,11 @@ import { CSS_LANG, getCssBaseFile } from '../common/css.js';
 import { SRC_DIR, STYLE_DEPS_JSON_FILE } from '../common/constant.js';
 
 type Options = {
-  outputPath: string;
+  outputPath?: string;
   pathResolver?: (path: string) => string;
 };
 
-export function genPackageStyle(options: Options) {
+export function genPackageStyle(options: Options = {}) {
   const require = createRequire(import.meta.url);
   const styleDepsJson = require(STYLE_DEPS_JSON_FILE);
   const ext = '.' + CSS_LANG;
@@ -43,5 +43,9 @@ export function genPackageStyle(options: Options) {
     .filter((item: string) => !!item)
     .join('\n');
 
-  smartOutputFile(options.outputPath, content);
+  if (options.outputPath) {
+    smartOutputFile(options.outputPath, content);
+  } else {
+    return content;
+  }
 }

--- a/packages/vant-cli/src/compiler/gen-site-desktop-shared.ts
+++ b/packages/vant-cli/src/compiler/gen-site-desktop-shared.ts
@@ -5,7 +5,6 @@ import {
   isDev,
   pascalize,
   getVantConfig,
-  smartOutputFile,
   normalizePath,
 } from '../common/index.js';
 import {
@@ -13,7 +12,6 @@ import {
   DOCS_DIR,
   getPackageJson,
   VANT_CONFIG_FILE,
-  SITE_DESKTOP_SHARED_FILE,
 } from '../common/constant.js';
 
 type DocumentItem = {
@@ -122,5 +120,5 @@ ${genExportDocuments(documents)}
 ${genExportVersion()}
 `;
 
-  smartOutputFile(SITE_DESKTOP_SHARED_FILE, code);
+  return code;
 }

--- a/packages/vant-cli/src/compiler/gen-site-mobile-shared.ts
+++ b/packages/vant-cli/src/compiler/gen-site-mobile-shared.ts
@@ -1,12 +1,11 @@
 import { join } from 'path';
 import { existsSync, readdirSync } from 'fs';
-import { SRC_DIR, SITE_MOBILE_SHARED_FILE } from '../common/constant.js';
+import { SRC_DIR } from '../common/constant.js';
 import {
   pascalize,
   removeExt,
   decamelize,
   getVantConfig,
-  smartOutputFile,
   normalizePath,
 } from '../common/index.js';
 import { CSS_LANG } from '../common/css.js';
@@ -68,7 +67,7 @@ function genCode(components: string[]) {
     }))
     .filter((item) => existsSync(item.path));
 
-  return `import './package-style.${CSS_LANG}';
+  return `import 'package-style.${CSS_LANG}';
 ${genImports(demos)}
 
 ${genExports(demos)}
@@ -80,5 +79,5 @@ export function genSiteMobileShared() {
   const dirs = readdirSync(SRC_DIR);
   const code = genCode(dirs);
 
-  smartOutputFile(SITE_MOBILE_SHARED_FILE, code);
+  return code;
 }

--- a/packages/vant-cli/src/config/vite.site.ts
+++ b/packages/vant-cli/src/config/vite.site.ts
@@ -92,7 +92,7 @@ function getHTMLMeta(vantConfig: any) {
   return '';
 }
 
-function genCode(): PluginOption {
+function vitePluginGenVantBaseCode(): PluginOption {
   const virtualMobileModuleId = 'site-mobile-shared';
   const resolvedMobileVirtualModuleId = `vant-cli:${virtualMobileModuleId}`;
 
@@ -103,7 +103,7 @@ function genCode(): PluginOption {
   const resolvedPackageStyleVirtualModuleId = `vant-cli${virtualPackageStyleModuleId}index.${CSS_LANG}`;
 
   return {
-    name: 'gen-site-code',
+    name: 'vite-plugin(vant-cli):gen-site-base-code',
     resolveId(id) {
       if (id === virtualMobileModuleId) {
         return resolvedMobileVirtualModuleId;
@@ -145,7 +145,7 @@ export function getViteConfigForSiteDev(): InlineConfig {
     root: SITE_SRC_DIR,
 
     plugins: [
-      genCode(),
+      vitePluginGenVantBaseCode(),
       vitePluginVue({
         include: [/\.vue$/, /\.md$/],
       }),


### PR DESCRIPTION
gen-site-mobile-shared/gen-site-desktop-shared 采用vite plugin虚拟文件的方式生成, gen-package-style site模式下同样使用虚拟文件, build模式下不走plugin