### PR TITLE
docs(vant): keep the doc consistent with the demo code

### DIFF
--- a/packages/vant/src/form/README.md
+++ b/packages/vant/src/form/README.md
@@ -115,7 +115,7 @@ export default {
   setup() {
     const value1 = ref('');
     const value2 = ref('');
-    const value3 = ref('');
+    const value3 = ref('abc');
     const value4 = ref('');
     const pattern = /\d{6}/;
 
@@ -129,7 +129,7 @@ export default {
 
         setTimeout(() => {
           Toast.clear();
-          resolve(/\d{6}/.test(val));
+          resolve(val === '1234');
         }, 1000);
       });
 

--- a/packages/vant/src/form/README.zh-CN.md
+++ b/packages/vant/src/form/README.zh-CN.md
@@ -123,7 +123,7 @@ export default {
   setup() {
     const value1 = ref('');
     const value2 = ref('');
-    const value3 = ref('');
+    const value3 = ref('abc');
     const value4 = ref('');
     const pattern = /\d{6}/;
 
@@ -140,7 +140,7 @@ export default {
 
         setTimeout(() => {
           Toast.clear();
-          resolve(/\d{6}/.test(val));
+          resolve(val === '1234');
         }, 1000);
       });
 


### PR DESCRIPTION
the docs is behind the [demo code](https://github.com/youzan/vant/blob/004f6426229fdb2916fae64101d1e04be201aa76/packages/vant/src/form/demo/ValidateRules.vue), so update the readme to keep it constitent with the demo code.

https://github.com/youzan/vant/blob/004f6426229fdb2916fae64101d1e04be201aa76/packages/vant/src/form/demo/ValidateRules.vue#L38-L56

![image](https://user-images.githubusercontent.com/21104054/165295033-68d1f3a6-8439-498f-9c07-a156c263219a.png)
