### PR TITLE
fix(Filed): onclick label execute twice

### DIFF
--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -585,6 +585,7 @@ export default defineComponent({
             id={`${id}-label`}
             for={getInputId()}
             onClick={(event: MouseEvent) => {
+              // https://github.com/youzan/vant/issues/11831
               preventDefault(event);
               focus();
             }}

--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -584,7 +584,10 @@ export default defineComponent({
           <label
             id={`${id}-label`}
             for={getInputId()}
-            onClick={(e) => e.stopPropagation()}
+            onClick={(event: MouseEvent) => {
+              preventDefault(event);
+              focus();
+            }}
             style={
               labelAlign === 'top' && labelWidth
                 ? { width: addUnit(labelWidth) }

--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -584,6 +584,7 @@ export default defineComponent({
           <label
             id={`${id}-label`}
             for={getInputId()}
+            onClick={(e) => e.stopPropagation()}
             style={
               labelAlign === 'top' && labelWidth
                 ? { width: addUnit(labelWidth) }


### PR DESCRIPTION
Fix Filed Bug #11831
将 label 事件 stopPropagation() 改成 preventDefault()，使点击事件的对象不受影响，并主动聚焦input