### PR TITLE
feat(VantCli): mobile page refreshes are located based on the hash

### DIFF
--- a/packages/vant-cli/site/mobile/components/DemoBlock.vue
+++ b/packages/vant-cli/site/mobile/components/DemoBlock.vue
@@ -31,6 +31,22 @@ export default {
     },
   },
 
+  watch: {
+    slugifyTitle(newVal) {
+      if (newVal) {
+        this.$nextTick(() => {
+          let hash = '';
+          if (top) hash = top.location.hash.split('#').pop();
+          else hash = location.hash.split('#').pop();
+          const target = document.getElementById(newVal);
+          if (target && newVal === hash) {
+            target.scrollIntoView(true);
+          }
+        });
+      }
+    },
+  },
+
   async mounted() {
     const { slugify } = await import('transliteration');
     this.slugify = slugify;


### PR DESCRIPTION
官方文档，刷新页面的时候移动端页面根据 `hash` 进行定位