### PR TITLE
chore: remove gitee issue template

### DIFF
--- a/.gitee/ISSUE_TEMPLATE.md
+++ b/.gitee/ISSUE_TEMPLATE.md
@@ -1,5 +1,0 @@
-注意：gitee 中为 vant 的镜像仓库，不进行 issue 处理。
-
-请移步 GitHub issues 进行反馈：
-
-https://github.com/vant-ui/vant/issues


### PR DESCRIPTION
Gitee now supports reading templates from the .github directory, so we can remove the Gitee issue template.

- Ref: https://help.gitee.com/issue/templates#%E6%A8%A1%E6%9D%BF%E9%80%89%E6%8B%A9%E5%99%A8%E9%85%8D%E7%BD%AEconfigyml