### PR TITLE
fix(ImagePreview): long vertical images sliding up and down

### DIFF
--- a/packages/vant/src/image-preview/ImagePreviewItem.tsx
+++ b/packages/vant/src/image-preview/ImagePreviewItem.tsx
@@ -188,7 +188,8 @@ export default defineComponent({
         // allow user to swipe to next image
         if (
           (moveX > maxMoveX.value || moveX < -maxMoveX.value) &&
-          !isImageMoved
+          !isImageMoved &&
+          touch.isHorizontal()
         ) {
           state.moving = false;
           return;


### PR DESCRIPTION
当一个长竖图被放大时，如果宽度没有填满屏幕，就很难上下滑动，是因为上下滑动的时候，左右只移动了一点就触发了这个判断(moveX > maxMoveX.value || moveX < -maxMoveX.value) &&!isImageMoved)，所以导致无法滑动