### PR TITLE
feat(Swipe): add index when trigger onDragStart or onDragEnd

### DIFF
--- a/packages/vant/src/swipe/README.md
+++ b/packages/vant/src/swipe/README.md
@@ -161,8 +161,8 @@ export default {
 | Event | Description | Arguments |
 | --- | --- | --- |
 | change | Emitted when current swipe changed | _index: number_ |
-| drag-start `v4.0.9` | Emitted when user starts dragging the swipe | - |
-| drag-end `v4.0.9` | Emitted when user ends dragging the swipe | - |
+| drag-start `v4.0.9` | Emitted when user starts dragging the swipe | _index: number_ |
+| drag-end `v4.0.9` | Emitted when user ends dragging the swipe | _index: number_ |
 
 ### SwipeItem Events
 

--- a/packages/vant/src/swipe/README.md
+++ b/packages/vant/src/swipe/README.md
@@ -161,8 +161,8 @@ export default {
 | Event | Description | Arguments |
 | --- | --- | --- |
 | change | Emitted when current swipe changed | _index: number_ |
-| drag-start `v4.0.9` | Emitted when user starts dragging the swipe | _index: number_ |
-| drag-end `v4.0.9` | Emitted when user ends dragging the swipe | _index: number_ |
+| drag-start `v4.0.9` | Emitted when user starts dragging the swipe | _{ index: number }_ |
+| drag-end `v4.0.9` | Emitted when user ends dragging the swipe | _{ index: number }_ |
 
 ### SwipeItem Events
 

--- a/packages/vant/src/swipe/README.zh-CN.md
+++ b/packages/vant/src/swipe/README.zh-CN.md
@@ -169,8 +169,8 @@ export default {
 | 事件名              | 说明                         | 回调参数        |
 | ------------------- | ---------------------------- | --------------- |
 | change              | 每一页轮播结束后触发         | _index: number_ |
-| drag-start `v4.0.9` | 当用户开始拖动轮播组件时触发 | -               |
-| drag-end `v4.0.9`   | 当用户结束拖动轮播组件时触发 | -               |
+| drag-start `v4.0.9` | 当用户开始拖动轮播组件时触发 | _index: number_ |
+| drag-end `v4.0.9`   | 当用户结束拖动轮播组件时触发 | _index: number_ |
 
 ### SwipeItem Events
 

--- a/packages/vant/src/swipe/README.zh-CN.md
+++ b/packages/vant/src/swipe/README.zh-CN.md
@@ -166,11 +166,11 @@ export default {
 
 ### Swipe Events
 
-| 事件名              | 说明                         | 回调参数        |
-| ------------------- | ---------------------------- | --------------- |
-| change              | 每一页轮播结束后触发         | _index: number_ |
-| drag-start `v4.0.9` | 当用户开始拖动轮播组件时触发 | _index: number_ |
-| drag-end `v4.0.9`   | 当用户结束拖动轮播组件时触发 | _index: number_ |
+| 事件名              | 说明                         | 回调参数            |
+| ------------------- | ---------------------------- | ------------------- |
+| change              | 每一页轮播结束后触发         | _index: number_     |
+| drag-start `v4.0.9` | 当用户开始拖动轮播组件时触发 | _{ index: number }_ |
+| drag-end `v4.0.9`   | 当用户结束拖动轮播组件时触发 | _{ index: number }_ |
 
 ### SwipeItem Events
 

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -333,7 +333,7 @@ export default defineComponent({
             move({ offset: delta.value });
 
             if (!dragging) {
-              emit('dragStart', activeIndicator.value);
+              emit('dragStart', { index: activeIndicator.value });
               dragging = true;
             }
           }
@@ -377,7 +377,7 @@ export default defineComponent({
       dragging = false;
       state.swiping = false;
 
-      emit('dragEnd', activeIndicator.value);
+      emit('dragEnd', { index: activeIndicator.value });
       autoplay();
     };
 

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -333,7 +333,7 @@ export default defineComponent({
             move({ offset: delta.value });
 
             if (!dragging) {
-              emit('dragStart');
+              emit('dragStart', activeIndicator.value);
               dragging = true;
             }
           }
@@ -377,7 +377,7 @@ export default defineComponent({
       dragging = false;
       state.swiping = false;
 
-      emit('dragEnd');
+      emit('dragEnd', activeIndicator.value);
       autoplay();
     };
 

--- a/packages/vant/src/swipe/test/index.spec.jsx
+++ b/packages/vant/src/swipe/test/index.spec.jsx
@@ -350,13 +350,13 @@ test('should emit drag-start and drag-end events correctly', async () => {
 
   await triggerDrag(track, 100, 0);
   expect(dragStart).toHaveBeenCalledTimes(1);
-  expect(dragStart).toHaveBeenCalledWith(0);
+  expect(dragStart).toHaveBeenCalledWith({ index: 0 });
   expect(dragEnd).toHaveBeenCalledTimes(1);
-  expect(dragEnd).toHaveBeenCalledWith(1);
+  expect(dragEnd).toHaveBeenCalledWith({ index: 1 });
 
   await triggerDrag(track, 100, 0);
   expect(dragStart).toHaveBeenCalledTimes(2);
-  expect(dragStart).toHaveBeenCalledWith(1);
+  expect(dragStart).toHaveBeenCalledWith({ index: 1 });
   expect(dragEnd).toHaveBeenCalledTimes(2);
-  expect(dragEnd).toHaveBeenCalledWith(0);
+  expect(dragEnd).toHaveBeenCalledWith({ index: 0 });
 });

--- a/packages/vant/src/swipe/test/index.spec.jsx
+++ b/packages/vant/src/swipe/test/index.spec.jsx
@@ -350,9 +350,13 @@ test('should emit drag-start and drag-end events correctly', async () => {
 
   await triggerDrag(track, 100, 0);
   expect(dragStart).toHaveBeenCalledTimes(1);
+  expect(dragStart).toHaveBeenCalledWith(0);
   expect(dragEnd).toHaveBeenCalledTimes(1);
+  expect(dragEnd).toHaveBeenCalledWith(1);
 
   await triggerDrag(track, 100, 0);
   expect(dragStart).toHaveBeenCalledTimes(2);
+  expect(dragStart).toHaveBeenCalledWith(1);
   expect(dragEnd).toHaveBeenCalledTimes(2);
+  expect(dragEnd).toHaveBeenCalledWith(0);
 });


### PR DESCRIPTION
有些时候我并不关心 Swipe 播放到哪一个位置，但是如果用户自己去操作轮播时，我关心他朝着哪个方向滑动或者用户期望看到第几页(为此我不得不添加 onChange 事件去记录播放位置)。
我对 Swipe 组件中 onDragStart 和 onDragEnd 两个事件添加了 index 参数。