### PR TITLE
fix(Picker): picker loading color in dark theme

### DIFF
--- a/packages/vant/src/picker/index.less
+++ b/packages/vant/src/picker/index.less
@@ -22,6 +22,7 @@
 }
 
 .van-theme-dark {
+  --van-picker-loading-mask-color: rgba(0, 0, 0, 0.6);
   --van-picker-mask-color: linear-gradient(
       180deg,
       rgba(0, 0, 0, 0.6),


### PR DESCRIPTION
暗黑模式下遮罩颜色错误。

![image](https://user-images.githubusercontent.com/34850199/209112563-2f6d9273-024a-4a33-832b-18e7b1778675.png)
