### PR TITLE
fix(Locale): ru-RU: fix typo of "Calendar"

### DIFF
--- a/packages/vant/src/locale/lang/ru-RU.ts
+++ b/packages/vant/src/locale/lang/ru-RU.ts
@@ -13,7 +13,7 @@ export default {
   vanCalendar: {
     end: 'Конец',
     start: 'Начало',
-    title: 'Каленарь',
+    title: 'Календарь',
     weekdays: ['ВС', 'ПН', 'ВТ', 'СР', 'ЧТ', 'ПТ', 'СБ'],
     monthTitle: (year: number, month: number) => `${year}/${month}`,
     rangePrompt: (maxRange: number) => `Укажите более ${maxRange} дней`,


### PR DESCRIPTION
_First of all, thanks for your work. Vant is amazing, please keep going 👍_ 

**PR**: Fixed typo of "Calendar" in `ru-RU` locale.