### PR TITLE
fix(popover): location update

### DIFF
--- a/src/popover/index.js
+++ b/src/popover/index.js
@@ -1,5 +1,5 @@
 import { createPopper, offsetModifier } from '@vant/popperjs';
-import { createNamespace } from '../utils';
+import { createNamespace, isServer } from '../utils';
 import { BORDER_BOTTOM } from '../utils/constant';
 
 // Mixins
@@ -60,8 +60,10 @@ export default createComponent({
 
   beforeDestroy() {
     if (this.popper) {
-      window.removeEventListener('animationend', this.popper.update);
-      window.removeEventListener('transitionend', this.popper.update);
+      if (!isServer) {
+        window.removeEventListener('animationend', this.updateLocation);
+        window.removeEventListener('transitionend', this.updateLocation);
+      }
       this.popper.destroy();
       this.popper = null;
     }
@@ -87,8 +89,10 @@ export default createComponent({
           },
         ],
       });
-      window.addEventListener('animationend', popper.update);
-      window.addEventListener('transitionend', popper.update);
+      if (!isServer) {
+        window.addEventListener('animationend', this.updateLocation);
+        window.addEventListener('transitionend', this.updateLocation);
+      }
       return popper;
     },
 

--- a/src/popover/index.js
+++ b/src/popover/index.js
@@ -60,6 +60,8 @@ export default createComponent({
 
   beforeDestroy() {
     if (this.popper) {
+      window.removeEventListener('animationend', this.popper.update);
+      window.removeEventListener('transitionend', this.popper.update);
       this.popper.destroy();
       this.popper = null;
     }
@@ -67,7 +69,7 @@ export default createComponent({
 
   methods: {
     createPopper() {
-      return createPopper(this.$refs.wrapper, this.$refs.popover.$el, {
+      const popper = createPopper(this.$refs.wrapper, this.$refs.popover.$el, {
         placement: this.placement,
         modifiers: [
           {
@@ -85,6 +87,9 @@ export default createComponent({
           },
         ],
       });
+      window.addEventListener('animationend', popper.update);
+      window.addEventListener('transitionend', popper.update);
+      return popper;
     },
 
     updateLocation() {


### PR DESCRIPTION
close #8564 
故障原因：
`<transition>`对元素使用animation导致位置更新不及时。
由于不知道哪个元素的animation会导致位置popover位置变化，所以这里监听的window的animationend事件。
要使popover的位置根据animation实时跟进似乎没有很好的api可用，唯一能想到的是animationstart事件后用settimeout隔一段时间更新，直到animationend或animationcancel事件触发，不过这应该由上游依赖`popover.js`解决。