### PR TITLE
fix(create-vant-cli-app): fix .gitignore template

### DIFF
--- a/packages/create-vant-cli-app/generators/vue3/.gitignore.tpl
+++ b/packages/create-vant-cli-app/generators/vue3/.gitignore.tpl
@@ -15,5 +15,5 @@ test/coverage
 es
 lib
 dist
-site
+**/site-dist
 changelog.generated.md


### PR DESCRIPTION
Directory `site-dist` rather than `site` was excluded from git.

Relative issue: https://github.com/youzan/vant/issues/11477