### PR TITLE
feat(VantMarkdownVetur): support arguments of events

### DIFF
--- a/packages/vant-markdown-vetur/src/formatter.ts
+++ b/packages/vant-markdown-vetur/src/formatter.ts
@@ -1,10 +1,25 @@
 /* eslint-disable no-continue */
 import { Articals } from './parser';
 import { formatOptions, formatType, removeVersion, toKebabCase } from './utils';
-import { VueTag } from './type';
+import { VueEventArgument, VueTag } from './type';
 
 function formatComponentName(name: string, tagPrefix: string) {
   return tagPrefix + toKebabCase(name);
+}
+
+function formatArguments(input: string): VueEventArgument[] {
+  if (input === '-') return [];
+  const args: VueEventArgument[] = [];
+  formatType(input)
+    .split(',')
+    .forEach((item) => {
+      const arg = item.split(':');
+      args.push({
+        name: arg[0].trim(),
+        type: arg[1].trim(),
+      });
+    });
+  return args;
 }
 
 function getNameFromTableTitle(tableTitle: string, tagPrefix: string) {
@@ -84,10 +99,11 @@ export function formatter(
       const tag = findTag(vueTags, name);
 
       table.body.forEach((line) => {
-        const [name, desc] = line;
+        const [name, desc, args] = line;
         tag.events!.push({
           name: removeVersion(name),
           description: desc,
+          arguments: formatArguments(args),
         });
       });
       return;

--- a/packages/vant-markdown-vetur/src/formatter.ts
+++ b/packages/vant-markdown-vetur/src/formatter.ts
@@ -19,7 +19,7 @@ function formatArguments(input: string): VueEventArgument[] {
   input = formatType(input);
   while (input.length > 0) {
     if (/(?!_)\w/.test(input[0])) {
-      const val = str.match(/(\w|\s|\p{P}|\||\[|\]|>|<)+/)[0] || '';
+      const val = input.match(/(\w|\s|\p{P}|\||\[|\]|>|<)+/)![0] || '';
       input = input.substring(val.length);
       items.push(val);
     } else if (input[0] === '{') {

--- a/packages/vant-markdown-vetur/src/formatter.ts
+++ b/packages/vant-markdown-vetur/src/formatter.ts
@@ -19,7 +19,7 @@ function formatArguments(input: string): VueEventArgument[] {
   input = formatType(input);
   while (input.length > 0) {
     if (/(?!_)\w/.test(input[0])) {
-      const val = input.match(/(\w|\s|\p{P}|\||\[|\])+/)![0] || '';
+      const val = str.match(/(\w|\s|\p{P}|\||\[|\]|>|<)+/)[0] || '';
       input = input.substring(val.length);
       items.push(val);
     } else if (input[0] === '{') {

--- a/packages/vant-markdown-vetur/src/formatter.ts
+++ b/packages/vant-markdown-vetur/src/formatter.ts
@@ -7,18 +7,41 @@ function formatComponentName(name: string, tagPrefix: string) {
   return tagPrefix + toKebabCase(name);
 }
 
+/**
+ * format arugments of events
+ * input  = value: { foo: foo or 1, bar: bar or 2 }, value2: { one: 1 and 1, two: 2 and 2 }, foo: bar
+ * output = [{ name: 'value', type: '{ foo: foo or 1, bar: bar or 2 }' }, { name: 'value2', type: '{ one: 1 and 1, two: 2 and 2 }'}, { name: 'foo', type: 'bar' }]
+ */
 function formatArguments(input: string): VueEventArgument[] {
   if (input === '-') return [];
   const args: VueEventArgument[] = [];
-  formatType(input)
-    .split(',')
-    .forEach((item) => {
-      const arg = item.split(':');
-      args.push({
-        name: arg[0].trim(),
-        type: arg[1].trim(),
-      });
+  const items = [];
+  input = formatType(input);
+  while (input.length > 0) {
+    if (/(?!_)\w/.test(input[0])) {
+      const val = input.match(/(\w|\s|\p{P}|\||\[|\])+/)![0] || '';
+      input = input.substring(val.length);
+      items.push(val);
+    } else if (input[0] === '{') {
+      const val = input.match(/\{[^}]+\}/)![0] || '';
+      input = input.substring(val.length);
+      items.push(val);
+    } else if ([':', ',', '_', ' '].includes(input[0])) {
+      input = input.substring(1);
+    } else {
+      const val = input.match(/( |'|\||\w)+/)![0] || '';
+      input = input.substring(val.length);
+      items.push(val);
+    }
+  }
+
+  for (let i = 0; i < items.length; i += 2) {
+    args.push({
+      name: items[i],
+      type: items[i + 1],
     });
+  }
+
   return args;
 }
 

--- a/packages/vant-markdown-vetur/src/parser.ts
+++ b/packages/vant-markdown-vetur/src/parser.ts
@@ -25,9 +25,11 @@ function readLine(input: string) {
 }
 
 function splitTableLine(line: string) {
-  line = line.replace('\\|', 'JOIN');
+  line = line.replace(/\\\|/g, 'JOIN');
 
-  const items = line.split('|').map((item) => item.trim().replace('JOIN', '|'));
+  const items = line
+    .split('|')
+    .map((item) => item.trim().replace(/JOIN/g, '|'));
 
   // remove pipe character on both sides
   items.pop();

--- a/packages/vant/src/action-bar/README.md
+++ b/packages/vant/src/action-bar/README.md
@@ -102,7 +102,7 @@ Use `badge` prop to show badge in icon.
 | icon-prefix `v3.0.17` | Icon className prefix | _string_ | `van-icon` |
 | dot | Whether to show red dot | _boolean_ | - |
 | badge | Content of the badge | _number \| string_ | - |
-| badge-props `v3.2.8` | Props of Badge，see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
+| badge-props `v3.2.8` | Props of Badge, see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
 | url | Link URL | _string_ | - |
 | to | Target route of the link, same as to of vue-router | _string \| object_ | - |
 | replace | If true, the navigation will not leave a history record | _boolean_ | `false` |

--- a/packages/vant/src/address-edit/README.md
+++ b/packages/vant/src/address-edit/README.md
@@ -102,9 +102,9 @@ export default {
 
 | Event | Description | Arguments |
 | --- | --- | --- |
-| save | Emitted when the save button is clicked | content：form content |
+| save | Emitted when the save button is clicked | content: form content |
 | focus | Emitted when field is focused | key: field name |
-| delete | Emitted when confirming delete | content：form content |
+| delete | Emitted when confirming delete | content: form content |
 | select-search | Emitted when a search result is selected | value: search content |
 | click-area | Emitted when the area field is clicked | - |
 | change-area | Emitted when area changed | values: area values |

--- a/packages/vant/src/address-list/README.md
+++ b/packages/vant/src/address-list/README.md
@@ -93,14 +93,7 @@ export default {
 
 ### Events
 
-| Event | Description | Arguments |
-| --- | --- | --- |
-| add | Emitted when the add button is clicked | - |
-| edit | Emitted when the edit icon of address is clicked | _item: Address, index: number_ |
-| select | Emitted when an address is selected | _item: Address, index: number_ |
-| edit-disabled | Emitted when the edit icon of disabled address is clicked | _item: Address, index: number_ |
-| select-disabled | Emitted when a disabled address is selected | _item: Address, index: number_ |
-| click-item | Emitted when an address item is clicked | _item: Address, index: number_ |
+| Event | Description | Arguments | | --- | ``--- | --- | | add | Emitted when the add button is clicked | - | | edit | Emitted when the edit icon of address is clicked | _item: Address, index: number_ | | select | Emitted when an address is selected | _item: Address, index: number_ | | edit-disabled | Emitted when the edit icon of disabled address is clicked | _item: Address, index: number_ | | select-disabled | Emitted when a disabled address is selected | _item: Address, index: number_ | | click-item | Emitted when an address item is clicked | _item: Address, index: number_ |
 
 ### Data Structure of Address
 

--- a/packages/vant/src/address-list/README.md
+++ b/packages/vant/src/address-list/README.md
@@ -93,7 +93,7 @@ export default {
 
 ### Events
 
-| Event | Description | Arguments | | --- | ``--- | --- | | add | Emitted when the add button is clicked | - | | edit | Emitted when the edit icon of address is clicked | _item: Address, index: number_ | | select | Emitted when an address is selected | _item: Address, index: number_ | | edit-disabled | Emitted when the edit icon of disabled address is clicked | _item: Address, index: number_ | | select-disabled | Emitted when a disabled address is selected | _item: Address, index: number_ | | click-item | Emitted when an address item is clicked | _item: Address, index: number_ |
+| Event | Description | Arguments | | --- | --- | --- | | add | Emitted when the add button is clicked | - | | edit | Emitted when the edit icon of address is clicked | _item: Address, index: number_ | | select | Emitted when an address is selected | _item: Address, index: number_ | | edit-disabled | Emitted when the edit icon of disabled address is clicked | _item: Address, index: number_ | | select-disabled | Emitted when a disabled address is selected | _item: Address, index: number_ | | click-item | Emitted when an address item is clicked | _item: Address, index: number_ |
 
 ### Data Structure of Address
 

--- a/packages/vant/src/address-list/README.md
+++ b/packages/vant/src/address-list/README.md
@@ -93,7 +93,14 @@ export default {
 
 ### Events
 
-| Event | Description | Arguments | | --- | --- | --- | | add | Emitted when the add button is clicked | - | | edit | Emitted when the edit icon of address is clicked | _item: Address, index: number_ | | select | Emitted when an address is selected | _item: Address, index: number_ | | edit-disabled | Emitted when the edit icon of disabled address is clicked | _item: Address, index: number_ | | select-disabled | Emitted when a disabled address is selected | _item: Address, index: number_ | | click-item | Emitted when an address item is clicked | _item: Address, index: number_ |
+| Event | Description | Arguments |
+| --- | --- | --- |
+| add | Emitted when the add button is clicked | - |
+| edit | Emitted when the edit icon of address is clicked | _item: Address, index: number_ |
+| select | Emitted when an address is selected | _item: Address, index: number_ |
+| edit-disabled | Emitted when the edit icon of disabled address is clicked | _item: Address, index: number_ |
+| select-disabled | Emitted when a disabled address is selected | _item: Address, index: number_ |
+| click-item | Emitted when an address item is clicked | _item: Address, index: number_ |
 
 ### Data Structure of Address
 

--- a/packages/vant/src/area/README.md
+++ b/packages/vant/src/area/README.md
@@ -129,7 +129,7 @@ To have a selected value，simply pass the `code` of target area to `value` prop
 | --- | --- | --- |
 | confirm | Emitted when the confirm button is clicked | _result: ConfirmResult_ |
 | cancel | Emitted when the cancel button is clicked | - |
-| change | Emitted when current option changed | current values，column index |
+| change | Emitted when current option changed | current: values，column: index |
 
 ### ConfirmResult
 

--- a/packages/vant/src/area/README.md
+++ b/packages/vant/src/area/README.md
@@ -77,7 +77,7 @@ export default {
 
 ### Initial Value
 
-To have a selected value，simply pass the `code` of target area to `value` property.
+To have a selected value, simply pass the `code` of target area to `value` property.
 
 ```html
 <van-area title="Title" :area-list="areaList" value="110101" />
@@ -120,7 +120,7 @@ To have a selected value，simply pass the `code` of target area to `value` prop
 | item-height | Option height, supports `px` `vw` `vh` `rem` unit, default `px` | _number \| string_ | `44` |
 | columns-num | Level of picker | _number \| string_ | `3` |
 | visible-item-count | Count of visible columns | _number \| string_ | `6` |
-| swipe-duration | Duration of the momentum animation，unit `ms` | _number \| string_ | `1000` |
+| swipe-duration | Duration of the momentum animation, unit `ms` | _number \| string_ | `1000` |
 | is-oversea-code | The method to validate oversea code | _() => boolean_ | - |
 
 ### Events
@@ -129,7 +129,7 @@ To have a selected value，simply pass the `code` of target area to `value` prop
 | --- | --- | --- |
 | confirm | Emitted when the confirm button is clicked | _result: ConfirmResult_ |
 | cancel | Emitted when the cancel button is clicked | - |
-| change | Emitted when current option changed | current: values，column: index |
+| change | Emitted when current option changed | current: values, column: index |
 
 ### ConfirmResult
 

--- a/packages/vant/src/badge/README.md
+++ b/packages/vant/src/badge/README.md
@@ -138,7 +138,7 @@ Use `position` prop to set the position of badge.
 | content | Badge content | _number \| string_ | - |
 | color | Background color | _string_ | `#ee0a24` |
 | dot | Whether to show dot | _boolean_ | `false` |
-| max | Max value，show `{max}+` when exceed，only works when content is number | _number \| string_ | - |
+| max | Max value, show `{max}+` when exceed, only works when content is number | _number \| string_ | - |
 | offset `v3.0.5` | Offset of badge dot | _[number \| string, number \| string]_ | - |
 | show-zero `v3.0.10` | Whether to show badge when content is zero | _boolean_ | `true` |
 | position `v3.2.7` | Badge position, can be set to `top-left` `bottom-left` `bottom-right` | _string_ | `top-right` |

--- a/packages/vant/src/calendar/README.md
+++ b/packages/vant/src/calendar/README.md
@@ -208,7 +208,7 @@ export default {
 
 ### Custom Position
 
-Use `position` to custom popup position，can be set to `top`、`left`、`right`.
+Use `position` to custom popup position, can be set to `top`、`left`、`right`.
 
 ```html
 <van-calendar v-model:show="show" :round="false" position="right" />
@@ -249,7 +249,7 @@ Set `poppable` to `false`, the calendar will be displayed directly on the page i
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| type | Type，can be set to `range` `multiple` | _string_ | `single` |
+| type | Type, can be set to `range` `multiple` | _string_ | `single` |
 | title | Title of calendar | _string_ | `Calendar` |
 | color | Color for the bottom button and selected date | _string_ | `#ee0a24` |
 | min-date | Min date | _Date_ | Today |
@@ -319,13 +319,13 @@ Following props are supported when the type is multiple
 | Event | Description | Arguments |
 | --- | --- | --- |
 | select | Emitted when date is selected | _value: Date \| Date[]_ |
-| confirm | Emitted after date selection is complete，if `show-confirm` is `true`, it is Emitted after clicking the confirm button | _value: Date \| Date[]_ |
+| confirm | Emitted after date selection is complete, if `show-confirm` is `true`, it is Emitted after clicking the confirm button | _value: Date \| Date[]_ |
 | open | Emitted when opening Popup | - |
 | close | Emitted when closing Popup | - |
 | opened | Emitted when Popup is opened | - |
 | closed | Emitted when Popup is closed | - |
 | unselect | Emitted when unselect date when type is multiple | _value: Date_ |
-| month-show | Emitted when a month enters the visible area | _{ date: Date, title: string }_ |
+| month-show | Emitted when a month enters the visible area | _value: { date: Date, title: string }_ |
 | over-range | Emitted when exceeded max range | - |
 | click-subtitle `v3.1.3` | Emitted when clicking the subtitle | _event: MouseEvent_ |
 

--- a/packages/vant/src/card/README.md
+++ b/packages/vant/src/card/README.md
@@ -83,7 +83,7 @@ Use slot to custom content.
 | centered | Whether content vertical centered | _boolean_ | `false` |
 | currency | Currency symbol | _string_ | `¥` |
 | thumb-link | Thumb link URL | _string_ | - |
-| lazy-load | Whether to enable thumb lazy load，should register [Lazyload](#/en-US/lazyload) component | _boolean_ | `false` |
+| lazy-load | Whether to enable thumb lazy load, should register [Lazyload](#/en-US/lazyload) component | _boolean_ | `false` |
 
 ### Events
 

--- a/packages/vant/src/cell/README.md
+++ b/packages/vant/src/cell/README.md
@@ -151,7 +151,7 @@ app.use(CellGroup);
 | title | Title | _number \| string_ | - |
 | value | Right text | _number \| string_ | - |
 | label | Description below the title | _string_ | - |
-| size | Size，can be set to `large` | _string_ | - |
+| size | Size, can be set to `large` | _string_ | - |
 | icon | Left Icon | _string_ | - |
 | icon-prefix | Icon className prefix | _string_ | `van-icon` |
 | border | Whether to show inner border | _boolean_ | `true` |

--- a/packages/vant/src/circle/README.md
+++ b/packages/vant/src/circle/README.md
@@ -157,9 +157,9 @@ export default {
 | speed | Animate speed（rate/s） | _number \| string_ | `0` |
 | text | Text | _string_ | - |
 | stroke-width | Stroke width | _number \| string_ | `40` |
-| stroke-linecap | Stroke linecap，can be set to `square` `butt` | _string_ | `round` |
+| stroke-linecap | Stroke linecap, can be set to `square` `butt` | _string_ | `round` |
 | clockwise | Whether to be clockwise | _boolean_ | `true` |
-| start-position `v3.2.1` | Progress start position，can be set to `left`、`right`、`bottom` | _CircleStartPosition_ | `top` |
+| start-position `v3.2.1` | Progress start position, can be set to `left`、`right`、`bottom` | _CircleStartPosition_ | `top` |
 
 ### Slots
 

--- a/packages/vant/src/col/README.md
+++ b/packages/vant/src/col/README.md
@@ -89,7 +89,7 @@ Set grid spacing using `gutter` attribute. The default value is 0.
 | --- | --- | --- | --- |
 | gutter | Grid spacing（px） | _number \| string_ | - |
 | tag | Custom element tag | _string_ | `div` |
-| justify | Flex main axis，can be set to end/center/space-around/space-between | _string_ | `start` |
+| justify | Flex main axis, can be set to end/center/space-around/space-between | _string_ | `start` |
 | align | Flex cross axis, be set to center/bottom | _string_ | `top` |
 | wrap `v3.0.11` | Whether to wrap | _boolean_ | `true` |
 

--- a/packages/vant/src/collapse/README.md
+++ b/packages/vant/src/collapse/README.md
@@ -120,9 +120,9 @@ export default {
 
 ### Collapse Events
 
-| Event  | Description                  | Arguments           |
-| ------ | ---------------------------- | ------------------- | ------ | ------------ | ------- |
-| change | Emitted when switching panel | activeNames: string | number | Array<string | number> |
+| Event | Description | Arguments |
+| --- | --- | --- |
+| change | Emitted when switching panel | _activeNames: string \| number \| Array<string \| number>_ |
 
 ### CollapseItem Props
 

--- a/packages/vant/src/collapse/README.md
+++ b/packages/vant/src/collapse/README.md
@@ -120,9 +120,9 @@ export default {
 
 ### Collapse Events
 
-| Event  | Description                  | Arguments   |
-| ------ | ---------------------------- | ----------- |
-| change | Emitted when switching panel | activeNames |
+| Event  | Description                  | Arguments           |
+| ------ | ---------------------------- | ------------------- | ------ | ------------ | ------- |
+| change | Emitted when switching panel | activeNames: string | number | Array<string | number> |
 
 ### CollapseItem Props
 
@@ -130,7 +130,7 @@ export default {
 | --- | --- | --- | --- |
 | name | Name | _number \| string_ | `index` |
 | icon | Left Icon | _string_ | - |
-| size | Title size，can be set to `large` | _string_ | - |
+| size | Title size, can be set to `large` | _string_ | - |
 | title | Title | _number \| string_ | - |
 | value | Right text | _number \| string_ | - |
 | label | Description below the title | _string_ | - |

--- a/packages/vant/src/collapse/README.md
+++ b/packages/vant/src/collapse/README.md
@@ -114,7 +114,7 @@ export default {
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| v-model | Names of current active panels | accordion mode： _number \| string_<br>non-accordion mode：_(number \| string)[]_ | - |
+| v-model | Names of current active panels | accordion mode: _number \| string_<br>non-accordion mode: _(number \| string)[]_ | - |
 | accordion | Whether to be accordion mode | _boolean_ | `false` |
 | border | Whether to show outer border | _boolean_ | `true` |
 

--- a/packages/vant/src/config-provider/README.md
+++ b/packages/vant/src/config-provider/README.md
@@ -112,7 +112,7 @@ export default {
 };
 ```
 
-> Tips：ConfigProvider only affects its child components.
+> Tips: ConfigProvider only affects its child components.
 
 ### Basic Variables
 

--- a/packages/vant/src/contact-edit/README.md
+++ b/packages/vant/src/contact-edit/README.md
@@ -70,8 +70,8 @@ export default {
 
 | Event  | Description                               | Arguments             |
 | ------ | ----------------------------------------- | --------------------- |
-| save   | Emitted when the save button is clicked   | content：contact info |
-| delete | Emitted when the delete button is clicked | content：contact info |
+| save   | Emitted when the save button is clicked   | content: contact info |
+| delete | Emitted when the delete button is clicked | content: contact info |
 
 ### Data Structure of Contact
 

--- a/packages/vant/src/contact-list/README.md
+++ b/packages/vant/src/contact-list/README.md
@@ -83,7 +83,7 @@ export default {
 | Event | Description | Arguments |
 | --- | --- | --- |
 | add | Emitted when the add button is clicked | - |
-| edit | Emitted when the edit button is clicked | _contact: Contact，index: number_ |
+| edit | Emitted when the edit button is clicked | _contact: Contact, index: number_ |
 | select | Emitted when a contact is selected | _contact: Contact, index: number_ |
 
 ### Data Structure of Contact

--- a/packages/vant/src/datetime-picker/README.md
+++ b/packages/vant/src/datetime-picker/README.md
@@ -293,7 +293,7 @@ export default {
 | columns-order | Array for ordering columns, where item can be set to<br> `year`, `month`, `day`, `hour` and `minute` | _string[]_ | - |
 | item-height | Option height, supports `px` `vw` `vh` `rem` unit, default `px` | _number \| string_ | `44` |
 | visible-item-count | Count of visible columns | _number \| string_ | `6` |
-| swipe-duration | Duration of the momentum animation，unit `ms` | _number \| string_ | `1000` |
+| swipe-duration | Duration of the momentum animation, unit `ms` | _number \| string_ | `1000` |
 
 ### DatePicker Props
 

--- a/packages/vant/src/dialog/README.md
+++ b/packages/vant/src/dialog/README.md
@@ -147,8 +147,8 @@ export default {
 | title | Title | _string_ | - |
 | width | Dialog width | _number \| string_ | `320px` |
 | message | Message | _string \| () => JSX.ELement_ | - |
-| messageAlign | Message text align，can be set to `left` `right` | _string_ | `center` |
-| theme | Theme style，can be set to `round-button` | _string_ | `default` |
+| messageAlign | Message text align, can be set to `left` `right` | _string_ | `center` |
+| theme | Theme style, can be set to `round-button` | _string_ | `default` |
 | className | Custom className | _string \| Array \| object_ | - |
 | showConfirmButton | Whether to show confirm button | _boolean_ | `true` |
 | showCancelButton | Whether to show cancel button | _boolean_ | `false` |
@@ -175,8 +175,8 @@ export default {
 | title | Title | _string_ | - |
 | width | Width | _number \| string_ | `320px` |
 | message | Message | _string \| () => JSX.ELement_ | - |
-| message-align | Message align，can be set to `left` `right` | _string_ | `center` |
-| theme | Theme style，can be set to `round-button` | _string_ | `default` |
+| message-align | Message align, can be set to `left` `right` | _string_ | `center` |
+| theme | Theme style, can be set to `round-button` | _string_ | `default` |
 | show-confirm-button | Whether to show confirm button | _boolean_ | `true` |
 | show-cancel-button | Whether to show cancel button | _boolean_ | `false` |
 | cancel-button-text | Cancel button text | _string_ | `Cancel` |

--- a/packages/vant/src/divider/README.md
+++ b/packages/vant/src/divider/README.md
@@ -61,7 +61,7 @@ app.use(Divider);
 | --- | --- | --- | --- |
 | dashed | Whether to use dashed border | _boolean_ | `false` |
 | hairline | Whether to use hairline | _boolean_ | `true` |
-| content-position | Content position，can be set to `left` `right` | _string_ | `center` |
+| content-position | Content position, can be set to `left` `right` | _string_ | `center` |
 
 ### Slots
 

--- a/packages/vant/src/dropdown-menu/README.md
+++ b/packages/vant/src/dropdown-menu/README.md
@@ -168,13 +168,13 @@ Use `active-color` prop to custom active color of the title and options.
 
 ### DropdownItem Events
 
-| Event  | Description                             | Arguments     |
-| ------ | --------------------------------------- | ------------- | ------ |
-| change | Emitted select option and value changed | value: number | string |
-| open   | Emitted when opening menu               | -             |
-| close  | Emitted when closing menu               | -             |
-| opened | Emitted when menu is opened             | -             |
-| closed | Emitted when menu is closed             | -             |
+| Event  | Description                             | Arguments                 |
+| ------ | --------------------------------------- | ------------------------- |
+| change | Emitted select option and value changed | _value: number \| string_ |
+| open   | Emitted when opening menu               | -                         |
+| close  | Emitted when closing menu               | -                         |
+| opened | Emitted when menu is opened             | -                         |
+| closed | Emitted when menu is closed             | -                         |
 
 ### DropdownItem Slots
 

--- a/packages/vant/src/dropdown-menu/README.md
+++ b/packages/vant/src/dropdown-menu/README.md
@@ -168,13 +168,13 @@ Use `active-color` prop to custom active color of the title and options.
 
 ### DropdownItem Events
 
-| Event  | Description                             | Arguments |
-| ------ | --------------------------------------- | --------- |
-| change | Emitted select option and value changed | value     |
-| open   | Emitted when opening menu               | -         |
-| close  | Emitted when closing menu               | -         |
-| opened | Emitted when menu is opened             | -         |
-| closed | Emitted when menu is closed             | -         |
+| Event  | Description                             | Arguments     |
+| ------ | --------------------------------------- | ------------- | ------ |
+| change | Emitted select option and value changed | value: number | string |
+| open   | Emitted when opening menu               | -             |
+| close  | Emitted when closing menu               | -             |
+| opened | Emitted when menu is opened             | -             |
+| closed | Emitted when menu is closed             | -             |
 
 ### DropdownItem Slots
 

--- a/packages/vant/src/empty/README.md
+++ b/packages/vant/src/empty/README.md
@@ -85,7 +85,7 @@ You can set the width and height separately.
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| image | Image type，can be set to `error` `network` `search` or image URL | _string_ | `default` |
+| image | Image type, can be set to `error` `network` `search` or image URL | _string_ | `default` |
 | image-size | Image size | _number \| string \| Array_ | - |
 | description | Description | _string_ | - |
 

--- a/packages/vant/src/field/README.md
+++ b/packages/vant/src/field/README.md
@@ -252,7 +252,7 @@ Use `input-align` prop to align the input value.
 | name | As the identifier when submitting the form | _string_ | - |
 | id `v3.2.2` | Input id, the for attribute of the label also will be set | _string_ | `van-field-n-input` |
 | type | Input type, support all [native types](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#input_types) and `digit` type | _FieldType_ | `text` |
-| size | Size，can be set to `large` | _string_ | - |
+| size | Size, can be set to `large` | _string_ | - |
 | maxlength | Max length of value | _number \| string_ | - |
 | placeholder | Input placeholder | _string_ | - |
 | border | Whether to show inner border | _boolean_ | `true` |
@@ -272,13 +272,13 @@ Use `input-align` prop to align the input value.
 | error-message | Error message | _string_ | - |
 | error-message-align | Error message align, can be set to `center` `right` | _FieldTextAlign_ | `left` |
 | formatter | Input value formatter | _(val: string) => string_ | - |
-| format-trigger | When to format value，can be set to `onBlur` | _FieldFormatTrigger_ | `onChange` |
+| format-trigger | When to format value, can be set to `onBlur` | _FieldFormatTrigger_ | `onChange` |
 | arrow-direction | Can be set to `left` `up` `down` | _string_ | `right` |
 | label-class | Label className | _string \| Array \| object_ | - |
 | label-width | Label width | _number \| string_ | `6.2em` |
 | label-align | Label align, can be set to `center` `right` | _FieldTextAlign_ | `left` |
 | input-align | Input align, can be set to `center` `right` | _FieldTextAlign_ | `left` |
-| autosize | Textarea auto resize，can accept an object,<br>e.g. { maxHeight: 100, minHeight: 50 } | _boolean \| FieldAutosizeConfig_ | `false` |
+| autosize | Textarea auto resize, can accept an object,<br>e.g. { maxHeight: 100, minHeight: 50 } | _boolean \| FieldAutosizeConfig_ | `false` |
 | left-icon | Left side icon name | _string_ | - |
 | right-icon | Right side icon name | _string_ | - |
 | icon-prefix | Icon className prefix | _string_ | `van-icon` |
@@ -287,7 +287,7 @@ Use `input-align` prop to align the input value.
 
 ### Events
 
-| Event | Description | Parameters |
+| Event | Description | Arguments |
 | --- | --- | --- |
 | update:model-value | Emitted when input value changed | _value: string_ |
 | focus | Emitted when input is focused | _event: Event_ |

--- a/packages/vant/src/form/README.md
+++ b/packages/vant/src/form/README.md
@@ -497,7 +497,7 @@ export default {
 | label-align | Field label align, can be set to `center` `right` | _string_ | `left` |
 | input-align | Field input align, can be set to `center` `right` | _string_ | `left` |
 | error-message-align | Error message align, can be set to `center` `right` | _string_ | `left` |
-| validate-trigger | When to validate the form，can be set to `onChange`、`onSubmit` | _string_ | `onBlur` |
+| validate-trigger | When to validate the form, can be set to `onChange`、`onSubmit` | _string_ | `onBlur` |
 | colon | Whether to display colon after label | _boolean_ | `false` |
 | disabled | Whether to disable form | _boolean_ | `false` |
 | readonly | Whether to be readonly | _boolean_ | `false` |
@@ -515,7 +515,7 @@ export default {
 | message | Error message | _string \| (value, rule) => string_ |
 | validator | Custom validator | _(value, rule) => boolean \| string \| Promise_ |
 | pattern | Regex pattern | _RegExp_ |
-| trigger | When to validate the form，can be set to `onChange`、`onBlur` | _string_ |
+| trigger | When to validate the form, can be set to `onChange`、`onBlur` | _string_ |
 | formatter | Format value before validate | _(value, rule) => any_ |
 
 ### validate-trigger

--- a/packages/vant/src/grid/README.md
+++ b/packages/vant/src/grid/README.md
@@ -124,7 +124,7 @@ app.use(GridItem);
 | icon-color | Icon color | _string_ | - |
 | dot | Whether to show red dot | _boolean_ | `false` |
 | badge | Content of the badge | _number \| string_ | - |
-| badge-props `v3.2.8` | Props of Badge，see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
+| badge-props `v3.2.8` | Props of Badge, see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
 | url | Link URL | _string_ | - |
 | to | Target route of the link, same as to of vue-router | _string \| object_ | - |
 | replace | If true, the navigation will not leave a history record | _boolean_ | `false` |

--- a/packages/vant/src/icon/README.md
+++ b/packages/vant/src/icon/README.md
@@ -96,7 +96,7 @@ Use `size` prop to set icon size.
 | name | Icon name or URL | _string_ | `''` |
 | dot | Whether to show red dot | _boolean_ | `false` |
 | badge | Content of the badge | _number \| string_ | `''` |
-| badge-props `v3.2.8` | Props of Badge，see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
+| badge-props `v3.2.8` | Props of Badge, see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
 | color | Icon color | _string_ | `inherit` |
 | size | Icon size | _number \| string_ | `inherit` |
 | class-prefix | ClassName prefix | _string_ | `van-icon` |

--- a/packages/vant/src/image-preview/README.md
+++ b/packages/vant/src/image-preview/README.md
@@ -174,7 +174,7 @@ export default {
 
 | Event | Description | Arguments |
 | --- | --- | --- |
-| close | Emitted when closing ImagePreview | value: { index, url } |
+| close | Emitted when closing ImagePreview | _value: { index, url }_ |
 | closed | Emitted when ImagePreview is closed | - |
 | change | Emitted when current image changed | _index: number_ |
 | scale | Emitted when scaling current image | _value: ImagePreviewScaleEventParams_ |

--- a/packages/vant/src/image-preview/README.md
+++ b/packages/vant/src/image-preview/README.md
@@ -140,7 +140,7 @@ export default {
 | minZoom | Min zoom | _number \| string_ | `1/3` |
 | closeable | Whether to show close icon | _boolean_ | `false` |
 | closeIcon | Close icon name | _string_ | `clear` |
-| closeIconPosition | Close icon position，can be set to `top-left` `bottom-left` `bottom-right` | _string_ | `top-right` |
+| closeIconPosition | Close icon position, can be set to `top-left` `bottom-left` `bottom-right` | _string_ | `top-right` |
 | transition `v3.0.8` | Transition, equivalent to `name` prop of [transition](https://v3.vuejs.org/api/built-in-components.html#transition) | _string_ | `van-fade` |
 | overlayClass `v3.2.8` | Custom overlay class | _string \| Array \| object_ | - |
 | overlayStyle `v3.0.8` | Custom overlay style | _object_ | - |
@@ -164,7 +164,7 @@ export default {
 | min-zoom | Min zoom | _number \| string_ | `1/3` |
 | closeable | Whether to show close icon | _boolean_ | `false` |
 | close-icon | Close icon name | _string_ | `clear` |
-| close-icon-position | Close icon position，can be set to `top-left` `bottom-left` `bottom-right` | _string_ | `top-right` |
+| close-icon-position | Close icon position, can be set to `top-left` `bottom-left` `bottom-right` | _string_ | `top-right` |
 | transition `v3.0.8` | Transition, equivalent to `name` prop of [transition](https://v3.vuejs.org/api/built-in-components.html#transition) | _string_ | `van-fade` |
 | overlay-class `v3.2.8` | Custom overlay class | _string \| Array \| object_ | - |
 | overlay-style `v3.0.8` | Custom overlay style | _object_ | - |
@@ -172,12 +172,13 @@ export default {
 
 ### Events
 
-| Event | Description | Parameters |
+| Event | Description | Arguments |
 | --- | --- | --- |
-| close | Emitted when closing ImagePreview | { index, url } |
+| close | Emitted when closing ImagePreview | value: { index, url } |
 | closed | Emitted when ImagePreview is closed | - |
-| change | Emitted when current image changed | index: index of current image |
-| scale | Emitted when scaling current image | { index: index of current image, scale: scale of current image} |
+| change | Emitted when current image changed | _index: number_ |
+| scale | Emitted when scaling current image | _value: ImagePreviewScaleEventParams_ |
+| scale | Emitted when scaling current image | _value: ImagePreviewScaleEventParams_ |
 
 ### Methods
 

--- a/packages/vant/src/image/README.md
+++ b/packages/vant/src/image/README.md
@@ -101,7 +101,7 @@ app.use(Lazyload);
 | height | Height | _number \| string_ | - |
 | radius | Border Radius | _number \| string_ | `0` |
 | round | Whether to be round | _boolean_ | `false` |
-| lazy-load | Whether to enable lazy load，should register [Lazyload](#/en-US/lazyload) component | _boolean_ | `false` |
+| lazy-load | Whether to enable lazy load, should register [Lazyload](#/en-US/lazyload) component | _boolean_ | `false` |
 | show-error | Whether to show error placeholder | _boolean_ | `true` |
 | show-loading | Whether to show loading placeholder | _boolean_ | `true` |
 | error-icon | Error icon | _string_ | `photo-fail` |

--- a/packages/vant/src/lazyload/README.md
+++ b/packages/vant/src/lazyload/README.md
@@ -80,4 +80,4 @@ app.use(Lazyload, {
 | filter | The image's listener filter | _object_ | - |
 | lazyComponent | Lazyload component | _boolean_ | `false` |
 
-> See more：[ vue-lazyload ](https://github.com/hilongjw/vue-lazyload)
+> See more: [ vue-lazyload ](https://github.com/hilongjw/vue-lazyload)

--- a/packages/vant/src/list/README.md
+++ b/packages/vant/src/list/README.md
@@ -167,15 +167,15 @@ export default {
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| v-model:loading | Whether to show loading info，the `load` event will not be Emitted when loading | _boolean_ | `false` |
-| v-model:error | Whether loading is error，the `load` event will be Emitted only when error text clicked | _boolean_ | `false` |
-| finished | Whether loading is finished，the `load` event will not be Emitted when finished | _boolean_ | `false` |
+| v-model:loading | Whether to show loading info, the `load` event will not be Emitted when loading | _boolean_ | `false` |
+| v-model:error | Whether loading is error, the `load` event will be Emitted only when error text clicked | _boolean_ | `false` |
+| finished | Whether loading is finished, the `load` event will not be Emitted when finished | _boolean_ | `false` |
 | offset | The load event will be Emitted when the distance between the scrollbar and the bottom is less than offset | _number \| string_ | `300` |
 | loading-text | Loading text | _string_ | `Loading...` |
 | finished-text | Finished text | _string_ | - |
 | error-text | Error loaded text | _string_ | - |
 | immediate-check | Whether to check loading position immediately after mounted | _boolean_ | `true` |
-| direction | Scroll direction，can be set to `up` | _string_ | `down` |
+| direction | Scroll direction, can be set to `up` | _string_ | `down` |
 
 ### Events
 

--- a/packages/vant/src/number-keyboard/README.md
+++ b/packages/vant/src/number-keyboard/README.md
@@ -171,7 +171,7 @@ export default {
 | v-model | Current value | _string_ | - |
 | show | Whether to show keyboard | _boolean_ | - |
 | title | Keyboard title | _string_ | - |
-| theme | Keyboard theme，can be set to `custom` | _string_ | `default` |
+| theme | Keyboard theme, can be set to `custom` | _string_ | `default` |
 | maxlength | Value maxlength | _number \| string_ | `Infinity` |
 | transition | Whether to show transition animation | _boolean_ | `true` |
 | z-index | Keyboard z-index | _number \| string_ | `100` |

--- a/packages/vant/src/picker/README.md
+++ b/packages/vant/src/picker/README.md
@@ -328,7 +328,7 @@ export default {
 | default-index | Default value index of single column picker | _number \| string_ | `0` |
 | item-height | Option height, supports `px` `vw` `vh` `rem` unit, default `px` | _number \| string_ | `44` |
 | visible-item-count | Count of visible columns | _number \| string_ | `6` |
-| swipe-duration | Duration of the momentum animation，unit `ms` | _number \| string_ | `1000` |
+| swipe-duration | Duration of the momentum animation, unit `ms` | _number \| string_ | `1000` |
 
 ### Events
 
@@ -336,9 +336,9 @@ Picker events will pass different parameters according to the columns are single
 
 | Event | Description | Arguments |
 | --- | --- | --- |
-| confirm | Emitted when click confirm button | Single column: current value，current index<br>Multiple columns: current values，current indexes |
-| cancel | Emitted when click cancel button | Single column: current value，current index<br>Multiple columns: current values，current indexes |
-| change | Emitted when current option changed | Single column: Picker instance, current value，current index<br>Multiple columns: Picker instance, current values，column index |
+| confirm | Emitted when click confirm button | Single column: current value, current index<br>Multiple columns: current values, current indexes |
+| cancel | Emitted when click cancel button | Single column: current value, current index<br>Multiple columns: current values, current indexes |
+| change | Emitted when current option changed | Single column: Picker instance, current value, current index<br>Multiple columns: Picker instance, current values, column index |
 
 ### Slots
 

--- a/packages/vant/src/picker/README.md
+++ b/packages/vant/src/picker/README.md
@@ -336,9 +336,9 @@ Picker events will pass different parameters according to the columns are single
 
 | Event | Description | Arguments |
 | --- | --- | --- |
-| confirm | Emitted when click confirm button | Single column：current value，current index<br>Multiple columns：current values，current indexes |
-| cancel | Emitted when click cancel button | Single column：current value，current index<br>Multiple columns：current values，current indexes |
-| change | Emitted when current option changed | Single column：Picker instance, current value，current index<br>Multiple columns：Picker instance, current values，column index |
+| confirm | Emitted when click confirm button | Single column: current value，current index<br>Multiple columns: current values，current indexes |
+| cancel | Emitted when click cancel button | Single column: current value，current index<br>Multiple columns: current values，current indexes |
+| change | Emitted when current option changed | Single column: Picker instance, current value，current index<br>Multiple columns: Picker instance, current values，column index |
 
 ### Slots
 

--- a/packages/vant/src/picker/README.md
+++ b/packages/vant/src/picker/README.md
@@ -336,9 +336,9 @@ Picker events will pass different parameters according to the columns are single
 
 | Event | Description | Arguments |
 | --- | --- | --- |
-| confirm | Emitted when click confirm button | Single column: current value, current index<br>Multiple columns: current values, current indexes |
-| cancel | Emitted when click cancel button | Single column: current value, current index<br>Multiple columns: current values, current indexes |
-| change | Emitted when current option changed | Single column: Picker instance, current value, current index<br>Multiple columns: Picker instance, current values, column index |
+| confirm | Emitted when click confirm button.<br>**Notice: the arguments return an array when the multiple columns mode.** | _currentValue: PickerOption \| PickerOption[], currentIndex: number \| number[]_ |
+| cancel | Emitted when click cancel button.<br>**Notice: the arguments return an array when the multiple columns mode.** | _currentValue: PickerOption \| PickerOption[], currentIndex: number \| number[]_ |
+| change | Emitted when current option changed.<br>**Notice: the arguments return an array when the multiple columns mode.** | _currentValue: PickerOption \| PickerOption[], currentIndex: number \| number[]_ |
 
 ### Slots
 

--- a/packages/vant/src/picker/README.zh-CN.md
+++ b/packages/vant/src/picker/README.zh-CN.md
@@ -359,9 +359,9 @@ export default {
 
 | 事件名 | 说明 | 回调参数 |
 | --- | --- | --- |
-| confirm | 点击完成按钮时触发 | 单列：选中值，选中值对应的索引<br>多列：所有列选中值，所有列选中值对应的索引 |
-| cancel | 点击取消按钮时触发 | 单列：选中值，选中值对应的索引<br>多列：所有列选中值，所有列选中值对应的索引 |
-| change | 选项改变时触发 | 单列：选中值，选中值对应的索引<br>多列：所有列选中值，当前列对应的索引 |
+| confirm | 点击完成按钮时触发。<br>**注意：当传入多列数据时，返回值为数组格式。** | _currentValue: PickerOption \| PickerOption[], currentIndex: number \| number[]_ |
+| cancel | 点击取消按钮时触发。<br>**注意：当传入多列数据时，返回值为数组格式。** | _currentValue: PickerOption \| PickerOption[], currentIndex: number \| number[]_ |
+| change | 选项改变时触发。<br>**注意：当传入多列数据时，返回值为数组格式。** | _currentValue: PickerOption \| PickerOption[], currentIndex: number \| number[]_ |
 
 ### Slots
 

--- a/packages/vant/src/popover/README.md
+++ b/packages/vant/src/popover/README.md
@@ -213,8 +213,8 @@ export default {
 | v-model:show | Whether to show Popover | _boolean_ | `false` |
 | actions | Actions | _PopoverAction[]_ | `[]` |
 | placement | Placement | _PopoverPlacement_ | `bottom` |
-| theme | Theme，can be set to `dark` | _PopoverTheme_ | `light` |
-| trigger | Trigger mode，can be set to `manual` | _PopoverTrigger_ | `click` |
+| theme | Theme, can be set to `dark` | _PopoverTheme_ | `light` |
+| trigger | Trigger mode, can be set to `manual` | _PopoverTrigger_ | `click` |
 | duration | Transition duration, unit second | _number \| string_ | `0.3` |
 | offset | Distance to reference | _[number, number]_ | `[0, 8]` |
 | overlay | Whether to show overlay | _boolean_ | `false` |

--- a/packages/vant/src/popup/README.md
+++ b/packages/vant/src/popup/README.md
@@ -119,7 +119,7 @@ Use `teleport` prop to specify mount location.
 | close-on-click-overlay | Whether to close when overlay is clicked | _boolean_ | `true` |
 | closeable | Whether to show close icon | _boolean_ | `false` |
 | close-icon | Close icon name | _string_ | `cross` |
-| close-icon-position | Close Icon Position，can be set to `top-left` `bottom-left` `bottom-right` | _string_ | `top-right` |
+| close-icon-position | Close Icon Position, can be set to `top-left` `bottom-left` `bottom-right` | _string_ | `top-right` |
 | before-close `v3.1.4` | Callback function before close | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | icon-prefix `v3.0.18` | Icon className prefix | _string_ | `van-icon` |
 | transition | Transition, equivalent to `name` prop of [transition](https://v3.vuejs.org/api/built-in-components.html#transition) | _string_ | - |

--- a/packages/vant/src/progress/README.md
+++ b/packages/vant/src/progress/README.md
@@ -40,7 +40,7 @@ Use `percentage` prop to set current progress.
 
 ### Custom Style
 
-Use `pivot-text` to custom text，use `color` to custom bar color.
+Use `pivot-text` to custom text, use `color` to custom bar color.
 
 ```html
 <van-progress pivot-text="Orange" color="#f2826a" :percentage="25" />

--- a/packages/vant/src/search/README.md
+++ b/packages/vant/src/search/README.md
@@ -155,7 +155,7 @@ export default {
 | error | Whether to mark the input content in red | _boolean_ | `false` |
 | error-message `v3.0.12` | Error message | _string_ | - |
 | formatter `v3.0.12` | Input value formatter | _(val: string) => string_ | - |
-| format-trigger `v3.0.12` | When to format value，can be set to `onBlur` | _string_ | `onChange` |
+| format-trigger `v3.0.12` | When to format value, can be set to `onBlur` | _string_ | `onChange` |
 | input-align | Text align of field, can be set to `center` `right` | _string_ | `left` |
 | left-icon | Left icon name | _string_ | `search` |
 | right-icon | Right icon name | _string_ | - |

--- a/packages/vant/src/share-sheet/README.md
+++ b/packages/vant/src/share-sheet/README.md
@@ -192,7 +192,7 @@ export default {
 | --- | --- | --- |
 | name | Option name | _string_ |
 | description | Option description | _string_ |
-| icon | Option icon，can be set to `wechat` `weibo` `qq` `link` `qrcode` `poster` `weapp-qrcode` `wechat-moments` or image URL | _string_ |
+| icon | Option icon, can be set to `wechat` `weibo` `qq` `link` `qrcode` `poster` `weapp-qrcode` `wechat-moments` or image URL | _string_ |
 | className | Option className is used to set the class props to the share item | _string_ |
 
 ### Events

--- a/packages/vant/src/sidebar/README.md
+++ b/packages/vant/src/sidebar/README.md
@@ -107,7 +107,7 @@ export default {
 | title | Content | _string_ | `''` |
 | dot | Whether to show red dot | _boolean_ | `false` |
 | badge | Content of the badge | _number \| string_ | `''` |
-| badge-props `v3.2.8` | Props of Badge，see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
+| badge-props `v3.2.8` | Props of Badge, see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
 | disabled | Whether to be disabled | _boolean_ | `false` |
 | url | Link | _string_ | - |
 | to | Target route of the link, same as to of vue-router | _string \| object_ | - |

--- a/packages/vant/src/skeleton/README.md
+++ b/packages/vant/src/skeleton/README.md
@@ -66,12 +66,12 @@ export default {
 | row-width | Row width, can be array | _number \| string \|<br>(number \| string)[]_ | `100%` |
 | title | Whether to show title placeholder | _boolean_ | `false` |
 | avatar | Whether to show avatar placeholder | _boolean_ | `false` |
-| loading | Whether to show skeleton，pass `false` to show child component | _boolean_ | `true` |
+| loading | Whether to show skeleton, pass `false` to show child component | _boolean_ | `true` |
 | animate | Whether to enable animation | _boolean_ | `true` |
 | round | Whether to show round title and row | _boolean_ | `false` |
 | title-width | Title width | _number \| string_ | `40%` |
 | avatar-size | Size of avatar placeholder | _number \| string_ | `32px` |
-| avatar-shape | Shape of avatar placeholder，can be set to `square` | _string_ | `round` |
+| avatar-shape | Shape of avatar placeholder, can be set to `square` | _string_ | `round` |
 
 ### Types
 

--- a/packages/vant/src/stepper/README.md
+++ b/packages/vant/src/stepper/README.md
@@ -139,7 +139,7 @@ export default {
 | disable-plus | Whether to disable plus button | _boolean_ | `false` |
 | disable-minus | Whether to disable minus button | _boolean_ | `false` |
 | disable-input | Whether to disable input | _boolean_ | `false` |
-| before-change | Callback function before changing，return `false` to prevent change，support return Promise | _(value: number \| string) => boolean \| Promise\<boolean\>_ | `false` |
+| before-change | Callback function before changing, return `false` to prevent change, support return Promise | _(value: number \| string) => boolean \| Promise\<boolean\>_ | `false` |
 | show-plus | Whether to show plus button | _boolean_ | `true` |
 | show-minus | Whether to show minus button | _boolean_ | `true` |
 | show-input | Whether to show input | _boolean_ | `true` |

--- a/packages/vant/src/submit-bar/README.md
+++ b/packages/vant/src/submit-bar/README.md
@@ -94,7 +94,7 @@ export default {
 | --- | --- | --- | --- |
 | price | Price | _number_ | - |
 | decimal-length | Price decimal length | _number \| string_ | `2` |
-| label | Price left label | _string_ | `Total：` |
+| label | Price left label | _string_ | `Total: ` |
 | suffix-label | Price right label | _string_ | - |
 | text-align | Price label text align can be set to `left` | _string_ | `right` |
 | button-text | Button text | _string_ | - |

--- a/packages/vant/src/swipe-cell/README.md
+++ b/packages/vant/src/swipe-cell/README.md
@@ -127,8 +127,8 @@ export default {
 | Event | Description | Arguments |
 | --- | --- | --- |
 | click | Emitted when SwipeCell is clicked | _position: 'left' \| 'right' \| 'cell' \| 'outside'_ |
-| open | Emitted when SwipeCell is opened | _{ name: string \| number, position: 'left' \| 'right' }_ |
-| close | Emitted when SwipeCell is closed | _{ name: string \| number, position: 'left' \| 'right' \| 'cell' \| 'outside' }_ |
+| open | Emitted when SwipeCell is opened | _value: { name: string \| number, position: 'left' \| 'right' }_ |
+| close | Emitted when SwipeCell is closed | _value: { name: string \| number, position: 'left' \| 'right' \| 'cell' \| 'outside' }_ |
 
 ### beforeClose Params
 

--- a/packages/vant/src/tab/README.md
+++ b/packages/vant/src/tab/README.md
@@ -283,7 +283,7 @@ export default {
 | rendered | Emitted when content first rendered in lazy-render mode | _name: string \| number, title: string_ |
 | scroll | Emitted when tab scrolling in sticky mode | _{ scrollTop: number, isFixed: boolean }_ |
 
-> Tips：click and disabled event is deprecated，place use click-tab event instead.
+> Tips: click and disabled event is deprecated，place use click-tab event instead.
 
 ### Tabs Methods
 

--- a/packages/vant/src/tab/README.md
+++ b/packages/vant/src/tab/README.md
@@ -256,7 +256,7 @@ export default {
 | swipe-threshold | Set swipe tabs threshold | _number \| string_ | `5` |
 | title-active-color | Title active color | _string_ | - |
 | title-inactive-color | Title inactive color | _string_ | - |
-| before-change | Callback function before changing tabs，return `false` to prevent change，support return Promise | _(name: number \| string) => boolean \| Promise\<boolean\>_ | - |
+| before-change | Callback function before changing tabs, return `false` to prevent change, support return Promise | _(name: number \| string) => boolean \| Promise\<boolean\>_ | - |
 
 ### Tab Props
 
@@ -283,7 +283,7 @@ export default {
 | rendered | Emitted when content first rendered in lazy-render mode | _name: string \| number, title: string_ |
 | scroll | Emitted when tab scrolling in sticky mode | _{ scrollTop: number, isFixed: boolean }_ |
 
-> Tips: click and disabled event is deprecated，place use click-tab event instead.
+> Tips: click and disabled event is deprecated, place use click-tab event instead.
 
 ### Tabs Methods
 

--- a/packages/vant/src/tabbar/README.md
+++ b/packages/vant/src/tabbar/README.md
@@ -173,7 +173,7 @@ export default {
 | route | Whether to enable route mode | _boolean_ | `false` |
 | placeholder | Whether to generate a placeholder element when fixed | _boolean_ | `false` |
 | safe-area-inset-bottom | Whether to enable bottom safe area adaptation | _boolean_ | `false` |
-| before-change | Callback function before changing tab，return `false` to prevent change，support return Promise | _(name: number \| string) => boolean \| Promise\<boolean\>_ | - |
+| before-change | Callback function before changing tab, return `false` to prevent change, support return Promise | _(name: number \| string) => boolean \| Promise\<boolean\>_ | - |
 
 ### Tabbar Events
 
@@ -190,7 +190,7 @@ export default {
 | icon-prefix | Icon className prefix | _string_ | `van-icon` |
 | dot | Whether to show red dot | _boolean_ | - |
 | badge | Content of the badge | _number \| string_ | `''` |
-| badge-props `v3.2.8` | Props of Badge，see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
+| badge-props `v3.2.8` | Props of Badge, see [Badge - props](#/en-US/badge#props) | _BadgeProps_ | - |
 | url | Link | _string_ | - |
 | to | Target route of the link, same as to of vue-router | _string \| object_ | - |
 | replace | If true, the navigation will not leave a history record | _boolean_ | `false` |

--- a/packages/vant/src/uploader/README.md
+++ b/packages/vant/src/uploader/README.md
@@ -310,14 +310,14 @@ export default {
 | preview-size | Size of preview image | _number \| string \| Array_ | `80px` |
 | preview-image | Whether to show image preview | _boolean_ | `true` |
 | preview-full-image | Whether to show full screen image preview when image is clicked | _boolean_ | `true` |
-| preview-options | Options of full screen image preview，see [ImagePreview](#/en-US/image-preview) | _object_ | - |
+| preview-options | Options of full screen image preview, see [ImagePreview](#/en-US/image-preview) | _object_ | - |
 | multiple | Whether to enable multiple selection pictures | _boolean_ | `false` |
 | disabled | Whether to disabled the upload | _boolean_ | `false` |
 | readonly `v3.1.5` | Whether to make upload area readonly | _boolean_ | `false` |
 | deletable | Whether to show delete icon | _boolean_ | `true` |
 | show-upload | Whether to show upload area | _boolean_ | `true` |
-| lazy-load | Whether to enable lazy load，should register [Lazyload](#/en-US/lazyload) component | _boolean_ | `false` |
-| capture | Capture，can be set to `camera` | _string_ | - |
+| lazy-load | Whether to enable lazy load, should register [Lazyload](#/en-US/lazyload) component | _boolean_ | `false` |
+| capture | Capture, can be set to `camera` | _string_ | - |
 | after-read | Hook after reading the file | _Function_ | - |
 | before-read | Hook before reading the file, return false to stop reading the file, can return Promise | _Function_ | - |
 | before-delete | Hook before delete the file, return false to stop reading the file, can return Promise | _Function_ | - |


### PR DESCRIPTION
#10422

- [x] transform '，' to ',' in README.md
- [x] support `events.arguments` compile to `web-types.json`
- [x] adjust part of `events.arguments` content in `README.md` & `README.zh-CN.md`
- [x] fixed multi '\|' can not transform to 'JOIN' in packages/vant-markdown-vetur/src/parser.ts

### Additions:
I discover so many regexp used in `vant-markdown-vetur` when support the feature that is understand difficulty. so I wonder if we should reduce the use of such. other, `vant-markdown-vetur` no unit test, we need to support it to improve the reliability.