### PR TITLE
fix(Row): fix gutter of row

### DIFF
--- a/packages/vant/src/col/Col.tsx
+++ b/packages/vant/src/col/Col.tsx
@@ -1,11 +1,20 @@
-import { computed, defineComponent, type ExtractPropTypes } from 'vue';
 import {
+  computed,
+  defineComponent,
+  type CSSProperties,
+  type ExtractPropTypes,
+} from 'vue';
+
+import {
+  addUnit,
   numericProp,
   createNamespace,
   makeNumericProp,
   makeStringProp,
 } from '../utils';
+
 import { useParent } from '@vant/use';
+
 import { ROW_KEY } from '../row/Row';
 
 const [name, bem] = createNamespace('col');
@@ -24,22 +33,23 @@ export default defineComponent({
   props: colProps,
 
   setup(props, { slots }) {
-    const { parent, index } = useParent(ROW_KEY);
+    const { parent } = useParent(ROW_KEY);
 
     const style = computed(() => {
       if (!parent) {
         return;
       }
 
-      const { spaces } = parent;
+      const { gutter } = parent;
+      const styles: CSSProperties = {};
 
-      if (spaces && spaces.value && spaces.value[index.value]) {
-        const { left, right } = spaces.value[index.value];
-        return {
-          paddingLeft: left ? `${left}px` : null,
-          paddingRight: right ? `${right}px` : null,
-        };
+      if (gutter) {
+        const halfGutter = Number(gutter) / 2;
+        styles.paddingLeft = addUnit(halfGutter);
+        styles.paddingRight = addUnit(halfGutter);
       }
+
+      return styles;
     });
 
     return () => {

--- a/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
@@ -28,18 +28,20 @@ exports[`should render demo and match snapshot 1`] = `
   </div>
 </div>
 <div>
-  <div class="van-row">
-    <div class="van-col van-col--8"
-         style="padding-right: 13.333333333333334px;"
-    >
-      span: 8
-    </div>
-    <div style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
+  <div style="margin-left: -10px; margin-right: -10px;"
+       class="van-row"
+  >
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       span: 8
     </div>
-    <div style="padding-left: 13.333333333333332px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
+    >
+      span: 8
+    </div>
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       span: 8

--- a/packages/vant/src/col/test/__snapshots__/index.spec.tsx.snap
+++ b/packages/vant/src/col/test/__snapshots__/index.spec.tsx.snap
@@ -6,71 +6,85 @@ exports[`should render Col correctly 1`] = `
 `;
 
 exports[`should render gutter correctly 1`] = `
-<div class="van-row">
-  <div class="van-col van-col--24">
+<div style="margin-left: -12px; margin-right: -12px;"
+     class="van-row"
+>
+  <div style="padding-left: 12px; padding-right: 12px;"
+       class="van-col van-col--24"
+  >
     24
   </div>
-  <div class="van-col van-col--12">
-    12
-  </div>
-  <div style="padding-left: 12px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--12"
   >
     12
   </div>
-  <div class="van-col van-col--8">
-    8
+  <div style="padding-left: 12px; padding-right: 12px;"
+       class="van-col van-col--12"
+  >
+    12
   </div>
-  <div style="padding-left: 12px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--8"
   >
     8
   </div>
-  <div style="padding-left: 16px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--8"
   >
     8
   </div>
-  <div class="van-col van-col--6">
-    6
+  <div style="padding-left: 12px; padding-right: 12px;"
+       class="van-col van-col--8"
+  >
+    8
   </div>
-  <div style="padding-left: 12px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--6"
   >
     6
   </div>
-  <div style="padding-left: 16px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--6"
   >
     6
   </div>
-  <div style="padding-left: 18px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--6"
   >
     6
   </div>
-  <div class="van-col van-col--7">
+  <div style="padding-left: 12px; padding-right: 12px;"
+       class="van-col van-col--6"
+  >
+    6
+  </div>
+  <div style="padding-left: 12px; padding-right: 12px;"
+       class="van-col van-col--7"
+  >
     7
   </div>
-  <div style="padding-left: 12px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--6"
   >
     6
   </div>
-  <div style="padding-left: 16px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--5"
   >
     5
   </div>
-  <div style="padding-left: 18px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--4"
   >
     4
   </div>
-  <div class="van-col van-col--3">
+  <div style="padding-left: 12px; padding-right: 12px;"
+       class="van-col van-col--3"
+  >
     3
   </div>
-  <div style="padding-left: 12px;"
+  <div style="padding-left: 12px; padding-right: 12px;"
        class="van-col van-col--2"
   >
     2

--- a/packages/vant/src/image/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/image/test/__snapshots__/demo.spec.ts.snap
@@ -17,9 +17,11 @@ exports[`should render demo and match snapshot 1`] = `
   </div>
 </div>
 <div>
-  <div class="van-row">
-    <div class="van-col van-col--8"
-         style="padding-right: 13.333333333333334px;"
+  <div style="margin-left: -10px; margin-right: -10px;"
+       class="van-row"
+  >
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image"
            style="width: 100%; height: 27vw;"
@@ -37,7 +39,7 @@ exports[`should render demo and match snapshot 1`] = `
         contain
       </div>
     </div>
-    <div style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -56,7 +58,7 @@ exports[`should render demo and match snapshot 1`] = `
         cover
       </div>
     </div>
-    <div style="padding-left: 13.333333333333332px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -75,8 +77,8 @@ exports[`should render demo and match snapshot 1`] = `
         fill
       </div>
     </div>
-    <div class="van-col van-col--8"
-         style="padding-right: 10px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image"
            style="width: 100%; height: 27vw;"
@@ -94,7 +96,7 @@ exports[`should render demo and match snapshot 1`] = `
         none
       </div>
     </div>
-    <div style="padding-left: 10px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -116,9 +118,11 @@ exports[`should render demo and match snapshot 1`] = `
   </div>
 </div>
 <div>
-  <div class="van-row">
-    <div class="van-col van-col--8"
-         style="padding-right: 13.333333333333334px;"
+  <div style="margin-left: -10px; margin-right: -10px;"
+       class="van-row"
+  >
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image"
            style="width: 100%; height: 27vw;"
@@ -139,7 +143,7 @@ exports[`should render demo and match snapshot 1`] = `
         left
       </div>
     </div>
-    <div style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -161,7 +165,7 @@ exports[`should render demo and match snapshot 1`] = `
         center
       </div>
     </div>
-    <div style="padding-left: 13.333333333333332px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -183,8 +187,8 @@ exports[`should render demo and match snapshot 1`] = `
         right
       </div>
     </div>
-    <div class="van-col van-col--8"
-         style="padding-right: 13.333333333333334px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image"
            style="width: 100%; height: 27vw;"
@@ -205,7 +209,7 @@ exports[`should render demo and match snapshot 1`] = `
         top
       </div>
     </div>
-    <div style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -227,7 +231,7 @@ exports[`should render demo and match snapshot 1`] = `
         center
       </div>
     </div>
-    <div style="padding-left: 13.333333333333332px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -252,9 +256,11 @@ exports[`should render demo and match snapshot 1`] = `
   </div>
 </div>
 <div>
-  <div class="van-row">
-    <div class="van-col van-col--8"
-         style="padding-right: 13.333333333333334px;"
+  <div style="margin-left: -10px; margin-right: -10px;"
+       class="van-row"
+  >
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image van-image--round"
            style="width: 100%; height: 27vw;"
@@ -272,7 +278,7 @@ exports[`should render demo and match snapshot 1`] = `
         contain
       </div>
     </div>
-    <div style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image van-image--round"
@@ -291,7 +297,7 @@ exports[`should render demo and match snapshot 1`] = `
         cover
       </div>
     </div>
-    <div style="padding-left: 13.333333333333332px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image van-image--round"
@@ -310,8 +316,8 @@ exports[`should render demo and match snapshot 1`] = `
         fill
       </div>
     </div>
-    <div class="van-col van-col--8"
-         style="padding-right: 10px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image van-image--round"
            style="width: 100%; height: 27vw;"
@@ -329,7 +335,7 @@ exports[`should render demo and match snapshot 1`] = `
         none
       </div>
     </div>
-    <div style="padding-left: 10px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image van-image--round"
@@ -351,9 +357,11 @@ exports[`should render demo and match snapshot 1`] = `
   </div>
 </div>
 <div>
-  <div class="van-row">
-    <div class="van-col van-col--8"
-         style="padding-right: 10px;"
+  <div style="margin-left: -10px; margin-right: -10px;"
+       class="van-row"
+  >
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image"
            style="width: 100%; height: 27vw;"
@@ -367,7 +375,7 @@ exports[`should render demo and match snapshot 1`] = `
         Default Tip
       </div>
     </div>
-    <div style="padding-left: 10px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"
@@ -416,9 +424,11 @@ exports[`should render demo and match snapshot 1`] = `
   </div>
 </div>
 <div>
-  <div class="van-row">
-    <div class="van-col van-col--8"
-         style="padding-right: 10px;"
+  <div style="margin-left: -10px; margin-right: -10px;"
+       class="van-row"
+  >
+    <div style="padding-left: 10px; padding-right: 10px;"
+         class="van-col van-col--8"
     >
       <div class="van-image"
            style="width: 100%; height: 27vw;"
@@ -435,7 +445,7 @@ exports[`should render demo and match snapshot 1`] = `
         Default Tip
       </div>
     </div>
-    <div style="padding-left: 10px;"
+    <div style="padding-left: 10px; padding-right: 10px;"
          class="van-col van-col--8"
     >
       <div class="van-image"


### PR DESCRIPTION
close: https://github.com/youzan/vant/issues/11638

这个改动有些大，相当于换了种方式。原有的实现方式感觉相对复杂吧（groups 那块），再加上换行情况下会发生错位问题。

目前改的这种方式也是 bootstrap 和 element-plus 的实现方式，感觉看上去清晰些。
https://v5.bootcss.com/docs/layout/gutters/
![image](https://user-images.githubusercontent.com/19986739/222698043-6166fb30-5944-44ca-acce-c4dd1a933d4f.png)

请大佬 check
