### PR TITLE
fix(Icon): use image URL as name prop, remove white space under image

### DIFF
--- a/packages/vant/src/icon/index.less
+++ b/packages/vant/src/icon/index.less
@@ -2,9 +2,9 @@
 
 .van-icon {
   &__image {
+    display: block;
     width: 1em;
     height: 1em;
     object-fit: contain;
-    vertical-align: bottom;
   }
 }

--- a/packages/vant/src/icon/index.less
+++ b/packages/vant/src/icon/index.less
@@ -5,5 +5,6 @@
     width: 1em;
     height: 1em;
     object-fit: contain;
+    vertical-align: bottom;
   }
 }


### PR DESCRIPTION
使用图片URL作为图标时，移除图片底部间隙。