### PR TITLE
perf: improve the type of setTimeout

### DIFF
--- a/packages/vant/src/image-preview/ImagePreviewItem.tsx
+++ b/packages/vant/src/image-preview/ImagePreviewItem.tsx
@@ -140,7 +140,7 @@ export default defineComponent({
     let startMoveY: number;
     let startScale: number;
     let startDistance: number;
-    let doubleTapTimer: NodeJS.Timeout | null;
+    let doubleTapTimer: ReturnType<typeof setTimeout> | null;
     let touchStartTime: number;
 
     const onTouchStart = (event: TouchEvent) => {

--- a/packages/vant/src/notice-bar/NoticeBar.tsx
+++ b/packages/vant/src/notice-bar/NoticeBar.tsx
@@ -56,7 +56,7 @@ export default defineComponent({
   setup(props, { emit, slots }) {
     let wrapWidth = 0;
     let contentWidth = 0;
-    let startTimer: NodeJS.Timeout;
+    let startTimer: ReturnType<typeof setTimeout>;
 
     const wrapRef = ref<HTMLElement>();
     const contentRef = ref<HTMLElement>();

--- a/packages/vant/src/notify/function-call.tsx
+++ b/packages/vant/src/notify/function-call.tsx
@@ -55,7 +55,7 @@ export function showNotify(options: NotifyMessage | NotifyOptions) {
   clearTimeout(timer);
 
   if (options.duration! > 0) {
-    timer = window.setTimeout(closeNotify, options.duration);
+    timer = setTimeout(closeNotify, options.duration);
   }
 
   return instance;

--- a/packages/vant/src/notify/function-call.tsx
+++ b/packages/vant/src/notify/function-call.tsx
@@ -3,7 +3,7 @@ import { mountComponent, usePopupState } from '../utils/mount-component';
 import VanNotify from './Notify';
 import type { NotifyMessage, NotifyOptions } from './types';
 
-let timer: number;
+let timer: ReturnType<typeof setTimeout>;
 let instance: ComponentInstance;
 
 const parseOptions = (message: NotifyMessage | NotifyOptions) =>

--- a/packages/vant/src/stepper/Stepper.tsx
+++ b/packages/vant/src/stepper/Stepper.tsx
@@ -214,7 +214,7 @@ export default defineComponent({
     };
 
     let isLongPress: boolean;
-    let longPressTimer: NodeJS.Timeout;
+    let longPressTimer: ReturnType<typeof setTimeout>;
 
     const longPressStep = () => {
       longPressTimer = setTimeout(() => {

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -235,7 +235,7 @@ export default defineComponent({
       });
     };
 
-    let autoplayTimer: NodeJS.Timeout;
+    let autoplayTimer: ReturnType<typeof setTimeout>;
 
     const stopAutoplay = () => clearTimeout(autoplayTimer);
 

--- a/packages/vant/src/toast/Toast.tsx
+++ b/packages/vant/src/toast/Toast.tsx
@@ -72,7 +72,7 @@ export default defineComponent({
   emits: ['update:show'],
 
   setup(props, { emit, slots }) {
-    let timer: NodeJS.Timeout;
+    let timer: ReturnType<typeof setTimeout>;
     let clickable = false;
 
     const toggleClickable = () => {


### PR DESCRIPTION
https://github.com/youzan/vant/issues/11066

example:
```ts
// let startTimer: NodeJS.Timeout;
let startTimer: ReturnType<typeof setTimeout>;
```