### PR TITLE
fix(2.x): search component @search-left-icon-color invalid & docs update

### DIFF
--- a/src/checkbox/demo/index.vue
+++ b/src/checkbox/demo/index.vue
@@ -15,7 +15,7 @@
 
     <demo-block :title="t('customShape')">
       <van-checkbox v-model="checkboxShape" shape="square">
-        {{ t('customColor') }}
+        {{ t('customShape') }}
       </van-checkbox>
     </demo-block>
 

--- a/src/checkbox/test/__snapshots__/demo.spec.js.snap
+++ b/src/checkbox/test/__snapshots__/demo.spec.js.snap
@@ -26,7 +26,7 @@ exports[`renders demo correctly 1`] = `
     <div role="checkbox" tabindex="0" aria-checked="true" class="van-checkbox">
       <div class="van-checkbox__icon van-checkbox__icon--square van-checkbox__icon--checked"><i class="van-icon van-icon-success">
           <!----></i></div><span class="van-checkbox__label">
-      自定义颜色
+      自定义形状
     </span>
     </div>
   </div>

--- a/src/form/README.zh-CN.md
+++ b/src/form/README.zh-CN.md
@@ -461,7 +461,7 @@ export default {
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | label-width | 表单项 label 宽度，默认单位为`px` | _number \| string_ | `6.2em` |
-| label-align |  表单项 label 对齐方式，可选值为 `center` `right` | _string_ | `left` |
+| label-align | 表单项 label 对齐方式，可选值为 `center` `right` | _string_ | `left` |
 | input-align | 输入框对齐方式，可选值为 `center` `right` | _string_ | `left` |
 | error-message-align | 错误提示文案对齐方式，可选值为 `center` `right` | _string_ | `left` |
 | validate-trigger `v2.5.2` | 表单校验触发时机，可选值为 `onChange`、`onSubmit`，详见下表 | _string_ | `onBlur` |

--- a/src/rate/README.zh-CN.md
+++ b/src/rate/README.zh-CN.md
@@ -116,7 +116,7 @@ export default {
 | void-icon | 未选中时的[图标名称](#/zh-CN/icon)或图片链接 | _string_ | `star-o` |
 | icon-prefix `v2.5.3` | 图标类名前缀，同 Icon 组件的 [class-prefix 属性](#/zh-CN/icon#props) | _string_ | `van-icon` |
 | allow-half | 是否允许半选 | _boolean_ | `false` |
-| readonly | 是否为只读状态  | _boolean_ | `false` |
+| readonly | 是否为只读状态 | _boolean_ | `false` |
 | disabled | 是否禁用评分 | _boolean_ | `false` |
 | touchable | 是否可以通过滑动手势选择评分 | _boolean_ | `true` |
 

--- a/src/search/index.less
+++ b/src/search/index.less
@@ -31,7 +31,7 @@
     padding: 5px @padding-xs 5px 0;
     background-color: transparent;
 
-    &__left-icon {
+    .van-field__left-icon {
       color: @search-left-icon-color;
     }
   }


### PR DESCRIPTION
## 自定义化 vant@2.x 时发现的一些错误 ==

### [fix(search): @search-left-icon-color invalid](https://github.com/youzan/vant/commit/8f0773fbb41b10ab4547388612e27b2f00cd9d2c)

- 修复 `.van-cell` 下 `&__left-icon` 类名选择器错误问题，导致search中icon未能作用到 `color: @search-left-icon-color`

### [docs(checkbox): update customShape content](https://github.com/youzan/vant/commit/2ddcdf4adc5eb059a09ef57bd660d9b949727ee9)

- 2.x 文档checkbox自定义形状类型组件文案错误

### [docs(checkbox): update customShape content](https://github.com/youzan/vant/commit/2ddcdf4adc5eb059a09ef57bd660d9b949727ee9)

- 2.x 文档部分非法字符移除