### PR TITLE
fix(FloatingPanel): remove passive event warning

### DIFF
--- a/packages/vant/src/floating-panel/FloatingPanel.tsx
+++ b/packages/vant/src/floating-panel/FloatingPanel.tsx
@@ -16,7 +16,7 @@ import {
 } from '../utils';
 
 // Composables
-import { useWindowSize } from '@vant/use';
+import { useWindowSize, useEventListener } from '@vant/use';
 import { useLockScroll } from '../composables/use-lock-scroll';
 import { useTouch } from '../composables/use-touch';
 import { useSyncPropRef } from '../composables/use-sync-prop-ref';
@@ -142,13 +142,15 @@ export default defineComponent({
 
     useLockScroll(rootRef, () => true);
 
+    // useEventListener will set passive to `false` to eliminate the warning of Chrome
+    useEventListener('touchmove', onTouchmove, { target: rootRef });
+
     return () => (
       <div
         class={[bem(), { 'van-safe-area-bottom': props.safeAreaInsetBottom }]}
         ref={rootRef}
         style={rootStyle.value}
         onTouchstartPassive={onTouchstart}
-        onTouchmove={onTouchmove}
         onTouchend={onTouchend}
         onTouchcancel={onTouchend}
       >

--- a/packages/vant/src/floating-panel/README.md
+++ b/packages/vant/src/floating-panel/README.md
@@ -44,7 +44,7 @@ For example, you can make the panel stop at three positions: `100px`, 40% of the
 ```html
 <van-floating-panel v-model:height="height" :anchors="anchors">
   <div style="text-align: center; padding: 15px">
-    <p>Panel Show Height {{ height }} px</p>
+    <p>Panel Show Height {{ height.toFixed(0) }} px</p>
   </div>
 </van-floating-panel>
 ```

--- a/packages/vant/src/floating-panel/README.zh-CN.md
+++ b/packages/vant/src/floating-panel/README.zh-CN.md
@@ -44,7 +44,7 @@ FloatingPanel 的默认高度为 `100px`，用户可以拖动来展开面板，�
 ```html
 <van-floating-panel v-model:height="height" :anchors="anchors">
   <div style="text-align: center; padding: 15px">
-    <p>面板显示高度 {{ height }} px</p>
+    <p>面板显示高度 {{ height.toFixed(0) }} px</p>
   </div>
 </van-floating-panel>
 ```

--- a/packages/vant/src/floating-panel/demo/index.vue
+++ b/packages/vant/src/floating-panel/demo/index.vue
@@ -52,7 +52,7 @@ const height = ref(anchors[0]);
     <van-tab :title="t('customAnchors')">
       <van-floating-panel v-model:height="height" :anchors="anchors">
         <div style="text-align: center; padding: 15px">
-          <p>{{ t('panelShowHeight') }} {{ height }} px</p>
+          <p>{{ t('panelShowHeight') }} {{ height.toFixed(0) }} px</p>
         </div>
       </van-floating-panel>
     </van-tab>


### PR DESCRIPTION
Fix Chrome warning:

<img width="1360" alt="Screenshot 2023-06-17 at 21 17 08" src="https://github.com/youzan/vant/assets/7237365/9d66f715-6541-45da-bea1-24851e9f08cb">
