### PR TITLE
fix: popover positioning failure

### DIFF
--- a/packages/vant/src/popover/Popover.tsx
+++ b/packages/vant/src/popover/Popover.tsx
@@ -57,6 +57,7 @@ const popoverProps = {
   show: Boolean,
   theme: makeStringProp<PopoverTheme>('light'),
   overlay: Boolean,
+  delay: Number,
   actions: makeArrayProp<PopoverAction>(),
   trigger: makeStringProp<PopoverTrigger>('click'),
   duration: numericProp,
@@ -116,8 +117,8 @@ export default defineComponent({
       return null;
     };
 
-    const updateLocation = () => {
-      nextTick(() => {
+    const updateLocation = () =>
+      nextTick().then(() => {
         if (!props.show) {
           return;
         }
@@ -130,7 +131,6 @@ export default defineComponent({
           });
         }
       });
-    };
 
     const updateShow = (value: boolean) => emit('update:show', value);
 
@@ -199,7 +199,17 @@ export default defineComponent({
       );
     };
 
-    onMounted(updateLocation);
+    onMounted(() => {
+      if (props.delay) {
+        const delay = setTimeout(() => {
+          updateLocation().then(() => {
+            clearTimeout(delay);
+          });
+        }, props.delay);
+      } else {
+        updateLocation();
+      }
+    });
     onBeforeUnmount(() => {
       if (popper) {
         popper.destroy();


### PR DESCRIPTION
导致这个问题是动画还没有结束popver就已经完成了创建挂载, 所以导致了错误的显示
所以添加一个props delay 让用户自行设置等待挂载时间, 可以解决一些边界行为, 暂时没有想到如何无感知做到这一步
看这个方案是否可以接受, 然后我会更新文档

- Fix #8564

```html
<!DOCTYPE html>
<html lang="en">
  <head>
    <meta charset="UTF-8" />
    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
    <title>Document</title>
    <script src="https://cdn.jsdelivr.net/npm/vue@2.6/dist/vue.min.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/vant@2.12/lib/vant.min.js"></script>
    <script src="https://cdn.jsdelivr.net/npm/vue-router/dist/vue-router.js"></script>
    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/vant@2.12/lib/index.css" />
    <style>
      .page {
        width: 500px;
        height: 300px;
        border: 2px solid #333;
        overflow: hidden;
      }
      .pageA {
        width: 100%;
        height: 100%;
        background-color: blue;
      }
      .pageB {
        width: 100%;
        height: 100%;
        background-color: red;
      }
    </style>
  </head>

  <body>
    <div id="app"></div>
    <script>
      const A = {
        template: `
            <div class="pageA">
                <van-popover
                    v-model="show1"
                    trigger="click"
                    placement="right"
                >
                    <p>跳到b页面后再回来我就不见了</p>
                    <template #reference>
                        <van-button type="primary">pageA</van-button>
                    </template>
                </van-popover>
            </div>`,
        data() {
          return { show: true }
        },
        props: ['show1']
      }
      const B = {
        template: '<div class="pageB">pageB</div>'
      }
      const routes = [
        { path: '/', component: A },
        { path: '/b', component: B }
      ]
      const router = new VueRouter({
        routes
      })

      new Vue({
        el: '#app',
        data() {
          return {
            show1: true
          }
        },
        methods: {
          afterLeave() {
            this.show1 = true
          },
          enter() {
            this.show1 = false
          }
        },
        template: `<div>
          <div class="page">
            <transition name="van-slide-left" @enter="enter" @after-leave="afterLeave">
                <router-view :show1="this.show1"></router-view>
            </transition>
          </div>
          <router-link :to="/">A页面</router-link>
          <router-link to="/b">B页面</router-link>
          <p>问题描述：第一次进A页面时popover组件可以正常显示，点击跳到b页面，再点击回到A页面时popover组件定位偏移不见了</p>
        </div>`,
        router
      })
    </script>
  </body>
</html>

```