### PR TITLE
fix(Calender): failed to render months after changing maxDate or minDate

### DIFF
--- a/packages/vant/src/calendar/Calendar.tsx
+++ b/packages/vant/src/calendar/Calendar.tsx
@@ -185,6 +185,10 @@ export default defineComponent({
       const months: Date[] = [];
       const cursor = new Date(props.minDate);
 
+      if (props.lazyRender && !props.show) {
+        return months;
+      }
+
       cursor.setDate(1);
 
       do {


### PR DESCRIPTION
fix: #10628 


lazyRender模式下隐藏展开calendar时重新渲染下months，lazyRender时元素较少，渲染成本应该不大