### PR TITLE
fix(DropdownMenu): fix dropdown-item position when expanded by default

### DIFF
--- a/packages/vant/src/dropdown-item/DropdownItem.tsx
+++ b/packages/vant/src/dropdown-item/DropdownItem.tsx
@@ -100,6 +100,7 @@ export default defineComponent({
       state.transition = !options.immediate;
 
       if (show) {
+        parent.updateOffset();
         state.showWrapper = true;
       }
     };

--- a/packages/vant/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/vant/src/dropdown-menu/DropdownMenu.tsx
@@ -143,7 +143,7 @@ export default defineComponent({
       );
     };
 
-    linkChildren({ id, props, offset });
+    linkChildren({ id, props, offset, updateOffset });
     useClickAway(root, onClickAway);
     useEventListener('scroll', onScroll, {
       target: scrollParent,

--- a/packages/vant/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/vant/src/dropdown-menu/DropdownMenu.tsx
@@ -103,7 +103,6 @@ export default defineComponent({
     const toggleItem = (active: number) => {
       children.forEach((item, index) => {
         if (index === active) {
-          updateOffset();
           item.toggle();
         } else if (item.state.showPopup) {
           item.toggle(false, { immediate: true });

--- a/packages/vant/src/dropdown-menu/types.ts
+++ b/packages/vant/src/dropdown-menu/types.ts
@@ -7,6 +7,7 @@ export type DropdownMenuProvide = {
   id: string;
   props: DropdownMenuProps;
   offset: Ref<number>;
+  updateOffset: () => void;
 };
 
 export type DropdownMenuThemeVars = {


### PR DESCRIPTION
close: https://github.com/youzan/vant/issues/11637

改的时候发现，如果通过**外部按钮**控制菜单项下拉是否显示时，会和`close-on-click-outside=true`的情况下冲突。

https://github.com/youzan/vant/blob/c63fee0d13b360b2ea911e8a1a707648e8239a1e/packages/vant/src/dropdown-menu/DropdownMenu.tsx#L78