### PR TITLE
fix(Space): Text is not defined in SSR

### DIFF
--- a/packages/vant/src/space/Space.tsx
+++ b/packages/vant/src/space/Space.tsx
@@ -1,10 +1,12 @@
 import {
   computed,
+  Comment,
   CSSProperties,
   defineComponent,
   ExtractPropTypes,
   Fragment,
   PropType,
+  Text,
   type VNode,
 } from 'vue';
 import { createNamespace } from '../utils';
@@ -47,7 +49,7 @@ function filterEmpty(children: VNode[] = []) {
     (c) =>
       !(
         c &&
-        ((typeof Comment !== 'undefined' && c.type === Comment) ||
+        (c.type === Comment ||
           (c.type === Fragment && c.children?.length === 0) ||
           (c.type === Text && (c.children as string).trim() === ''))
       )


### PR DESCRIPTION
在SSR中使用 Space 组件时报错 `Text is not defined`

[相关代码](https://github.com/youzan/vant/blob/main/packages/vant/src/space/Space.tsx#L52)

在过滤 VNode 时，Comment 和 Text 应该是来自 vue 而不是全局