### PR TITLE
fix(Calendar, Picker): Fix calendar and picker's title color in dark mode

### DIFF
--- a/packages/vant/src/calendar/index.less
+++ b/packages/vant/src/calendar/index.less
@@ -61,6 +61,7 @@ body {
   &__month-title,
   &__header-title,
   &__header-subtitle {
+    color: var(--van-text-color);
     height: var(--van-calendar-header-title-height);
     font-weight: var(--van-font-bold);
     line-height: var(--van-calendar-header-title-height);

--- a/packages/vant/src/dialog/index.less
+++ b/packages/vant/src/dialog/index.less
@@ -37,6 +37,7 @@ body {
   }
 
   &__header {
+    color: var(--van-text-color);
     padding-top: var(--van-dialog-header-padding-top);
     font-weight: var(--van-dialog-header-font-weight);
     line-height: var(--van-dialog-header-line-height);
@@ -56,6 +57,7 @@ body {
   }
 
   &__message {
+    color: var(--van-text-color);
     flex: 1;
     max-height: var(--van-dialog-message-max-height);
     padding: 26px var(--van-dialog-message-padding);

--- a/packages/vant/src/picker/index.less
+++ b/packages/vant/src/picker/index.less
@@ -60,6 +60,7 @@ body {
   }
 
   &__title {
+    color: var(--van-text-color);
     max-width: 50%;
     font-weight: var(--van-font-bold);
     font-size: var(--van-picker-title-font-size);


### PR DESCRIPTION
### Vant version: 4.0.0-alpha.0

### Fix calendar and picker's title color in dark mode