### PR TITLE
style(Coupon): fix the style of coupon checkbox

### DIFF
--- a/packages/vant/src/coupon/index.less
+++ b/packages/vant/src/coupon/index.less
@@ -34,6 +34,7 @@
   &__content {
     display: flex;
     align-items: center;
+    position: relative;
     box-sizing: border-box;
     min-height: var(--van-coupon-content-height);
     padding: var(--van-coupon-content-padding);


### PR DESCRIPTION
https://github.com/youzan/vant/issues/11149

The reason for this issue is that the parent element does not have `relative`, which makes the positioning of the checkbox dependent on the `van-tabs`

before
![image](https://user-images.githubusercontent.com/19986739/196844833-47503096-dcf7-49ca-a3f9-21e527ea35da.png)

after
![image](https://user-images.githubusercontent.com/19986739/196844879-9084cd23-a166-46a4-954c-086a2e1653b3.png)
