### PR TITLE
fix(lazyload): lazy-image h is not a function

### DIFF
--- a/packages/vant/src/lazyload/vue-lazyload/lazy-image.js
+++ b/packages/vant/src/lazyload/vue-lazyload/lazy-image.js
@@ -6,6 +6,7 @@
 import { useRect } from '@vant/use';
 import { loadImageAsync } from './util';
 import { noop } from '../../utils';
+import { h } from 'vue';
 
 export default (lazyManager) => ({
   props: {
@@ -15,15 +16,13 @@ export default (lazyManager) => ({
       default: 'img',
     },
   },
-  render(h) {
+  render() {
     return h(
       this.tag,
       {
-        attrs: {
-          src: this.renderSrc,
-        },
+        src: this.renderSrc,
       },
-      this.$slots.default
+      this.$slots.default?.()
     );
   },
   data() {


### PR DESCRIPTION
in vue 3.x h is not function. this.$slots.default is  a function.

[vue 3.x refs render-function-api-change](https://github.com/vuejs/rfcs/blob/master/active-rfcs/0008-render-function-api-change.md) 
[vue 3.x docs h](https://cn.vuejs.org/api/render-function.html#h)

- reappear
- test

```vue
// vant/packages/vant/src/lazyload/demo/index.vue
<script lang="ts">
import Lazyload from '..';

if (window.app) {
  window.app.use(Lazyload, { lazyComponent: true, lazyImage: true });
}
</script>
<template>
   <demo-block :title="t('basicUsage')">
    <lazy-image v-for="img in imageList" :key="img" :src="img">
    </lazy-image>
  </demo-block>
</teamplate>
```