### PR TITLE
chore: add `typescript` dev deps to `vant-markdown-vetur`

### DIFF
--- a/packages/vant-markdown-vetur/package.json
+++ b/packages/vant-markdown-vetur/package.json
@@ -29,6 +29,7 @@
     "fs-extra": "^10.0.0"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.13"
+    "@types/fs-extra": "^9.0.13",
+    "typescript": "^4.7.4"
   }
 }


### PR DESCRIPTION
Hi, Vant team,

thanks for the great project!
I try to clone the repo and run it on local.
Will fail on `pnpm i` step in prepare script of `vant-markdown-vetur` package.

<img width="927" alt="image" src="https://user-images.githubusercontent.com/26245542/178100888-58cb1b72-f702-48c0-8c7d-052146f5523f.png">

I think just because `typescript` dep is not in package.json cause. so I added it and rerun `pnpm i` then fixed the problem.