### PR TITLE
feat(signature): Enhance signature clarity by devicePixelRatio

### DIFF
--- a/packages/vant/src/signature/README.md
+++ b/packages/vant/src/signature/README.md
@@ -76,6 +76,7 @@ Use `line-width` prop to set the width of the line.
 | type | Export image type | _string_ | `png` |
 | pen-color | Color of the brush stroke, default is black | _string_ | `#000` |
 | line-width | Width of the line | _number_ | `3` |
+| background-color | Background color | _string_ | - |
 | tips | Text that appears when Canvas is not supported | _string_ | - |
 | clear-button-text | Clear button text | _string_ | `Clear` |
 | confirm-button-text | Confirm button text | _string_ | `Confirm` |

--- a/packages/vant/src/signature/README.zh-CN.md
+++ b/packages/vant/src/signature/README.zh-CN.md
@@ -76,6 +76,7 @@ export default {
 | type | 导出图片类型 | _string_ | `png` |
 | pen-color | 笔触颜色，默认黑色 | _string_ | `#000` |
 | line-width | 线条宽度 | _number_ | `3` |
+| background-color | 背景颜色 | _string_ | - |
 | tips | 当不支持 Canvas 的时候出现的提示文案 | _string_ | - |
 | clear-button-text | 清除按钮文案 | _string_ | `清空` |
 | confirm-button-text | 确认按钮文案 | _string_ | `确认` |

--- a/packages/vant/src/signature/Signature.tsx
+++ b/packages/vant/src/signature/Signature.tsx
@@ -119,7 +119,6 @@ export default defineComponent({
         ? ''
         : (
             {
-              png: (): string => canvas.toDataURL('image/png'),
               jpg: (): string => canvas.toDataURL('image/jpeg', 0.8),
               jpeg: (): string => canvas.toDataURL('image/jpeg', 0.8),
             }[props.type] as () => string

--- a/packages/vant/src/signature/Signature.tsx
+++ b/packages/vant/src/signature/Signature.tsx
@@ -145,6 +145,7 @@ export default defineComponent({
         state.width = (wrapRef.value?.offsetWidth || 0) * state.ratio;
         state.height = (wrapRef.value?.offsetHeight || 0) * state.ratio;
 
+        // ensure canvas is rendered
         nextTick(() => {
           setCanvasBgColor();
         });

--- a/packages/vant/src/signature/index.less
+++ b/packages/vant/src/signature/index.less
@@ -17,6 +17,11 @@
     border: var(--van-signature-content-border);
     border-radius: var(--van-radius-lg);
     overflow: hidden;
+
+    canvas {
+      width: 100%;
+      height: 100%;
+    }
   }
 
   &__footer {


### PR DESCRIPTION
### 消除签名锯齿增强签名清晰度

#### 问题描述：
1. 设置导出类型为jpg时依然还是png格式，只能设置jpeg不方便。
2. 当导出jpg时默认会将透明alpha像素转换为黑色，导致导出全黑图片。
3. 清晰度很低签名锯齿状很明显

#### 解决方案
1. 修复`type`设置为jpg不生效的错误，`canvas.toDataURL` 仅支持jpeg全称写法。
2. 增加一个背景色`backgroundColor`属性方便快速便捷的设置底色。
3. 通过物理像素分辨率与CSS 像素分辨率的像素比进行canvas放大缩小提高绘制清晰度，拟补显示器之间的差异。
_组件默认提供导出高清不缩小版，如果有特殊需求可以通过第二参数canvas自行处理导出图片_

| Before(锯齿) | Now(不缩小版) | Scaled(缩小版) |
| ------ | --- | ------ |
| <img src="https://github.com/youzan/vant/assets/48879481/e6396584-f7bd-4858-90c5-671837d635ed" width="344" height="202"> | <img src="https://github.com/youzan/vant/assets/48879481/e66d5af7-a7af-4598-b48a-d29013a7c599" width="344" height="202"> | <img src="https://github.com/youzan/vant/assets/48879481/5f566a2d-3b98-4e84-94fd-04f76dd4a9da" width="344" height="202"> |
| 7kb | 12kb | 7kb |


### Changelog
Changelog(CN) | Changelog(EN) | Related issues
 -- | -- | --
增强画质消除锯齿 | Enhance signature clarity | 
新增背景色属性 | Add backgroundColor | #11827
增加jpg图片导出 | Add support for exporting as JPG image | 

