### PR TITLE
fix(Dialog): fix the rounded corners of shadow when button is clicked

### DIFF
--- a/packages/vant/src/dialog/index.less
+++ b/packages/vant/src/dialog/index.less
@@ -100,6 +100,7 @@
     height: var(--van-dialog-button-height);
     margin: 0;
     border: 0;
+    border-radius: 0;
   }
 
   &__confirm {
@@ -128,6 +129,18 @@
 
     .van-dialog__confirm {
       color: var(--van-white);
+    }
+    
+    .van-action-bar-button {
+      &--first {
+        border-top-left-radius: var(--van-radius-max);
+        border-bottom-left-radius: var(--van-radius-max);
+      }
+
+      &--last {
+        border-top-right-radius: var(--van-radius-max);
+        border-bottom-right-radius: var(--van-radius-max);
+      }
     }
   }
 


### PR DESCRIPTION
圆角边框问题如图所示：

<img width="713" alt="image" src="https://github.com/youzan/vant/assets/29498153/c0fdef1f-d298-4ece-a996-b5f668f0602f">


修复后 `theme="default"` 如图所示：

<img width="713" alt="image" src="https://github.com/youzan/vant/assets/29498153/c22e40c5-da30-41b1-a24a-2ed5c078d8da">


修复后 `theme="round-button"` 如图所示：

<img width="713" alt="image" src="https://github.com/youzan/vant/assets/29498153/b9268663-25f5-4477-8aa1-da26adf39fc9">
<img width="714" alt="image" src="https://github.com/youzan/vant/assets/29498153/d461b35d-f9d8-46a7-8734-5178f43855d7">


