### PR TITLE
fix(Field): should emit blur event when readonly

### DIFF
--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -397,13 +397,14 @@ export default defineComponent({
     };
 
     const onBlur = (event: Event) => {
+      state.focused = false;
+      updateValue(getModelValue(), 'onBlur');
+      emit('blur', event);
+
       if (getProp('readonly')) {
         return;
       }
 
-      state.focused = false;
-      updateValue(getModelValue(), 'onBlur');
-      emit('blur', event);
       validateWithTrigger('onBlur');
       nextTick(adjustTextareaSize);
       resetScroll();


### PR DESCRIPTION
an input with readonly attr can focus & blur, but it only emit focus event right now.