### PR TITLE
fix(create-vant-cli-app): prompt config bug

### DIFF
--- a/packages/create-vant-cli-app/src/generator.ts
+++ b/packages/create-vant-cli-app/src/generator.ts
@@ -52,14 +52,14 @@ export class VanGenerator {
   }
 
   async prompting() {
-    const inputs = await prompt<Record<string, string>>(PROMPTS);
-    console.log('inputs==>', inputs);
-    const preprocessor = inputs.preprocessor.toLowerCase();
-    const cssLang = preprocessor === 'sass' ? 'scss' : preprocessor;
+    return prompt<Record<string, string>>(PROMPTS).then((inputs) => {
+      const preprocessor = inputs.preprocessor.toLowerCase();
+      const cssLang = preprocessor === 'sass' ? 'scss' : preprocessor;
 
-    this.inputs.cssLang = cssLang;
-    this.inputs.vueVersion = inputs.vueVersion;
-    this.inputs.preprocessor = preprocessor;
+      this.inputs.cssLang = cssLang;
+      this.inputs.vueVersion = inputs.vueVersion;
+      this.inputs.preprocessor = preprocessor;
+    });
   }
 
   writing() {

--- a/packages/create-vant-cli-app/src/generator.ts
+++ b/packages/create-vant-cli-app/src/generator.ts
@@ -13,12 +13,12 @@ const PROMPTS = [
     type: 'select',
     choices: [
       {
-        name: 'Vue 2',
-        value: 'vue2',
+        name: 'vue2',
+        message: 'Vue 2',
       },
       {
-        name: 'Vue 3',
-        value: 'vue3',
+        name: 'vue3',
+        message: 'Vue 3',
       },
     ],
   },
@@ -52,14 +52,14 @@ export class VanGenerator {
   }
 
   async prompting() {
-    return prompt<Record<string, string>>(PROMPTS).then((inputs) => {
-      const preprocessor = inputs.preprocessor.toLowerCase();
-      const cssLang = preprocessor === 'sass' ? 'scss' : preprocessor;
+    const inputs = await prompt<Record<string, string>>(PROMPTS);
+    console.log('inputs==>', inputs);
+    const preprocessor = inputs.preprocessor.toLowerCase();
+    const cssLang = preprocessor === 'sass' ? 'scss' : preprocessor;
 
-      this.inputs.cssLang = cssLang;
-      this.inputs.vueVersion = inputs.vueVersion;
-      this.inputs.preprocessor = preprocessor;
-    });
+    this.inputs.cssLang = cssLang;
+    this.inputs.vueVersion = inputs.vueVersion;
+    this.inputs.preprocessor = preprocessor;
   }
 
   writing() {


### PR DESCRIPTION
# create-vant-cli-app bug

最新版本的create-vant-cli-app 执行`npx create-vant-cli-app` 得到的是一个空文件夹

替换enquirer的时候 choices的配置写错了

![image](https://user-images.githubusercontent.com/12869626/212867219-784fe2f1-87d3-44c0-bb58-c05d2c3fdd40.png)

