### PR TITLE
fix(package.json): fix to resolve nodejs 16 deprecation message DEP0148

### DIFF
--- a/packages/vant/package.json
+++ b/packages/vant/package.json
@@ -20,8 +20,10 @@
     },
     "./es": "./es/index.js",
     "./lib": "./lib/vant.cjs.js",
-    "./es/": "./es/",
-    "./lib/": "./lib/",
+    "./es/": "./es/*.js",
+    "./es/*.js": "./es/*.js",
+    "./lib/": "./lib/*.js",
+    "./lib/*.js": "./lib/*.js",
     "./package.json": "./package.json"
   },
   "files": [


### PR DESCRIPTION
## 本地环境

1. 操作系统：Mac 
2. node 版本：16.13.2
3. vue-cli5 + + vue3 + vant 3 + ts


## 出现的问题
**(node:20011) [DEP0148] DeprecationWarning: Use of deprecated folder mapping "./es/" in the "exports" field module resolution of the package at /Users/liwb/Desktop/liwb_work/lab/vue-offical-demo/vue-project-cli-v3-ts/node_modules/vant/package.json.
Update this package.json to use a subpath pattern like "./es/*".**

## 修复方案

修改 `packages/vant/package.json`
```diff
...
"exports": {
    ".": {
      "node": {
        "import": "./lib/ssr.mjs",
        "require": "./lib/ssr.js"
      },
      "import": "./es/index.js",
      "require": "./lib/vant.cjs.js",
      "types": "./lib/index.d.ts"
    },
    "./es": "./es/index.js",
    "./lib": "./lib/vant.cjs.js",
-   "./es/": "./es/",
-   "./lib/": "./lib/",
+   "./es/": "./es/*.js",
+   "./es/*.js": "./es/*.js",
+   "./lib/": "./lib/*.js",
+   "./lib/*.js": "./lib/*.js",
    "./package.json": "./package.json"
  },
...
```