### PR TITLE
fix(Picker): correct v-model when emit confirm event

### DIFF
--- a/packages/vant/src/date-picker/test/index.spec.ts
+++ b/packages/vant/src/date-picker/test/index.spec.ts
@@ -17,7 +17,7 @@ test('should emit confirm event correctly', async () => {
   });
 
   await later();
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
   expect(wrapper.emitted<[PickerConfirmEventParams]>('confirm')![0][0]).toEqual(
     {
       selectedOptions: [
@@ -90,7 +90,7 @@ test('should render with max-date correctly', async () => {
   });
 
   await later();
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
   expect(
     wrapper.emitted<[PickerConfirmEventParams]>('confirm')![0][0].selectedValues
   ).toEqual(['2010', '01', '10']);
@@ -115,7 +115,7 @@ test('should render with min-date correctly', async () => {
   });
 
   await later();
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
   expect(
     wrapper.emitted<[PickerConfirmEventParams]>('confirm')![0][0].selectedValues
   ).toEqual(['2000', '10', '10']);
@@ -193,7 +193,7 @@ test('should update value correctly when dynamically change min-date', async () 
     minDate: new Date(2020, 11, 20),
   });
 
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
   expect(
     wrapper.emitted<[PickerConfirmEventParams]>('confirm')![0][0].selectedValues
   ).toEqual(['2020', '12', '20']);

--- a/packages/vant/src/picker/Picker.tsx
+++ b/packages/vant/src/picker/Picker.tsx
@@ -2,6 +2,7 @@ import {
   ref,
   watch,
   computed,
+  nextTick,
   defineComponent,
   type PropType,
   type ExtractPropTypes,
@@ -162,7 +163,13 @@ export default defineComponent({
     const confirm = () => {
       children.forEach((child) => child.stopMomentum());
       const params = getEventParams();
-      emit('confirm', params);
+
+      // wait nextTick to ensure the model value is update to date
+      // when confirm event is emitted
+      nextTick(() => {
+        emit('confirm', params);
+      });
+
       return params;
     };
 

--- a/packages/vant/src/picker/test/cascade.spec.ts
+++ b/packages/vant/src/picker/test/cascade.spec.ts
@@ -48,14 +48,14 @@ const cascadeColumns = [
   },
 ];
 
-test('should emit confirm event for cascade picker correctly', () => {
+test('should emit confirm event for cascade picker correctly', async () => {
   const wrapper = mount(Picker, {
     props: {
       columns: cascadeColumns,
     },
   });
 
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
 
   const params = wrapper.emitted<PickerConfirmEventParams[]>('confirm')?.[0];
   expect(params?.[0].selectedValues).toEqual(['A1', 'B1', 'C1']);

--- a/packages/vant/src/picker/test/index.spec.tsx
+++ b/packages/vant/src/picker/test/index.spec.tsx
@@ -10,7 +10,7 @@ const simpleColumn = [
   { text: '1995', value: '1995' },
 ];
 
-test('should emit confirm event after clicking the confirm button', () => {
+test('should emit confirm event after clicking the confirm button', async () => {
   const wrapper = mount(Picker, {
     props: {
       showToolbar: true,
@@ -18,7 +18,7 @@ test('should emit confirm event after clicking the confirm button', () => {
     },
   });
 
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
   expect(wrapper.emitted('confirm')![0]).toEqual([
     {
       selectedOptions: [{ text: '1990', value: '1990' }],
@@ -178,7 +178,7 @@ test('should allow to update columns props dynamically', async () => {
     ],
   });
 
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
   expect(wrapper.emitted<[string, number]>('confirm')![0]).toEqual([
     { selectedOptions: [{ text: '2', value: '2' }], selectedValues: ['2'] },
   ]);

--- a/packages/vant/src/time-picker/test/index.spec.tsx
+++ b/packages/vant/src/time-picker/test/index.spec.tsx
@@ -61,14 +61,14 @@ test('should format options correctly when using formatter prop', async () => {
   expect(wrapper.html()).toMatchSnapshot();
 });
 
-test('should emit confirm event after clicking the confirm button', () => {
+test('should emit confirm event after clicking the confirm button', async () => {
   const wrapper = mount(TimePicker, {
     props: {
       modelValue: ['12', '00'],
     },
   });
 
-  wrapper.find('.van-picker__confirm').trigger('click');
+  await wrapper.find('.van-picker__confirm').trigger('click');
   expect(wrapper.emitted('confirm')).toEqual([
     [
       {


### PR DESCRIPTION
close https://github.com/youzan/vant/issues/11186