### PR TITLE
fix(Swipe): should resize after props.width/height changed

### DIFF
--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -290,11 +290,7 @@ export default defineComponent({
       };
 
       // issue: https://github.com/vant-ui/vant/issues/10052
-      if (isHidden(root)) {
-        nextTick().then(cb);
-      } else {
-        cb();
-      }
+      nextTick().then(cb);
     };
 
     const resize = () => initialize(state.active);

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -457,7 +457,10 @@ export default defineComponent({
 
     watch(count, () => initialize(state.active));
     watch(() => props.autoplay, autoplay);
-    watch([windowWidth, windowHeight], () => nextTick().then(resize));
+    watch(
+      [windowWidth, windowHeight, () => props.width, () => props.height],
+      resize
+    );
     watch(usePageVisibility(), (visible) => {
       if (visible === 'visible') {
         autoplay();

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -290,7 +290,11 @@ export default defineComponent({
       };
 
       // issue: https://github.com/vant-ui/vant/issues/10052
-      nextTick().then(cb);
+      if (isHidden(root)) {
+        nextTick().then(cb);
+      } else {
+        cb();
+      }
     };
 
     const resize = () => initialize(state.active);
@@ -453,7 +457,7 @@ export default defineComponent({
 
     watch(count, () => initialize(state.active));
     watch(() => props.autoplay, autoplay);
-    watch([windowWidth, windowHeight], resize);
+    watch([windowWidth, windowHeight], () => nextTick().then(resize));
     watch(usePageVisibility(), (visible) => {
       if (visible === 'visible') {
         autoplay();


### PR DESCRIPTION
### Before submitting a pull request, please make sure the following is done:

1. Read the [contributing guide](https://github.com/vant-ui/vant/blob/main/.github/CONTRIBUTING.md).
2. If you've added code that should be tested, add tests.
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).

#### Title Format

type(ComponentName?)：commit message

Example：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

Allowed Types:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change

#### Description

https://github.com/zhousg/vant/tree/demo

```ts
const { width } = useWindowSize();
```
```html
  <demo-block :title="t('title5')">
    <!-- 根据设备宽度设置滑块宽度，swipe 组件执行 initialize 拿的上次的 width -->
    <van-swipe
      :width="(300 / 375) * width"
      :loop="false"
      indicator-color="white"
    >
      <van-swipe-item>1</van-swipe-item>
      <van-swipe-item>2</van-swipe-item>
      <van-swipe-item>3</van-swipe-item>
      <van-swipe-item>4</van-swipe-item>
    </van-swipe>
  </demo-block>
```


