### PR TITLE
fix(TextEllipsis): failed to inherit attrs

### DIFF
--- a/packages/vant/src/text-ellipsis/TextEllipsis.tsx
+++ b/packages/vant/src/text-ellipsis/TextEllipsis.tsx
@@ -26,8 +26,6 @@ export type TextEllipsisProps = ExtractPropTypes<typeof textEllipsisProps>;
 export default defineComponent({
   name,
 
-  inheritAttrs: false,
-
   props: textEllipsisProps,
 
   emits: ['clickAction'],
@@ -120,9 +118,7 @@ export default defineComponent({
       </span>
     );
 
-    onMounted(() => {
-      calcEllipsised();
-    });
+    onMounted(calcEllipsised);
 
     watch(() => [props.content, props.rows], calcEllipsised);
 


### PR DESCRIPTION
We should allow `TextEllipsis` to inherit attrs, such as custom styles.

```html
<van-text-ellipsis context="..." style="font-size: 20px;" />
```