### PR TITLE
fix: change some colors to primary color

### DIFF
--- a/packages/vant/src/config-provider/README.md
+++ b/packages/vant/src/config-provider/README.md
@@ -262,7 +262,6 @@ There are all **Basic Variables** below, for component CSS Variables, please ref
 --van-text-color: var(--van-gray-8);
 --van-text-color-2: var(--van-gray-6);
 --van-text-color-3: var(--van-gray-5);
---van-link-color: #576b95;
 --van-active-color: var(--van-gray-2);
 --van-active-opacity: 0.6;
 --van-disabled-opacity: 0.5;

--- a/packages/vant/src/config-provider/README.zh-CN.md
+++ b/packages/vant/src/config-provider/README.zh-CN.md
@@ -262,7 +262,6 @@ Vant 中的 CSS 变量分为 **基础变量** 和 **组件变量**。组件变�
 --van-text-color: var(--van-gray-8);
 --van-text-color-2: var(--van-gray-6);
 --van-text-color-3: var(--van-gray-5);
---van-link-color: #576b95;
 --van-active-color: var(--van-gray-2);
 --van-active-opacity: 0.6;
 --van-disabled-opacity: 0.5;

--- a/packages/vant/src/number-keyboard/README.md
+++ b/packages/vant/src/number-keyboard/README.md
@@ -231,7 +231,7 @@ The component provides the following CSS variables, which can be used to customi
 | --van-number-keyboard-title-height | _34px_ | - |
 | --van-number-keyboard-title-font-size | _var(--van-font-size-lg)_ | - |
 | --van-number-keyboard-close-padding | _0 var(--van-padding-md)_ | - |
-| --van-number-keyboard-close-color | _var(--van-link-color)_ | - |
+| --van-number-keyboard-close-color | _var(--van-primary-color)_ | - |
 | --van-number-keyboard-close-font-size | _var(--van-font-size-md)_ | - |
 | --van-number-keyboard-button-text-color | _var(--van-white)_ | - |
 | --van-number-keyboard-button-background | _var(--van-primary-color)_ | - |

--- a/packages/vant/src/number-keyboard/README.zh-CN.md
+++ b/packages/vant/src/number-keyboard/README.zh-CN.md
@@ -238,7 +238,7 @@ import type { NumberKeyboardProps, NumberKeyboardTheme } from 'vant';
 | --van-number-keyboard-title-height      | _34px_                     | -    |
 | --van-number-keyboard-title-font-size   | _var(--van-font-size-lg)_  | -    |
 | --van-number-keyboard-close-padding     | _0 var(--van-padding-md)_  | -    |
-| --van-number-keyboard-close-color       | _var(--van-link-color)_    | -    |
+| --van-number-keyboard-close-color       | _var(--van-primary-color)_ | -    |
 | --van-number-keyboard-close-font-size   | _var(--van-font-size-md)_  | -    |
 | --van-number-keyboard-button-text-color | _var(--van-white)_         | -    |
 | --van-number-keyboard-button-background | _var(--van-primary-color)_ | -    |

--- a/packages/vant/src/number-keyboard/index.less
+++ b/packages/vant/src/number-keyboard/index.less
@@ -9,7 +9,7 @@
   --van-number-keyboard-title-height: 34px;
   --van-number-keyboard-title-font-size: var(--van-font-size-lg);
   --van-number-keyboard-close-padding: 0 var(--van-padding-md);
-  --van-number-keyboard-close-color: var(--van-link-color);
+  --van-number-keyboard-close-color: var(--van-primary-color);
   --van-number-keyboard-close-font-size: var(--van-font-size-md);
   --van-number-keyboard-button-text-color: var(--van-white);
   --van-number-keyboard-button-background: var(--van-primary-color);

--- a/packages/vant/src/picker/README.md
+++ b/packages/vant/src/picker/README.md
@@ -434,7 +434,7 @@ The component provides the following CSS variables, which can be used to customi
 | --van-picker-title-line-height | _var(--van-line-height-md)_ | - |
 | --van-picker-action-padding | _0 var(--van-padding-md)_ | - |
 | --van-picker-action-font-size | _var(--van-font-size-md)_ | - |
-| --van-picker-confirm-action-color | _var(--van-link-color)_ | - |
+| --van-picker-confirm-action-color | _var(--van-primary-color)_ | - |
 | --van-picker-cancel-action-color | _var(--van-text-color-2)_ | - |
 | --van-picker-option-padding | _0 var(--van-padding-base)_ | - |
 | --van-picker-option-font-size | _var(--van-font-size-lg)_ | - |

--- a/packages/vant/src/picker/README.zh-CN.md
+++ b/packages/vant/src/picker/README.zh-CN.md
@@ -455,7 +455,7 @@ pickerRef.value?.confirm();
 | --van-picker-title-line-height       | _var(--van-line-height-md)_ | -    |
 | --van-picker-action-padding          | _0 var(--van-padding-md)_   | -    |
 | --van-picker-action-font-size        | _var(--van-font-size-md)_   | -    |
-| --van-picker-confirm-action-color    | _var(--van-link-color)_     | -    |
+| --van-picker-confirm-action-color    | _var(--van-primary-color)_  | -    |
 | --van-picker-cancel-action-color     | _var(--van-text-color-2)_   | -    |
 | --van-picker-option-padding          | _0 var(--van-padding-base)_ | -    |
 | --van-picker-option-font-size        | _var(--van-font-size-lg)_   | -    |

--- a/packages/vant/src/picker/index.less
+++ b/packages/vant/src/picker/index.less
@@ -5,7 +5,7 @@
   --van-picker-title-line-height: var(--van-line-height-md);
   --van-picker-action-padding: 0 var(--van-padding-md);
   --van-picker-action-font-size: var(--van-font-size-md);
-  --van-picker-confirm-action-color: var(--van-link-color);
+  --van-picker-confirm-action-color: var(--van-primary-color);
   --van-picker-cancel-action-color: var(--van-text-color-2);
   --van-picker-option-font-size: var(--van-font-size-lg);
   --van-picker-option-padding: 0 var(--van-padding-base);

--- a/packages/vant/src/style/css-variables.less
+++ b/packages/vant/src/style/css-variables.less
@@ -29,7 +29,6 @@
   --van-text-color: var(--van-gray-8);
   --van-text-color-2: var(--van-gray-6);
   --van-text-color-3: var(--van-gray-5);
-  --van-link-color: #576b95;
   --van-active-color: var(--van-gray-2);
   --van-active-opacity: 0.6;
   --van-disabled-opacity: 0.5;


### PR DESCRIPTION
- The confirm button of the picker and number-keyboard components is not the primary color.

- Original color is not obvious in dark mode.

- `--van-link-color` is not in use except for these two components,  so if I delete it  from `css-variables.less`,  will it be break-change?