### PR TITLE
fix(Calendar): throw an error that scrollTop in undefined when poppable = true in popup(#10360)(#10614)

### DIFF
--- a/src/calendar/index.js
+++ b/src/calendar/index.js
@@ -172,7 +172,9 @@ export default createComponent({
   mounted() {
     this.init();
     // https://github.com/vant-ui/vant/issues/9845
-    this.vanPopup?.$on('opened', this.onScroll);
+    if (!this.poppable) {
+      this.vanPopup?.$on('opened', this.onScroll);
+    }
   },
 
   /* istanbul ignore next */


### PR DESCRIPTION
Bug cause: 该bug出现的原因是之前在修复 #9845 issue时的判断逻辑缺失。

该问题主要是为了解决平铺模式下Calendar在popup弹出层中使用时导致大量日期空白的问题。
但是对于非平铺模式（即弹出模式），在Calendar的mounted生命周期，组件并未渲染到DOM中，所以此时监听外层popup的opened event时去执行onScroll方法，会去获取 ref 名为body的元素并执行 getScrollTop 方法，此时因为还未渲染到DOM中，获取到的元素是undefined，执行了 getScrollTop 方法便导致了报错。