### PR TITLE
fix(Uploader): optimize image preview

### DIFF
--- a/packages/vant/src/uploader/Uploader.tsx
+++ b/packages/vant/src/uploader/Uploader.tsx
@@ -230,7 +230,7 @@ export default defineComponent({
         const imageFiles = props.modelValue.filter(isImageFile);
         const images = imageFiles
           .map((item) => {
-            if (item.file && !item.url) {
+            if (item.file && !item.url && item.status !== 'failed') {
               item.url = URL.createObjectURL(item.file);
               urls.push(item.url);
             }


### PR DESCRIPTION
I don't think the image that fails to upload does not need to be converted again. I hope the big guy will adopt it.