### PR TITLE
build(@vant/use): add types exports

### DIFF
--- a/packages/vant-use/package.json
+++ b/packages/vant-use/package.json
@@ -7,6 +7,7 @@
   "typings": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js"
     }


### PR DESCRIPTION
related discussion #11981 

[reference](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing)