### PR TITLE
chore(Watermark): rename font-color to text-color

### DIFF
--- a/packages/vant/src/watermark/README.md
+++ b/packages/vant/src/watermark/README.md
@@ -100,7 +100,7 @@ Use the `default` slot to pass HTML directly. Inline styles are supported, and s
 | full-page | Whether to display the watermark in full screen | _boolean_ | `true` |
 | gapX | Horizontal spacing between watermarks | _number_ | `0` |
 | gapY | Vertical spacing between watermarks | _number_ | `0` |
-| font-color | Color of text watermark | _string_ | `#dcdee0` |
+| text-color | Color of text watermark | _string_ | `#dcdee0` |
 | opacity | Opacity of watermark | _number \| string_ | - |
 
 ### Slots

--- a/packages/vant/src/watermark/README.zh-CN.md
+++ b/packages/vant/src/watermark/README.zh-CN.md
@@ -100,7 +100,7 @@ app.use(Watermark);
 | full-page | 水印是否全屏显示 | _boolean_ | `false` |
 | gapX | 水印之间的水平间隔 | _number_ | `0` |
 | gapY | 水印之间的垂直间隔 | _number_ | `0` |
-| font-color | 文字水印的颜色 | _string_ | `#dcdee0` |
+| text-color | 文字水印的颜色 | _string_ | `#dcdee0` |
 | opacity | 水印的透明度 | _number \| string_ | - |
 
 ### Slots

--- a/packages/vant/src/watermark/Watermark.tsx
+++ b/packages/vant/src/watermark/Watermark.tsx
@@ -31,7 +31,7 @@ export const watermarkProps = {
   content: String,
   opacity: numericProp,
   fullPage: truthProp,
-  fontColor: makeStringProp('#dcdee0'),
+  textColor: makeStringProp('#dcdee0'),
 };
 
 export type WatermarkProps = ExtractPropTypes<typeof watermarkProps>;
@@ -76,7 +76,7 @@ export default defineComponent({
               {props.content ? (
                 <span
                   style={{
-                    color: props.fontColor,
+                    color: props.textColor,
                   }}
                 >
                   {props.content}
@@ -140,7 +140,7 @@ export default defineComponent({
       () => [
         imageBase64.value,
         props.content,
-        props.fontColor,
+        props.textColor,
         props.height,
         props.width,
         props.rotate,
@@ -148,7 +148,11 @@ export default defineComponent({
         props.gapY,
       ],
       () => {
-        // 路径为 renderWatermark渲染的实际HTML => SVG字符串转换为blob图片 => 放到background-image中。
+        /**
+         * The path is the actual HTML rendered by renderWatermark
+         * => convert the SVG string to a blob image
+         * => put it in background-image.
+         */
         nextTick(() => {
           if (svgElRef.value) {
             if (watermarkUrl.value) {

--- a/packages/vant/src/watermark/test/index.spec.ts
+++ b/packages/vant/src/watermark/test/index.spec.ts
@@ -47,7 +47,7 @@ describe('watermark', () => {
     const wrapper = mount(Watermark, {
       props: {
         content: 'Vant',
-        fontColor: 'red',
+        textColor: 'red',
       },
     });
 


### PR DESCRIPTION
Keep the `text-color` prop name of the Watermark component consistent with other components.