### PR TITLE
fix(Slider): should update startValue when the slider is clicked

### DIFF
--- a/packages/vant/src/slider/Slider.tsx
+++ b/packages/vant/src/slider/Slider.tsx
@@ -133,6 +133,15 @@ export default defineComponent({
       return addNumber(min, diff);
     };
 
+    const updateStartValue = () => {
+      const current = props.modelValue;
+      if (isRange(current)) {
+        startValue = current.map(format) as NumberRange;
+      } else {
+        startValue = format(current);
+      }
+    };
+
     const handleRangeValue = (value: NumberRange) => {
       // 设置默认值
       const left = value[0] ?? Number(props.min);
@@ -163,6 +172,8 @@ export default defineComponent({
       if (props.disabled || props.readonly) {
         return;
       }
+
+      updateStartValue();
 
       const { min, reverse, vertical, modelValue } = props;
       const rect = useRect(root);
@@ -204,12 +215,7 @@ export default defineComponent({
 
       touch.start(event);
       current = props.modelValue;
-
-      if (isRange(current)) {
-        startValue = current.map(format) as NumberRange;
-      } else {
-        startValue = format(current);
-      }
+      updateStartValue();
 
       dragStatus.value = 'start';
     };

--- a/packages/vant/src/slider/test/index.spec.ts
+++ b/packages/vant/src/slider/test/index.spec.ts
@@ -182,6 +182,8 @@ test('should emit "update:modelValue" event after clicking vertical slider', () 
 });
 
 test('should not emit change event when value not changed', async () => {
+  const restoreMock = mockRect();
+
   const wrapper = mount(Slider, {
     props: {
       modelValue: 50,
@@ -196,8 +198,16 @@ test('should not emit change event when value not changed', async () => {
   await wrapper.setProps({ modelValue: 100 });
   trigger(button, 'touchstart');
   trigger(wrapper, 'click', 100, 0);
-
   expect(wrapper.emitted('change')).toHaveLength(1);
+
+  trigger(wrapper, 'click', 50, 0);
+  expect(wrapper.emitted('change')).toHaveLength(2);
+
+  await wrapper.setProps({ modelValue: 50 });
+  trigger(wrapper, 'click', 100, 0);
+  expect(wrapper.emitted('change')).toHaveLength(3);
+
+  restoreMock();
 });
 
 // https://github.com/vant-ui/vant/issues/8889


### PR DESCRIPTION
拖动按钮到最左边后，点击 slider 的其它地方会触发 change 事件。再点击 slider 的最左边，这个时候不会触发 change 事件。