### PR TITLE
fix(docs): ✏️ 修复 Dialog 组件文档示例的问题

### DIFF
--- a/packages/vant/src/dialog/README.zh-CN.md
+++ b/packages/vant/src/dialog/README.zh-CN.md
@@ -305,7 +305,9 @@ Vant 从 4.0 版本开始不再支持 `babel-plugin-import` 插件，请参考 [
 将 `closeOnPopstate` 属性设置为 false 即可。
 
 ```js
-Dialog.alert({
+import { showDialog } from 'vant';
+
+showDialog({
   title: '标题',
   message: '弹窗内容',
   closeOnPopstate: false,


### PR DESCRIPTION
发现了一处文档代码示例错误

问题描述：Vant4.x 里的 Dialog 组件文档，“常见问题”的[第二个示例](http://vant-contrib.gitee.io/vant/#/zh-CN/dialog#zai-beforerouteleave-li-diao-yong-dialog-wu-fa-zhan-shi)代码是有问题的。对此进行了代码示例调整。