### PR TITLE
fix(Calendar): throw an error that scrollTop in undefined when poppable = true in popup(#10360)(#10614)

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -173,6 +173,9 @@ export default createComponent({
     this.init();
     // https://github.com/vant-ui/vant/issues/9845
     this.vanPopup?.$on('opened', this.onScroll);
+    if (!this.poppable) {
+      this.vanPopup?.$on('opened', this.onScroll);
+    }
   },
 
   /* istanbul ignore next */


### PR DESCRIPTION
 Bug cause: 该bug出现的原因是之前在修复 #9845 issue时的判断逻辑缺失。