### PR TITLE
fix(Dialog): improve slot exit judgment

### DIFF
--- a/packages/vant/src/dialog/Dialog.tsx
+++ b/packages/vant/src/dialog/Dialog.tsx
@@ -170,8 +170,9 @@ export default defineComponent({
     };
 
     const renderContent = () => {
-      if (slots.default) {
-        return <div class={bem('content')}>{slots.default()}</div>;
+      const defaultSlot = slots.default?.();
+      if (defaultSlot) {
+        return <div class={bem("content")}>{defaultSlot}</div>;
       }
 
       const { title, message, allowHtml } = props;


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-contrib.gitee.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-contrib.gitee.io/vant/#/zh-CN/contribution)。

重新修改了在二次封装传入<slot /> 占位时，slots.default永远存在，即使不传入插槽内容也不会渲染message