### PR TITLE
fix(DatetimePicker): fix minDate && maxDate wacher

### DIFF
--- a/packages/vant/src/datetime-picker/DatePicker.tsx
+++ b/packages/vant/src/datetime-picker/DatePicker.tsx
@@ -296,7 +296,10 @@ export default defineComponent({
       emit('update:modelValue', oldValue ? value : null)
     );
 
-    watch(() => [props.filter, props.minDate, props.maxDate], () => nextTick(updateInnerValue));
+    watch(
+      () => [props.filter, props.minDate, props.maxDate],
+      () => nextTick(updateInnerValue)
+    );
 
     watch(
       () => props.modelValue,

--- a/packages/vant/src/datetime-picker/DatePicker.tsx
+++ b/packages/vant/src/datetime-picker/DatePicker.tsx
@@ -298,7 +298,9 @@ export default defineComponent({
 
     watch(
       () => [props.filter, props.minDate, props.maxDate],
-      () => nextTick(updateInnerValue)
+      () => {
+        nextTick(updateInnerValue);
+      }
     );
 
     watch(

--- a/packages/vant/src/datetime-picker/DatePicker.tsx
+++ b/packages/vant/src/datetime-picker/DatePicker.tsx
@@ -296,14 +296,7 @@ export default defineComponent({
       emit('update:modelValue', oldValue ? value : null)
     );
 
-    watch(() => [props.filter, props.maxDate], updateInnerValue);
-
-    watch(
-      () => props.minDate,
-      () => {
-        nextTick(updateInnerValue);
-      }
-    );
+    watch(() => [props.filter, props.minDate, props.maxDate], () => nextTick(updateInnerValue));
 
     watch(
       () => props.modelValue,


### PR DESCRIPTION
#10110

关联历史issue: #7253
历史issue是为了解决动态改变最大值最小值时，currentDate不准确问题，加了层 `nextTick`，当时 `maxDate` 没加这层。
本次调整让 `minDate` `maxDate` 的行为保持一致

### 测试
- [x] 当前issue可复现链接用例已测试
- [x] 历史issue可复现链接 `minDate` `maxDate` 已分别测试
- [x] 单测用例跑通