### PR TITLE
chore(Button): add animation button demo

### DIFF
--- a/packages/vant/src/button/README.md
+++ b/packages/vant/src/button/README.md
@@ -109,6 +109,30 @@ app.use(Button);
 </van-button>
 ```
 
+### Animation Button
+
+```html
+<van-button type="danger" round>
+  <van-swipe
+    vertical
+    class="notice-swipe"
+    :autoplay="2000"
+    :touchable="false"
+    :show-indicators="false"
+  >
+    <van-swipe-item>Do Task</van-swipe-item>
+    <van-swipe-item>Lottery</van-swipe-item>
+  </van-swipe>
+</van-button>
+
+<style>
+  .notice-swipe {
+    height: 40px;
+    line-height: 40px;
+  }
+</style>
+```
+
 ## API
 
 ### Props

--- a/packages/vant/src/button/README.md
+++ b/packages/vant/src/button/README.md
@@ -109,7 +109,7 @@ app.use(Button);
 </van-button>
 ```
 
-### Animation Button
+### Animated Button
 
 ```html
 <van-button type="danger" round>

--- a/packages/vant/src/button/README.zh-CN.md
+++ b/packages/vant/src/button/README.zh-CN.md
@@ -131,6 +131,32 @@ app.use(Button);
 </van-button>
 ```
 
+### 动画按钮
+
+搭配 Button 和 Swipe 组件，可以实现垂直滚动的动画按钮效果。
+
+```html
+<van-button type="danger" round>
+  <van-swipe
+    vertical
+    class="notice-swipe"
+    :autoplay="2000"
+    :touchable="false"
+    :show-indicators="false"
+  >
+    <van-swipe-item>做任务</van-swipe-item>
+    <van-swipe-item>抽大奖</van-swipe-item>
+  </van-swipe>
+</van-button>
+
+<style>
+  .notice-swipe {
+    height: 40px;
+    line-height: 40px;
+  }
+</style>
+```
+
 ## API
 
 ### Props

--- a/packages/vant/src/button/demo/index.vue
+++ b/packages/vant/src/button/demo/index.vue
@@ -33,7 +33,7 @@ const t = useTranslate({
     pure: '单色按钮',
     gradient: '渐变色按钮',
     blockElement: '块级元素',
-    aniButton: '动画按钮',
+    animatedButton: '动画按钮',
     doTask: '做任务',
     lottery: '抽大奖',
   },
@@ -65,7 +65,7 @@ const t = useTranslate({
     pure: 'Pure',
     gradient: 'Gradient',
     blockElement: 'Block Element',
-    aniButton: 'aniButton',
+    animatedButton: 'AnimatedButton',
     doTask: 'Do Task',
     lottery: 'Lottery',
   },
@@ -149,7 +149,7 @@ const t = useTranslate({
     />
   </demo-block>
 
-  <demo-block :title="t('aniButton')">
+  <demo-block :title="t('animatedButton')">
     <van-button type="danger" round>
       <van-swipe
         vertical

--- a/packages/vant/src/button/demo/index.vue
+++ b/packages/vant/src/button/demo/index.vue
@@ -65,7 +65,7 @@ const t = useTranslate({
     pure: 'Pure',
     gradient: 'Gradient',
     blockElement: 'Block Element',
-    animatedButton: 'AnimatedButton',
+    animatedButton: 'Animated Button',
     doTask: 'Do Task',
     lottery: 'Lottery',
   },

--- a/packages/vant/src/button/demo/index.vue
+++ b/packages/vant/src/button/demo/index.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
 import VanButton from '..';
+import VanSwipe from '../../swipe';
+import VanSwipeItem from '../../swipe-item';
 import { cdnURL, useTranslate } from '../../../docs/site';
 
 const t = useTranslate({
@@ -31,6 +33,9 @@ const t = useTranslate({
     pure: '单色按钮',
     gradient: '渐变色按钮',
     blockElement: '块级元素',
+    aniButton: '动画按钮',
+    doTask: '做任务',
+    lottery: '抽大奖',
   },
   'en-US': {
     type: 'Type',
@@ -60,6 +65,9 @@ const t = useTranslate({
     pure: 'Pure',
     gradient: 'Gradient',
     blockElement: 'Block Element',
+    aniButton: 'aniButton',
+    doTask: 'Do Task',
+    lottery: 'Lottery',
   },
 });
 </script>
@@ -140,6 +148,21 @@ const t = useTranslate({
       :text="t('gradient')"
     />
   </demo-block>
+
+  <demo-block :title="t('aniButton')">
+    <van-button type="danger" round>
+      <van-swipe
+        vertical
+        class="notice-swipe"
+        :autoplay="2000"
+        :touchable="false"
+        :show-indicators="false"
+      >
+        <van-swipe-item>{{ t('doTask') }}</van-swipe-item>
+        <van-swipe-item>{{ t('lottery') }}</van-swipe-item>
+      </van-swipe>
+    </van-button>
+  </demo-block>
 </template>
 
 <style lang="less">
@@ -166,5 +189,9 @@ const t = useTranslate({
   &-row {
     margin-bottom: var(--van-padding-sm);
   }
+}
+.notice-swipe {
+  height: 40px;
+  line-height: 40px;
 }
 </style>

--- a/packages/vant/src/button/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/button/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -420,4 +420,36 @@ exports[`should render demo and match snapshot 1`] = `
     </div>
   </button>
 </div>
+<div>
+  <!--[-->
+  <button type="button"
+          class="van-button van-button--danger van-button--normal van-button--round"
+          style
+  >
+    <div class="van-button__content">
+      <span class="van-button__text">
+        <!--[-->
+        <div class="van-swipe notice-swipe">
+          <div style="transition-duration:500ms;transform:translateY(0px);"
+               class="van-swipe__track van-swipe__track--vertical"
+          >
+            <!--[-->
+            <div class="van-swipe-item"
+                 style
+            >
+              <!--[-->
+              Do Task
+            </div>
+            <div class="van-swipe-item"
+                 style
+            >
+              <!--[-->
+              Lottery
+            </div>
+          </div>
+        </div>
+      </span>
+    </div>
+  </button>
+</div>
 `;

--- a/packages/vant/src/button/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/button/test/__snapshots__/demo.spec.ts.snap
@@ -356,4 +356,30 @@ exports[`should render demo and match snapshot 1`] = `
     </div>
   </button>
 </div>
+<div>
+  <button type="button"
+          class="van-button van-button--danger van-button--normal van-button--round"
+  >
+    <div class="van-button__content">
+      <span class="van-button__text">
+        <div class="van-swipe notice-swipe">
+          <div style="transition-duration: 0ms; transform: translateY(0px); height: 200px;"
+               class="van-swipe__track van-swipe__track--vertical"
+          >
+            <div class="van-swipe-item"
+                 style="height: 100px;"
+            >
+              Do Task
+            </div>
+            <div class="van-swipe-item"
+                 style="height: 100px;"
+            >
+              Lottery
+            </div>
+          </div>
+        </div>
+      </span>
+    </div>
+  </button>
+</div>
 `;


### PR DESCRIPTION
之前遇到过这个动画按钮需求，发现vant的示例里没有，就以为做不到；后来自己还专门封装了一个动画按钮。

最近又遇到给H5做公告栏的需求，发现notice-bar组件里有一个`垂直滚动`的demo，实际上按这个做法，就可以完全实现当时的动画按钮的功能。

所以，这个PR就在Button组件的文档 加上了 `动画按钮` 的demo。

防止也有人看不到这个能力。