### PR TITLE
fix(@vant/use): missing subTree when flattening vnodes

### DIFF
--- a/packages/vant-use/src/useRelation/useChildren.ts
+++ b/packages/vant-use/src/useRelation/useChildren.ts
@@ -20,6 +20,7 @@ export function flattenVNodes(children: VNodeNormalizedChildren) {
           result.push(child);
 
           if (child.component?.subTree) {
+            result.push(child.component.subTree);
             traverse(child.component.subTree.children);
           }
 

--- a/packages/vant/src/tab/test/__snapshots__/insert.spec.tsx.snap
+++ b/packages/vant/src/tab/test/__snapshots__/insert.spec.tsx.snap
@@ -15,7 +15,7 @@ exports[`should render Tab inside a component correctly 1`] = `
            aria-controls="van-tab"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
-          2
+          1
         </span>
       </div>
       <div id="van-tabs-1"
@@ -26,7 +26,7 @@ exports[`should render Tab inside a component correctly 1`] = `
            aria-controls="van-tab"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
-          1
+          2
         </span>
       </div>
       <div id="van-tabs-2"
@@ -50,19 +50,19 @@ exports[`should render Tab inside a component correctly 1`] = `
     <div id="van-tab"
          role="tabpanel"
          class="van-tab__panel"
-         tabindex="0"
-         aria-labelledby="van-tabs-1"
-         style
-    >
-      1
-    </div>
-    <div id="van-tab"
-         role="tabpanel"
-         class="van-tab__panel"
          tabindex="-1"
          aria-labelledby="van-tabs-0"
          style="display: none;"
     >
+    </div>
+    <div id="van-tab"
+         role="tabpanel"
+         class="van-tab__panel"
+         tabindex="0"
+         aria-labelledby="van-tabs-1"
+         style
+    >
+      2
     </div>
     <div id="van-tab"
          role="tabpanel"


### PR DESCRIPTION
close https://github.com/youzan/vant/issues/10230