### PR TITLE
fix(Uploader): render objectUrl to avoid perf issue

### DIFF
--- a/packages/vant/src/uploader/Uploader.tsx
+++ b/packages/vant/src/uploader/Uploader.tsx
@@ -168,6 +168,7 @@ export default defineComponent({
               file,
               status: '',
               message: '',
+              objectUrl: URL.createObjectURL(file),
             };
 
             if (contents[index]) {
@@ -185,6 +186,7 @@ export default defineComponent({
             file: files as File,
             status: '',
             message: '',
+            objectUrl: URL.createObjectURL(files as File),
           };
 
           if (content) {
@@ -240,8 +242,8 @@ export default defineComponent({
         const imageFiles = props.modelValue.filter(isImageFile);
         const images = imageFiles
           .map((item) => {
-            if (item.file && !item.url && item.status !== 'failed') {
-              item.url = URL.createObjectURL(item.file);
+            if (item.objectUrl && !item.url && item.status !== 'failed') {
+              item.url = item.objectUrl;
               urls.push(item.url);
             }
             return item.url;

--- a/packages/vant/src/uploader/UploaderPreviewItem.tsx
+++ b/packages/vant/src/uploader/UploaderPreviewItem.tsx
@@ -114,7 +114,7 @@ export default defineComponent({
           <Image
             v-slots={{ default: renderCover }}
             fit={imageFit}
-            src={item.content || item.url}
+            src={item.objectUrl || item.content || item.url}
             class={bem('preview-image')}
             width={Array.isArray(previewSize) ? previewSize[0] : previewSize}
             height={Array.isArray(previewSize) ? previewSize[1] : previewSize}

--- a/packages/vant/src/uploader/types.ts
+++ b/packages/vant/src/uploader/types.ts
@@ -8,6 +8,7 @@ export type UploaderResultType = 'dataUrl' | 'text' | 'file';
 export type UploaderFileListItem = {
   url?: string;
   file?: File;
+  objectUrl?: string;
   content?: string;
   isImage?: boolean;
   status?: '' | 'uploading' | 'done' | 'failed';

--- a/packages/vant/test/dom.ts
+++ b/packages/vant/test/dom.ts
@@ -59,6 +59,9 @@ export async function mockScrollTop(value: number) {
   return nextTick();
 }
 
+// js-dom do not implement `URL.createObjectURL`
+global.URL.createObjectURL = jest.fn();
+
 mockScrollIntoView();
 mockHTMLElementOffset();
 mockGetBoundingClientRect({


### PR DESCRIPTION
Render objectUrl to avoid perf issue, base64 image may slow down the Wechat WebView.

- https://github.com/youzan/vant/issues/12048