### PR TITLE
fix(Picker): picker columnsfieldnames responsiveness

### DIFF
--- a/packages/vant/src/picker/test/index.spec.tsx
+++ b/packages/vant/src/picker/test/index.spec.tsx
@@ -28,7 +28,6 @@ test('simple columns confirm & cancel event', () => {
   expect(wrapper.emitted('cancel')![0]).toEqual(['1990', 0]);
   wrapper.unmount();
 });
-
 test('multiple columns confirm & cancel event', () => {
   const wrapper = mount(Picker, {
     props: {
@@ -358,4 +357,29 @@ test('should not render mask and frame when options is empty', async () => {
   await wrapper.setProps({ columns: [{ values: ['foo'] }] });
   expect(wrapper.find('.van-picker__mask').exists()).toBeTruthy();
   expect(wrapper.find('.van-picker__frame').exists()).toBeTruthy();
+});
+
+test('columns-field-names responsiveness', async () => {
+  const columnsOne = [
+    { type: 1, name: 'Ios' },
+    { type: 2, name: 'Android' },
+  ];
+  const columnsTwo = [
+    { type: 1, serverName: 'server1' },
+    { type: 2, serverName: 'server2' },
+  ];
+  const wrapper = mount(Picker, {
+    props: {
+      columns: columnsOne,
+      columnsFieldNames: {
+        text: 'name',
+      },
+    },
+  });
+  expect(wrapper.findAll('.van-ellipsis')[0].text()).toEqual('Ios');
+  await wrapper.setProps({
+    columns: columnsTwo,
+    columnsFieldNames: { text: 'serverName' },
+  });
+  expect(wrapper.findAll('.van-ellipsis')[0].text()).toEqual('server1');
 });


### PR DESCRIPTION
**问题定位：**
当我在使用picker组件时，我希望columns数据改变后，修改columns-field-names后能够正确的展示，如下：
初始时结果展示正确
![image](https://user-images.githubusercontent.com/46644748/165513371-5a27e8dc-cd45-4929-bec9-995722c3bfbb.png)

当点击change按钮后，我希望修改了columns后，同时修改columns-field-names的text,能够正确展示如下图serverName字段，但实际是不可以的，现阶段是展示一个对象。
![image](https://user-images.githubusercontent.com/46644748/165513496-4b01947b-af7f-43c3-9342-8c4fa274ba79.png)

**希望得到得结果：**
直接修改columns-field-names的text属性，能够正确的展示结果

**上述案例地址：**
https://codesandbox.io/s/jovial-morning-rbjcni?file=/src/App.vue:393-472

**解决方案：**
关键代码


    const columnsFieldNames = reactive({
      // compatible with valueKey prop
      text: props.valueKey || 'text',
      values: 'values',
      children: 'children',
    });

    extend(columnsFieldNames, props.columnsFieldNames);
    watch(
      () => props.columnsFieldNames,
      (value) => {
        if (value) extend(columnsFieldNames, value);
      },
      {
        deep: true,
      }
    );
    const {
      text: textKey,
      values: valuesKey,
      children: childrenKey,
    } = toRefs(columnsFieldNames);



**测试用例：**

  
    test('columns-field-names responsiveness', async () => {
      const columnsOne = [
        { type: 1, name: 'Ios' },
        { type: 2, name: 'Android' },
      ];
      const columnsTwo = [
        { type: 1, serverName: 'server1' },
        { type: 2, serverName: 'server2' },
      ];
      const wrapper = mount(Picker, {
        props: {
          columns: columnsOne,
          columnsFieldNames: {
            text: 'name',
          },
        },
      });
      expect(wrapper.findAll('.van-ellipsis')[0].text()).toEqual('Ios');
      await wrapper.setProps({
        columns: columnsTwo,
        columnsFieldNames: { text: 'serverName' },
      });
      expect(wrapper.findAll('.van-ellipsis')[0].text()).toEqual('server1');
    });

