### PR TITLE
fix(Tab): add key when render TabsTitle

### DIFF
--- a/packages/vant/src/tabs/Tabs.tsx
+++ b/packages/vant/src/tabs/Tabs.tsx
@@ -365,6 +365,7 @@ export default defineComponent({
     const renderNav = () =>
       children.map((item, index) => (
         <TabsTitle
+          key={item}
           v-slots={{ title: item.$slots.title }}
           id={`${id}-${index}`}
           ref={setTitleRefs(index)}

--- a/packages/vant/src/tabs/Tabs.tsx
+++ b/packages/vant/src/tabs/Tabs.tsx
@@ -365,7 +365,7 @@ export default defineComponent({
     const renderNav = () =>
       children.map((item, index) => (
         <TabsTitle
-          key={item.title}
+          key={item.id}
           v-slots={{ title: item.$slots.title }}
           id={`${id}-${index}`}
           ref={setTitleRefs(index)}

--- a/packages/vant/src/tabs/Tabs.tsx
+++ b/packages/vant/src/tabs/Tabs.tsx
@@ -365,7 +365,7 @@ export default defineComponent({
     const renderNav = () =>
       children.map((item, index) => (
         <TabsTitle
-          key={item}
+          key={item.title}
           v-slots={{ title: item.$slots.title }}
           id={`${id}-${index}`}
           ref={setTitleRefs(index)}


### PR DESCRIPTION
#10292

### 复现
issue中复现代码放在 `vant3` 的 `tab/demo/index.vue` 中可百分百复现

### 原因
应该是 map render 时没有为 `TabTitle` 添加唯一 `key` 导致的
