### PR TITLE
Correct typo "Filed" in "Field"

### DIFF
--- a/packages/vant/src/cascader/types.ts
+++ b/packages/vant/src/cascader/types.ts
@@ -7,7 +7,7 @@ export type CascaderOption = {
   disabled?: boolean;
   children?: CascaderOption[];
   className?: unknown;
-  // for custom filed names
+  // for custom field names
   [key: PropertyKey]: any;
 };
 

--- a/packages/vant/src/field/README.md
+++ b/packages/vant/src/field/README.md
@@ -340,7 +340,7 @@ import type {
   FieldClearTrigger,
   FieldFormatTrigger,
   FieldRuleValidator,
-  FiledRuleFormatter,
+  FieldRuleFormatter,
   FieldValidateError,
   FieldAutosizeConfig,
   FieldValidateTrigger,

--- a/packages/vant/src/field/README.zh-CN.md
+++ b/packages/vant/src/field/README.zh-CN.md
@@ -359,7 +359,7 @@ import type {
   FieldClearTrigger,
   FieldFormatTrigger,
   FieldRuleValidator,
-  FiledRuleFormatter,
+  FieldRuleFormatter,
   FieldValidateError,
   FieldAutosizeConfig,
   FieldValidateTrigger,

--- a/packages/vant/src/field/index.ts
+++ b/packages/vant/src/field/index.ts
@@ -15,7 +15,7 @@ export type {
   FieldClearTrigger,
   FieldFormatTrigger,
   FieldRuleValidator,
-  FiledRuleFormatter,
+  FieldRuleFormatter,
   FieldValidateError,
   FieldAutosizeConfig,
   FieldValidateTrigger,

--- a/packages/vant/src/field/types.ts
+++ b/packages/vant/src/field/types.ts
@@ -55,7 +55,7 @@ export type FieldRuleValidator = (
   rule: FieldRule
 ) => boolean | string | Promise<boolean | string>;
 
-export type FiledRuleFormatter = (value: any, rule: FieldRule) => string;
+export type FieldRuleFormatter = (value: any, rule: FieldRule) => string;
 
 export type FieldRule = {
   pattern?: RegExp;
@@ -63,7 +63,7 @@ export type FieldRule = {
   message?: FieldRuleMessage;
   required?: boolean;
   validator?: FieldRuleValidator;
-  formatter?: FiledRuleFormatter;
+  formatter?: FieldRuleFormatter;
   validateEmpty?: boolean;
 };
 

--- a/packages/vant/src/picker/types.ts
+++ b/packages/vant/src/picker/types.ts
@@ -17,7 +17,7 @@ export type PickerOption = {
   disabled?: boolean;
   children?: PickerColumn;
   className?: unknown;
-  // for custom filed names
+  // for custom field names
   [key: PropertyKey]: any;
 };
 

--- a/packages/vant/src/search/Search.tsx
+++ b/packages/vant/src/search/Search.tsx
@@ -54,7 +54,7 @@ export default defineComponent({
 
   setup(props, { emit, slots, attrs }) {
     const id = useId();
-    const filedRef = ref<FieldInstance>();
+    const fieldRef = ref<FieldInstance>();
 
     const onCancel = () => {
       if (!slots.action) {
@@ -99,8 +99,8 @@ export default defineComponent({
       }
     };
 
-    const blur = () => filedRef.value?.blur();
-    const focus = () => filedRef.value?.focus();
+    const blur = () => fieldRef.value?.blur();
+    const focus = () => fieldRef.value?.focus();
     const onBlur = (event: Event) => emit('blur', event);
     const onFocus = (event: Event) => emit('focus', event);
     const onClear = (event: MouseEvent) => emit('clear', event);
@@ -123,7 +123,7 @@ export default defineComponent({
       return (
         <Field
           v-slots={pick(slots, ['left-icon', 'right-icon'])}
-          ref={filedRef}
+          ref={fieldRef}
           type="search"
           class={bem('field')}
           border={false}


### PR DESCRIPTION
Correct typo "Filed" in "Field". It has small breaking change.

`FiledRuleFormatter` -> `FieldRuleFormatter`