### PR TITLE
chore(CI): fix the set-output deprecation warning when deploy website

### DIFF
--- a/.github/workflows/deploy-v4-site.yml
+++ b/.github/workflows/deploy-v4-site.yml
@@ -54,7 +54,7 @@ jobs:
             vant-use/**/*
 
       - name: Deploy for GitHub 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.4.0
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
         with:
           branch: main
           folder: packages/vant/site-dist


### PR DESCRIPTION
## Summary

Fix the following warning:

![image](https://user-images.githubusercontent.com/7237365/237008916-9788c5b3-d30b-4402-9017-18e943ad9f4f.png)

Ref: 

- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
- https://github.com/JamesIves/github-pages-deploy-action/issues/1241
