### PR TITLE
docs: remove search from v2 site

### DIFF
--- a/docs/markdown/changelog.en-US.md
+++ b/docs/markdown/changelog.en-US.md
@@ -738,7 +738,7 @@ Vant follows [Semantic Versioning 2.0.0](https://semver.org/lang/zh-CN/).
 - Field: incorrect disabled color in iOS 14 [#7206](https://github.com/youzan/vant/issues/7206)
 - List: scoped style not applied to first child [#7202](https://github.com/youzan/vant/issues/7202)
 - Swipe: can't disable loop in some cases [#7208](https://github.com/youzan/vant/issues/7208)
-- Swipe: incorrect indicator color trantision [#7207](https://github.com/youzan/vant/issues/7207)
+- Swipe: incorrect indicator color transition [#7207](https://github.com/youzan/vant/issues/7207)
 
 ### [v2.10.7](https://github.com/youzan/vant/compare/v2.10.6...v2.10.7)
 

--- a/vant.config.js
+++ b/vant.config.js
@@ -40,26 +40,6 @@ module.exports = {
             url: 'https://github.com/youzan/vant',
           },
         ],
-        searchConfig: {
-          apiKey: '90067aecdaa2c85220e2783cd305caac',
-          indexName: 'vant',
-          placeholder: '搜索文档...',
-          algoliaOptions: {
-            facetFilters: ['version:v2'],
-          },
-          transformData(hits) {
-            if (location.hostname === 'vant-contrib.gitee.io') {
-              hits.forEach((hit) => {
-                if (hit.url) {
-                  hit.url = hit.url.replace(
-                    'youzan.github.io',
-                    'vant-contrib.gitee.io'
-                  );
-                }
-              });
-            }
-          },
-        },
         nav: [
           {
             title: '开发指南',
@@ -458,14 +438,6 @@ module.exports = {
             url: 'https://github.com/youzan/vant',
           },
         ],
-        searchConfig: {
-          apiKey: '90067aecdaa2c85220e2783cd305caac',
-          indexName: 'vant',
-          placeholder: 'Search...',
-          algoliaOptions: {
-            facetFilters: ['version:v2'],
-          },
-        },
         nav: [
           {
             title: 'Essentials',


### PR DESCRIPTION
v2 网站的搜索依赖 docsearch 在 jsdelivr 上的 CDN 资源，而近期 jsdelivr 在很多地方无法访问，阻塞了文档加载。

相比来说，文档搜索功能的必要性没有那么强，因此暂时下线文档搜索。

close https://github.com/youzan/vant/issues/10631