### PR TITLE
fix: 修改 isEmptyValue  当值为布尔类型：false的时候，校验失败的情况

### DIFF
--- a/packages/vant/src/field/utils.ts
+++ b/packages/vant/src/field/utils.ts
@@ -15,7 +15,7 @@ function isEmptyValue(value: unknown) {
   if (value === 0) {
     return false;
   }
-  return !value;
+  return !(value === null || value === undefined);
 }
 
 export function runSyncRule(value: unknown, rule: FieldRule) {


### PR DESCRIPTION
radio 组件的 name 值可以传false， 但是 field组件的校验是失败的