### PR TITLE
feat(cli): add build.bundleOptions config

### DIFF
--- a/packages/vant-cli/docs/config.md
+++ b/packages/vant-cli/docs/config.md
@@ -221,6 +221,45 @@ module.exports = {
 
 `npm` package manager.
 
+### build.bundleOptions
+
+- Type: `BundleOptions[]`
+
+Specify the format of the bundled output.
+
+The type of `BundleOptions`:
+
+```ts
+type BundleOption = {
+  // Whether to minify code (Tips: es format output can't be minified by vite)
+  minify?: boolean;
+  // Formats, can be set to 'es' | 'cjs' | 'umd' | 'iife'
+  formats: LibraryFormats[];
+  // Dependencies to external (Vue is externaled by default)
+  external?: string[];
+};
+```
+
+Default value：
+
+```ts
+const DEFAULT_OPTIONS: BundleOption[] = [
+  {
+    minify: false,
+    formats: ['umd'],
+  },
+  {
+    minify: true,
+    formats: ['umd'],
+  },
+  {
+    minify: false,
+    formats: ['es', 'cjs'],
+    external: allDependencies,
+  },
+];
+```
+
 ### site.title
 
 - Type: `string`

--- a/packages/vant-cli/docs/config.zh-CN.md
+++ b/packages/vant-cli/docs/config.zh-CN.md
@@ -223,6 +223,45 @@ module.exports = {
 
 指定使用的包管理器。
 
+### build.bundleOptions
+
+- Type: `BundleOptions[]`
+
+指定打包后产物的格式。
+
+产物格式由三个配置项控制：
+
+```ts
+type BundleOption = {
+  // 是否压缩代码（注意 es 产物无法被 vite 压缩）
+  minify?: boolean;
+  // 产物类型，可选值为 'es' | 'cjs' | 'umd' | 'iife'
+  formats: LibraryFormats[];
+  // 需要 external 的依赖（Vue 默认会被 external）
+  external?: string[];
+};
+```
+
+该选项的默认值为：
+
+```ts
+const DEFAULT_OPTIONS: BundleOption[] = [
+  {
+    minify: false,
+    formats: ['umd'],
+  },
+  {
+    minify: true,
+    formats: ['umd'],
+  },
+  {
+    minify: false,
+    formats: ['es', 'cjs'],
+    external: allDependencies,
+  },
+];
+```
+
 ### site.title
 
 - Type: `string`

--- a/packages/vant-cli/src/config/vite.package.ts
+++ b/packages/vant-cli/src/config/vite.package.ts
@@ -1,17 +1,14 @@
 import { join } from 'path';
 import { setBuildTarget } from '../common/index.js';
 import { CWD, ES_DIR, getVantConfig, LIB_DIR } from '../common/constant.js';
-import type { InlineConfig, LibraryFormats } from 'vite';
+import type { InlineConfig } from 'vite';
+import type { BundleOption } from '../compiler/compile-bundles.js';
 
 export function getViteConfigForPackage({
   minify,
   formats,
-  external,
-}: {
-  minify: boolean;
-  formats: LibraryFormats[];
-  external: string[];
-}): InlineConfig {
+  external = [],
+}: BundleOption): InlineConfig {
   setBuildTarget('package');
 
   const { name, build } = getVantConfig();
@@ -36,7 +33,7 @@ export function getViteConfigForPackage({
       // terser has better compression than esbuild
       minify: minify ? 'terser' : false,
       rollupOptions: {
-        external,
+        external: [...external, 'vue'],
         output: {
           dir: LIB_DIR,
           exports: 'named',


### PR DESCRIPTION
Allow to config bundle options, and removed minified es and cjs output from default options, because they are never used.