### PR TITLE
fix(cli): should escape curly brackets in markdown

### DIFF
--- a/packages/vant-cli/src/compiler/vite-plugin-md.ts
+++ b/packages/vant-cli/src/compiler/vite-plugin-md.ts
@@ -64,6 +64,8 @@ const markdownToVue = ({
   let html = md.render(raw, { id });
   html = `<div class="van-doc-markdown-body">${html}</div>`;
   html = markdownCardWrapper(html);
+  // escape curly brackets
+  html = html.replace(/<code(.*?)>/g, '<code$1 v-pre>');
   return `<template>${html}</template>`;
 };
 


### PR DESCRIPTION
https://github.com/youzan/vant/issues/12186