### PR TITLE
fix(SwipeCell): cell should stopPropagation when lockClick is true

### DIFF
--- a/packages/vant/src/swipe-cell/SwipeCell.tsx
+++ b/packages/vant/src/swipe-cell/SwipeCell.tsx
@@ -219,7 +219,7 @@ export default defineComponent({
         <div
           ref={root}
           class={bem()}
-          onClick={getClickHandler('cell')}
+          onClick={getClickHandler('cell', lockClick)}
           onTouchstart={onTouchStart}
           onTouchmove={onTouchMove}
           onTouchend={onTouchEnd}


### PR DESCRIPTION
#10304 

看起来应该是 `getClickHandler` 中的 `event.stopPropagation()` 没有被触发。