### PR TITLE
fix(Tab): van-tab__panel unused attrs when animated or swipeable

### DIFF
--- a/packages/vant/src/back-top/demo/index.vue
+++ b/packages/vant/src/back-top/demo/index.vue
@@ -30,7 +30,7 @@ const targetEl = ref<HTMLElement>();
 
 <template>
   <van-tabs v-model:active="activeTab" :ellipsis="false">
-    <van-tab :title="t('basicUsage')" class="abc">
+    <van-tab :title="t('basicUsage')">
       <van-cell v-for="item in list" :key="item" :title="item" />
       <van-back-top v-if="activeTab === 0" />
     </van-tab>

--- a/packages/vant/src/back-top/demo/index.vue
+++ b/packages/vant/src/back-top/demo/index.vue
@@ -30,7 +30,7 @@ const targetEl = ref<HTMLElement>();
 
 <template>
   <van-tabs v-model:active="activeTab" :ellipsis="false">
-    <van-tab :title="t('basicUsage')">
+    <van-tab :title="t('basicUsage')" class="abc">
       <van-cell v-for="item in list" :key="item" :title="item" />
       <van-back-top v-if="activeTab === 0" />
     </van-tab>

--- a/packages/vant/src/tab/Tab.tsx
+++ b/packages/vant/src/tab/Tab.tsx
@@ -54,7 +54,7 @@ export default defineComponent({
 
   props: tabProps,
 
-  setup(props, { slots }) {
+  setup(props, { slots, attrs }) {
     const id = useId();
     const inited = ref(false);
     const instance = getCurrentInstance();
@@ -166,7 +166,9 @@ export default defineComponent({
             aria-hidden={!active.value}
             aria-labelledby={label}
           >
-            <div class={bem('panel')}>{slots.default?.()}</div>
+            <div class={bem('panel')} {...attrs}>
+              {slots.default?.()}
+            </div>
           </SwipeItem>
         );
       }


### PR DESCRIPTION
close #11842 

加上 `attrs` 后可以设置给 `van-tab__panel` 元素类名，选择器可以简单精确些吧  