### PR TITLE
fix(Circle): add slot content default class

### DIFF
--- a/packages/vant/src/circle/Circle.tsx
+++ b/packages/vant/src/circle/Circle.tsx
@@ -174,7 +174,7 @@ export default defineComponent({
 
     const renderText = () => {
       if (slots.default) {
-        return slots.default();
+        return <div class={bem('text')}>{slots.default()}</div>;
       }
       if (props.text) {
         return <div class={bem('text')}>{props.text}</div>;

--- a/packages/vant/src/circle/README.zh-CN.md
+++ b/packages/vant/src/circle/README.zh-CN.md
@@ -152,7 +152,7 @@ export default {
 <van-circle
   v-model:current-rate="currentRate"
   :rate="rate"
-  :text="左侧"
+  text="左侧"
   start-position="left"
 />
 <van-circle


### PR DESCRIPTION
docs(Circle): using demo is wrong(:text="左侧")
fix(Circle): add slot content default class. when using "fill" Props,the default
slot content cannot see
