### PR TITLE
docs: remove search from v3 site

### DIFF
--- a/packages/vant/vant.config.mjs
+++ b/packages/vant/vant.config.mjs
@@ -46,26 +46,6 @@ export default {
             url: 'https://github.com/youzan/vant',
           },
         ],
-        searchConfig: {
-          appId: 'BLI2GGOUL8',
-          apiKey: '07cb725cd26aa496996de6cb8ab9b5cc',
-          indexName: 'vant',
-          searchParameters: {
-            facetFilters: ['lang:zh-CN', 'version:v3'],
-          },
-          transformItems(items) {
-            if (location.hostname !== 'youzan.github.io') {
-              items.forEach((item) => {
-                if (item.url) {
-                  item.url =
-                    item.url &&
-                    item.url.replace('youzan.github.io', location.hostname);
-                }
-              });
-            }
-            return items;
-          },
-        },
         nav: [
           {
             title: '开发指南',
@@ -490,14 +470,6 @@ export default {
             url: 'https://github.com/youzan/vant',
           },
         ],
-        searchConfig: {
-          appId: 'BLI2GGOUL8',
-          apiKey: '07cb725cd26aa496996de6cb8ab9b5cc',
-          indexName: 'vant',
-          searchParameters: {
-            facetFilters: ['lang:en-US', 'version:v3'],
-          },
-        },
         nav: [
           {
             title: 'Essentials',


### PR DESCRIPTION
v3 版本的文档搜索功能一直存在问题，docsearch的爬虫无法爬取到有效的内容，尝试了一下未能解决，因此暂时下线文档搜索入口，后续有时间再处理。

close https://github.com/youzan/vant/issues/10308