### PR TITLE
fix(ActionSheet): fix that close is invalid without title

### DIFF
--- a/packages/vant/src/action-sheet/index.less
+++ b/packages/vant/src/action-sheet/index.less
@@ -123,6 +123,7 @@
     position: absolute;
     top: 0;
     right: 0;
+    z-index: 1;
     padding: var(--van-action-sheet-close-icon-padding);
     color: var(--van-action-sheet-close-icon-color);
     font-size: var(--van-action-sheet-close-icon-size);


### PR DESCRIPTION
fix: https://github.com/youzan/vant/issues/11211

`ActionSheet`在苹果手机上只有`close`图标时（title设置一个空格），无法关闭。
该问题在2.x及3.x都存在（2.x稍后修复）。