### PR TITLE
fix(@vant/cli): replace vue file import causing duplicate suffixes

### DIFF
--- a/packages/vant-cli/src/compiler/get-deps.ts
+++ b/packages/vant-cli/src/compiler/get-deps.ts
@@ -116,7 +116,7 @@ export function replaceScriptImportExt(
 
   imports.forEach((line, index) => {
     if (line.includes('.vue')) {
-      updateImport(index, line.replace('.vue', ''));
+      updateImport(index, line.replace('.vue', ext));
     }
   });
 
@@ -126,6 +126,12 @@ export function replaceScriptImportExt(
       if (isStyleImport) {
         return;
       }
+
+      const isExistExt = line.includes(ext);
+      if (isExistExt) {
+        return;
+      }
+
 
       const pathInfo = getPathByImport(line, filePath);
 

--- a/packages/vant-cli/src/compiler/get-deps.ts
+++ b/packages/vant-cli/src/compiler/get-deps.ts
@@ -116,7 +116,7 @@ export function replaceScriptImportExt(
 
   imports.forEach((line, index) => {
     if (line.includes('.vue')) {
-      updateImport(index, line.replace('.vue', ext));
+      updateImport(index, line.replace('.vue', ''));
     }
   });
 


### PR DESCRIPTION
编译 `mjs` 或者 `cjs` 时，  替换 vue 文件导入出现重复后缀