### PR TITLE
fix(Sticky): resize or orientationchange wrapper no reset width and height

### DIFF
--- a/packages/vant/src/sticky/Sticky.tsx
+++ b/packages/vant/src/sticky/Sticky.tsx
@@ -154,6 +154,8 @@ export default defineComponent({
       }
       root.value.style.width = 'auto';
       root.value.style.height = 'auto';
+      (root.value.firstElementChild as HTMLDivElement).style.width = 'auto';
+      (root.value.firstElementChild as HTMLDivElement).style.height = 'auto';
       const rootRect = useRect(root);
       state.width = rootRect.width;
       state.height = rootRect.height;

--- a/packages/vant/src/sticky/Sticky.tsx
+++ b/packages/vant/src/sticky/Sticky.tsx
@@ -7,6 +7,7 @@ import {
   type PropType,
   type CSSProperties,
   type ExtractPropTypes,
+  nextTick,
 } from 'vue';
 
 // Utils
@@ -58,12 +59,16 @@ export default defineComponent({
       height: 0, // root height
       transform: 0,
     });
+    const isReset = ref(false);
 
     const offset = computed(() =>
       unitToPx(props.position === 'top' ? props.offsetTop : props.offsetBottom)
     );
 
     const rootStyle = computed<CSSProperties | undefined>(() => {
+      if (isReset.value) {
+        return;
+      }
       const { fixed, height, width } = state;
       if (fixed) {
         return {
@@ -74,7 +79,7 @@ export default defineComponent({
     });
 
     const stickyStyle = computed<CSSProperties | undefined>(() => {
-      if (!state.fixed) {
+      if (!state.fixed || isReset.value) {
         return;
       }
 
@@ -152,18 +157,21 @@ export default defineComponent({
       if (!root.value || isHidden(root) || !state.fixed) {
         return;
       }
-      root.value.style.width = 'auto';
-      root.value.style.height = 'auto';
-      (root.value.firstElementChild as HTMLDivElement).style.width = 'auto';
-      (root.value.firstElementChild as HTMLDivElement).style.height = 'auto';
-      const rootRect = useRect(root);
-      state.width = rootRect.width;
-      state.height = rootRect.height;
+      isReset.value = true;
+      nextTick(() => {
+        const rootRect = useRect(root);
+        state.width = rootRect.width;
+        state.height = rootRect.height;
+        isReset.value = false;
+      });
     });
 
     return () => (
       <div ref={root} style={rootStyle.value}>
-        <div class={bem({ fixed: state.fixed })} style={stickyStyle.value}>
+        <div
+          class={bem({ fixed: state.fixed && !isReset.value })}
+          style={stickyStyle.value}
+        >
           {slots.default?.()}
         </div>
       </div>

--- a/packages/vant/src/sticky/Sticky.tsx
+++ b/packages/vant/src/sticky/Sticky.tsx
@@ -20,6 +20,8 @@ import {
   makeStringProp,
   makeNumericProp,
   createNamespace,
+  windowWidth,
+  windowHeight,
 } from '../utils';
 
 // Composables
@@ -145,6 +147,17 @@ export default defineComponent({
       passive: true,
     });
     useVisibilityChange(root, onScroll);
+
+    watch([windowWidth, windowHeight], () => {
+      if (!root.value || isHidden(root) || !state.fixed) {
+        return;
+      }
+      root.value.style.width = 'auto';
+      root.value.style.height = 'auto';
+      const rootRect = useRect(root);
+      state.width = rootRect.width;
+      state.height = rootRect.height;
+    });
 
     return () => (
       <div ref={root} style={rootStyle.value}>

--- a/packages/vant/src/sticky/test/__snapshots__/index.spec.tsx.snap
+++ b/packages/vant/src/sticky/test/__snapshots__/index.spec.tsx.snap
@@ -83,9 +83,9 @@ exports[`should sticky inside container when using container prop 2`] = `
 `;
 
 exports[`should sticky resize or orientationchange reset root height and width 1`] = `
-<div style="width: 300px; height: 20px;">
+<div style="width: 375px; height: 20px;">
   <div class="van-sticky van-sticky--fixed"
-       style="width: 300px; height: 20px; top: 0px;"
+       style="width: 375px; height: 20px; top: 0px;"
   >
     <div class="content"
          style="height: 20px;"

--- a/packages/vant/src/sticky/test/__snapshots__/index.spec.tsx.snap
+++ b/packages/vant/src/sticky/test/__snapshots__/index.spec.tsx.snap
@@ -82,6 +82,34 @@ exports[`should sticky inside container when using container prop 2`] = `
 </div>
 `;
 
+exports[`should sticky resize or orientationchange reset root height and width 1`] = `
+<div style="width: 300px; height: 20px;">
+  <div class="van-sticky van-sticky--fixed"
+       style="width: 300px; height: 20px; top: 0px;"
+  >
+    <div class="content"
+         style="height: 20px;"
+    >
+      Content
+    </div>
+  </div>
+</div>
+`;
+
+exports[`should sticky resize or orientationchange reset root height and width 2`] = `
+<div style="width: 677px; height: 20px;">
+  <div class="van-sticky van-sticky--fixed"
+       style="width: 677px; height: 20px; top: 0px;"
+  >
+    <div class="content"
+         style="height: 20px;"
+    >
+      Content
+    </div>
+  </div>
+</div>
+`;
+
 exports[`should sticky to bottom after scrolling 1`] = `
 <div style="height: 10px;">
   <div class="van-sticky van-sticky--fixed"

--- a/packages/vant/src/sticky/test/index.spec.tsx
+++ b/packages/vant/src/sticky/test/index.spec.tsx
@@ -1,5 +1,5 @@
 import { nextTick, ref } from 'vue';
-import { VueWrapper } from '@vue/test-utils';
+import { VueWrapper, flushPromises } from '@vue/test-utils';
 import { mockScrollTop, trigger, mount } from '../../../test';
 import { Sticky } from '..';
 import { ComponentInstance } from '../../utils';
@@ -382,12 +382,11 @@ test('should sticky resize or orientationchange reset root height and width', as
 
   window.innerWidth = 677;
   mockStickyRect.mockReturnValue({
-    top: -100,
-    bottom: -90,
     width: window.innerWidth,
     height: 20,
   } as DOMRect);
   await trigger(window, 'resize');
+  await flushPromises();
   expect(wrapper.html()).toMatchSnapshot();
 
   mockStickyRect.mockRestore();

--- a/packages/vant/src/sticky/test/index.spec.tsx
+++ b/packages/vant/src/sticky/test/index.spec.tsx
@@ -381,14 +381,13 @@ test('should sticky resize or orientationchange reset root height and width', as
   expect(wrapper.html()).toMatchSnapshot();
 
   window.innerWidth = 677;
-  await trigger(window, 'resize');
   mockStickyRect.mockReturnValue({
     top: -100,
     bottom: -90,
     width: window.innerWidth,
     height: 20,
   } as DOMRect);
-  await mockScrollTop(100);
+  await trigger(window, 'resize');
   expect(wrapper.html()).toMatchSnapshot();
 
   mockStickyRect.mockRestore();

--- a/packages/vant/src/sticky/test/index.spec.tsx
+++ b/packages/vant/src/sticky/test/index.spec.tsx
@@ -367,6 +367,7 @@ test('should sticky resize or orientationchange reset root height and width', as
     },
   });
 
+  window.innerWidth = 375;
   const mockStickyRect = jest
     .spyOn(wrapper.element, 'getBoundingClientRect')
     .mockReturnValue({

--- a/packages/vant/src/sticky/test/index.spec.tsx
+++ b/packages/vant/src/sticky/test/index.spec.tsx
@@ -353,3 +353,42 @@ test('should emit change event when sticky status changed', async () => {
 
   restore();
 });
+
+test('should sticky resize or orientationchange reset root height and width', async () => {
+  const wrapper = mount({
+    render() {
+      return (
+        <Sticky>
+          <div class="content" style="height:20px">
+            Content
+          </div>
+        </Sticky>
+      );
+    },
+  });
+
+  const mockStickyRect = jest
+    .spyOn(wrapper.element, 'getBoundingClientRect')
+    .mockReturnValue({
+      top: -100,
+      bottom: -90,
+      width: window.innerWidth,
+      height: 20,
+    } as DOMRect);
+
+  await mockScrollTop(100);
+  expect(wrapper.html()).toMatchSnapshot();
+
+  window.innerWidth = 677;
+  await trigger(window, 'resize');
+  mockStickyRect.mockReturnValue({
+    top: -100,
+    bottom: -90,
+    width: window.innerWidth,
+    height: 20,
+  } as DOMRect);
+  await mockScrollTop(100);
+  expect(wrapper.html()).toMatchSnapshot();
+
+  mockStickyRect.mockRestore();
+});

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -290,11 +290,7 @@ export default defineComponent({
       };
 
       // issue: https://github.com/vant-ui/vant/issues/10052
-      if (isHidden(root)) {
-        nextTick().then(cb);
-      } else {
-        cb();
-      }
+      nextTick().then(cb);
     };
 
     const resize = () => initialize(state.active);

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -457,7 +457,10 @@ export default defineComponent({
 
     watch(count, () => initialize(state.active));
     watch(() => props.autoplay, autoplay);
-    watch([windowWidth, windowHeight], () => nextTick().then(resize));
+    watch(
+      [windowWidth, windowHeight, () => props.width, () => props.height],
+      resize
+    );
     watch(usePageVisibility(), (visible) => {
       if (visible === 'visible') {
         autoplay();

--- a/packages/vant/src/swipe/Swipe.tsx
+++ b/packages/vant/src/swipe/Swipe.tsx
@@ -290,7 +290,11 @@ export default defineComponent({
       };
 
       // issue: https://github.com/vant-ui/vant/issues/10052
-      nextTick().then(cb);
+      if (isHidden(root)) {
+        nextTick().then(cb);
+      } else {
+        cb();
+      }
     };
 
     const resize = () => initialize(state.active);
@@ -453,7 +457,7 @@ export default defineComponent({
 
     watch(count, () => initialize(state.active));
     watch(() => props.autoplay, autoplay);
-    watch([windowWidth, windowHeight], resize);
+    watch([windowWidth, windowHeight], () => nextTick().then(resize));
     watch(usePageVisibility(), (visible) => {
       if (visible === 'visible') {
         autoplay();


### PR DESCRIPTION
### Before submitting a pull request, please make sure the following is done:

1. Read the [contributing guide](https://github.com/vant-ui/vant/blob/main/.github/CONTRIBUTING.md).
2. If you've added code that should be tested, add tests.
3. If you've changed APIs, update the documentation.
4. Ensure the test suite passes (`npm test`).

#### Title Format

type(ComponentName?)：commit message

Example：

- docs: fix typo in quickstart
- build: optimize build speed
- fix(Button): incorrect style
- feat(Button): add color prop

Allowed Types:

- fix
- feat
- docs
- perf
- test
- types
- build
- chore
- refactor
- breaking change

#### 问题说明

https://vant-contrib.gitee.io/vant/mobile.html#/zh-CN/tab

<img width="600" alt="image" src="https://user-images.githubusercontent.com/15833290/232240241-f04449aa-9e9d-4aca-bf3b-0181903d1d6c.png">

横屏后

<img width="704" alt="image" src="https://user-images.githubusercontent.com/15833290/232240390-fe7de023-ccb1-4dd7-bcf1-fe29e4adb2a3.png">


#### 处理方式

监听 resize 且是 fixed 状态后，还原 Sticky 组件容器样式切换至非 fixed 状态，让其再次获取原始大小重新设置容器尺寸，切换回 fixed 状态。




