### PR TITLE
feat(CalendarDay): add default margin-bottom

### DIFF
--- a/packages/vant/src/calendar/CalendarDay.tsx
+++ b/packages/vant/src/calendar/CalendarDay.tsx
@@ -54,6 +54,10 @@ export default defineComponent({
         }
       }
 
+      if (offset + (item.date?.getDate() || 1) > 28) {
+        style.marginBottom = 0;
+      }
+
       return style;
     });
 

--- a/packages/vant/src/calendar/README.md
+++ b/packages/vant/src/calendar/README.md
@@ -395,7 +395,7 @@ The component provides the following CSS variables, which can be used to customi
 | --van-calendar-month-mark-font-size | _160px_ | - |
 | --van-calendar-day-height | _64px_ | - |
 | --van-calendar-day-font-size | _var(--van-font-size-lg)_ | - |
-| --van-calendar-day-margin-bottom | 4px\_ | - |
+| --van-calendar-day-margin-bottom | _4px_ | - |
 | --van-calendar-range-edge-color | _var(--van-white)_ | - |
 | --van-calendar-range-edge-background-color | _var(--van-danger-color)_ | - |
 | --van-calendar-range-middle-color | _var(--van-danger-color)_ | - |

--- a/packages/vant/src/calendar/README.md
+++ b/packages/vant/src/calendar/README.md
@@ -395,6 +395,7 @@ The component provides the following CSS variables, which can be used to customi
 | --van-calendar-month-mark-font-size | _160px_ | - |
 | --van-calendar-day-height | _64px_ | - |
 | --van-calendar-day-font-size | _var(--van-font-size-lg)_ | - |
+| --van-calendar-day-margin-bottom | 4px\_ | - |
 | --van-calendar-range-edge-color | _var(--van-white)_ | - |
 | --van-calendar-range-edge-background-color | _var(--van-danger-color)_ | - |
 | --van-calendar-range-middle-color | _var(--van-danger-color)_ | - |

--- a/packages/vant/src/calendar/README.zh-CN.md
+++ b/packages/vant/src/calendar/README.zh-CN.md
@@ -401,6 +401,7 @@ calendarRef.value?.reset();
 | --van-calendar-month-mark-font-size | _160px_ | - |
 | --van-calendar-day-height | _64px_ | - |
 | --van-calendar-day-font-size | _var(--van-font-size-lg)_ | - |
+| --van-calendar-day-margin-bottom | 4px\_ | - |
 | --van-calendar-range-edge-color | _var(--van-white)_ | - |
 | --van-calendar-range-edge-background-color | _var(--van-danger-color)_ | - |
 | --van-calendar-range-middle-color | _var(--van-danger-color)_ | - |

--- a/packages/vant/src/calendar/README.zh-CN.md
+++ b/packages/vant/src/calendar/README.zh-CN.md
@@ -401,7 +401,7 @@ calendarRef.value?.reset();
 | --van-calendar-month-mark-font-size | _160px_ | - |
 | --van-calendar-day-height | _64px_ | - |
 | --van-calendar-day-font-size | _var(--van-font-size-lg)_ | - |
-| --van-calendar-day-margin-bottom | 4px\_ | - |
+| --van-calendar-day-margin-bottom | _4px_ | - |
 | --van-calendar-range-edge-color | _var(--van-white)_ | - |
 | --van-calendar-range-edge-background-color | _var(--van-danger-color)_ | - |
 | --van-calendar-range-middle-color | _var(--van-danger-color)_ | - |

--- a/packages/vant/src/calendar/index.less
+++ b/packages/vant/src/calendar/index.less
@@ -125,6 +125,7 @@
     height: var(--van-calendar-day-height);
     font-size: var(--van-calendar-day-font-size);
     cursor: pointer;
+    margin-bottom: 10px;
 
     &--end,
     &--start,

--- a/packages/vant/src/calendar/index.less
+++ b/packages/vant/src/calendar/index.less
@@ -14,6 +14,7 @@
   --van-calendar-month-mark-font-size: @calendar-month-mark-font-size;
   --van-calendar-day-height: @calendar-day-height;
   --van-calendar-day-font-size: @calendar-day-font-size;
+  --van-calendar-day-margin-bottom: @calendar-day-margin-bottom;
   --van-calendar-range-edge-color: @calendar-range-edge-color;
   --van-calendar-range-edge-background-color: @calendar-range-edge-background-color;
   --van-calendar-range-middle-color: @calendar-range-middle-color;
@@ -124,8 +125,8 @@
     width: 14.285%;
     height: var(--van-calendar-day-height);
     font-size: var(--van-calendar-day-font-size);
+    margin-bottom: var(--van-calendar-day-margin-bottom);
     cursor: pointer;
-    margin-bottom: 10px;
 
     &--end,
     &--start,

--- a/packages/vant/src/calendar/test/__snapshots__/index.spec.ts.snap
+++ b/packages/vant/src/calendar/test/__snapshots__/index.spec.ts.snap
@@ -251,41 +251,49 @@ exports[`color prop when type is single 1`] = `
           23
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           24
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           25
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           26
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           27
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           28
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           29
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           30
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           31
@@ -484,41 +492,49 @@ exports[`formatter prop 1`] = `
           23
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           24
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           25
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           26
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           27
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           28
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           29
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           30
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           31
@@ -836,49 +852,49 @@ exports[`row-height prop 1`] = `
           23
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           24
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           25
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           26
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           27
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           28
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           29
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           30
         </div>
         <div role="gridcell"
-             style="height: 50px;"
+             style="height: 50px; margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           31
@@ -1083,41 +1099,49 @@ exports[`should render title、footer、subtitle slot correctly 1`] = `
           23
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           24
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           25
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           26
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           27
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           28
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           29
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           30
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           31

--- a/packages/vant/src/calendar/test/__snapshots__/prop.spec.ts.snap
+++ b/packages/vant/src/calendar/test/__snapshots__/prop.spec.ts.snap
@@ -170,41 +170,49 @@ exports[`lazy-render prop 1`] = `
           23
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           24
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           25
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           26
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           27
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           28
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           29
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           30
         </div>
         <div role="gridcell"
+             style="margin-bottom: 0px;"
              class="van-calendar__day van-calendar__day--disabled"
         >
           31

--- a/packages/vant/src/calendar/var.less
+++ b/packages/vant/src/calendar/var.less
@@ -13,6 +13,7 @@
 @calendar-month-mark-font-size: 160px;
 @calendar-day-height: 64px;
 @calendar-day-font-size: var(--van-font-size-lg);
+@calendar-day-margin-bottom: 10px;
 @calendar-range-edge-color: var(--van-white);
 @calendar-range-edge-background-color: var(--van-danger-color);
 @calendar-range-middle-color: var(--van-danger-color);

--- a/packages/vant/src/calendar/var.less
+++ b/packages/vant/src/calendar/var.less
@@ -13,7 +13,7 @@
 @calendar-month-mark-font-size: 160px;
 @calendar-day-height: 64px;
 @calendar-day-font-size: var(--van-font-size-lg);
-@calendar-day-margin-bottom: 10px;
+@calendar-day-margin-bottom: 4px;
 @calendar-range-edge-color: var(--van-white);
 @calendar-range-edge-background-color: var(--van-danger-color);
 @calendar-range-middle-color: var(--van-danger-color);


### PR DESCRIPTION
#10440

## 调整
- CalendarDay 默认 marginBottom = 10px
- 每月最后一周日期默认 marginBottom = 0

## discuss
- APP上的携程、美团等样式均有10px间距，然而网页版的均无marginBottom，个人审美感觉加上后会美观点