### PR TITLE
fix(Rate): should change value when half icon is touchmoved

### DIFF
--- a/packages/vant/src/rate/index.less
+++ b/packages/vant/src/rate/index.less
@@ -31,6 +31,7 @@
       top: 0;
       left: 0;
       overflow: hidden;
+      pointer-events: none;
     }
 
     &--full {


### PR DESCRIPTION
touchmove 的触发对象和 touchstart 是一致的。这意味着在 half icon 上触发移动后，即使在 half icon 外移动，事件也是在它上触发的。这会产生一个问题，因为现在监听的父元素的 touchmove 事件，当 half icon 从文档中移除后，touchmove 将无法冒泡到父元素，表现为断触。

before:
![before](https://github.com/youzan/vant/assets/18509404/11279415-2223-4f7d-939f-d015e3ba2be7)

after this PR:
![after](https://github.com/youzan/vant/assets/18509404/08b67e59-6130-47a8-a948-32a74dfa2151)
