### PR TITLE
fix(ActionBar): set correct height when toggling diaplay

### DIFF
--- a/packages/vant/src/composables/use-placeholder.tsx
+++ b/packages/vant/src/composables/use-placeholder.tsx
@@ -1,12 +1,20 @@
-import { Ref } from 'vue';
-import { useHeight } from './use-height';
+import { type Ref, ref } from 'vue';
 import type { BEM } from '../utils/create';
+import { useRect } from '@vant/use';
+import { useHeight } from './use-height';
+import { useVisibilityChange } from './use-visibility-change';
 
 export function usePlaceholder(contentRef: Ref<Element | undefined>, bem: BEM) {
+  const root = ref<HTMLElement>();
   const height = useHeight(contentRef, true);
+
+  useVisibilityChange(root, () => {
+    height.value = useRect(contentRef).height;
+  });
 
   return (renderContent: () => JSX.Element) => (
     <div
+      ref={root}
       class={bem('placeholder')}
       style={{ height: height.value ? `${height.value}px` : undefined }}
     >


### PR DESCRIPTION
close: https://github.com/youzan/vant/issues/11704

感觉跟 https://github.com/youzan/vant/issues/11325 这个差不多，没放到`useHight`里是因为高度和显示隐藏Dom节点不一样...