### PR TITLE
feat(vant-use): add useRaf

### DIFF
--- a/packages/vant-use/src/index.ts
+++ b/packages/vant-use/src/index.ts
@@ -9,4 +9,5 @@ export * from './useScrollParent';
 export * from './useEventListener';
 export * from './usePageVisibility';
 export * from './useCustomFieldValue';
+export * from './useRaf';
 export * from './onMountedOrActivated';

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -1,0 +1,19 @@
+import { inBrowser } from '..';
+export function useRaf(fn: FrameRequestCallback, interval = 0): () => void {
+  if (inBrowser) {
+    let start: number;
+    const id = requestAnimationFrame(function wrappedFn(
+      timestamp = Date.now(),
+    ) {
+      if (start === undefined) {
+        start = timestamp;
+      } else if (timestamp - start === interval) {
+        fn(timestamp);
+        start = timestamp;
+      }
+      requestAnimationFrame(wrappedFn);
+    });
+    return () => cancelAnimationFrame(id);
+  }
+  return () => {};
+}

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -1,19 +1,25 @@
 import { inBrowser } from '..';
+
 export function useRaf(fn: FrameRequestCallback, interval = 0): () => void {
   if (inBrowser) {
     let start: number;
-    const id = requestAnimationFrame(function wrappedFn(
-      timestamp = Date.now(),
-    ) {
+    const disposesId: number[] = [];
+
+    const myFrame = (timestamp: number) => {
       if (start === undefined) {
         start = timestamp;
-      } else if (timestamp - start === interval) {
+      } else if (timestamp - start > interval) {
         fn(timestamp);
         start = timestamp;
       }
-      requestAnimationFrame(wrappedFn);
-    });
-    return () => cancelAnimationFrame(id);
+      disposesId.push(requestAnimationFrame(myFrame));
+    };
+    disposesId.push(requestAnimationFrame(myFrame));
+
+    return () => {
+      disposesId.forEach((id) => cancelAnimationFrame(id));
+      disposesId.length = 0;
+    };
   }
   return () => {};
 }

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -6,7 +6,7 @@ export function useRaf(fn: FrameRequestCallback, interval = 0): () => void {
     const disposesId: number[] = [];
     let isStopped = false;
 
-    const myFrame = (timestamp: number) => {
+    const frameWrapper = (timestamp: number) => {
       if (isStopped) return;
       if (start === undefined) {
         start = timestamp;
@@ -14,9 +14,9 @@ export function useRaf(fn: FrameRequestCallback, interval = 0): () => void {
         fn(timestamp);
         start = timestamp;
       }
-      disposesId.push(requestAnimationFrame(myFrame));
+      disposesId.push(requestAnimationFrame(frameWrapper));
     };
-    disposesId.push(requestAnimationFrame(myFrame));
+    disposesId.push(requestAnimationFrame(frameWrapper));
 
     return () => {
       isStopped = true;

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -21,7 +21,6 @@ export function useRaf(
       disposesId.length = 0;
     };
     const frameWrapper = (timestamp: number) => {
-      console.log({ disposesId });
       if (isStopped) return;
       if (start === undefined) {
         start = timestamp;
@@ -30,7 +29,6 @@ export function useRaf(
         start = timestamp;
         if (!isLoop) {
           stop();
-          console.log({ disposesId });
           return;
         }
       }

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -31,7 +31,6 @@ export function useRaf(
           return;
         }
       }
-      cancelAnimationFrame(rafId);
       rafId = requestAnimationFrame(frameWrapper);
     };
     rafId = requestAnimationFrame(frameWrapper);

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -4,8 +4,10 @@ export function useRaf(fn: FrameRequestCallback, interval = 0): () => void {
   if (inBrowser) {
     let start: number;
     const disposesId: number[] = [];
+    let isStopped = false;
 
     const myFrame = (timestamp: number) => {
+      if (isStopped) return;
       if (start === undefined) {
         start = timestamp;
       } else if (timestamp - start > interval) {
@@ -17,6 +19,7 @@ export function useRaf(fn: FrameRequestCallback, interval = 0): () => void {
     disposesId.push(requestAnimationFrame(myFrame));
 
     return () => {
+      isStopped = true;
       disposesId.forEach((id) => cancelAnimationFrame(id));
       disposesId.length = 0;
     };

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -12,13 +12,12 @@ export function useRaf(
   if (inBrowser) {
     const { interval = 0, isLoop = false } = options || {};
     let start: number;
-    const disposesId: number[] = [];
     let isStopped = false;
+    let rafId: number;
 
     const stop = () => {
       isStopped = true;
-      disposesId.forEach((id) => cancelAnimationFrame(id));
-      disposesId.length = 0;
+      cancelAnimationFrame(rafId);
     };
     const frameWrapper = (timestamp: number) => {
       if (isStopped) return;
@@ -32,9 +31,10 @@ export function useRaf(
           return;
         }
       }
-      requestAnimationFrame(frameWrapper);
+      cancelAnimationFrame(rafId);
+      rafId = requestAnimationFrame(frameWrapper);
     };
-    disposesId.push(requestAnimationFrame(frameWrapper));
+    rafId = requestAnimationFrame(frameWrapper);
 
     return stop;
   }

--- a/packages/vant-use/src/useRaf/index.ts
+++ b/packages/vant-use/src/useRaf/index.ts
@@ -21,15 +21,20 @@ export function useRaf(
       disposesId.length = 0;
     };
     const frameWrapper = (timestamp: number) => {
+      console.log({ disposesId });
       if (isStopped) return;
       if (start === undefined) {
         start = timestamp;
       } else if (timestamp - start > interval) {
         fn(timestamp);
         start = timestamp;
-        if (!isLoop) stop();
+        if (!isLoop) {
+          stop();
+          console.log({ disposesId });
+          return;
+        }
       }
-      disposesId.push(requestAnimationFrame(frameWrapper));
+      requestAnimationFrame(frameWrapper);
     };
     disposesId.push(requestAnimationFrame(frameWrapper));
 

--- a/packages/vant-use/src/utils.ts
+++ b/packages/vant-use/src/utils.ts
@@ -14,6 +14,14 @@ export function cancelRaf(id: number) {
   }
 }
 
+export function useRaf(fn: FrameRequestCallback): () => void {
+  if (inBrowser) {
+    const id = requestAnimationFrame(fn);
+    return () => cancelAnimationFrame(id);
+  }
+  return () => {};
+}
+
 // double raf for animation
 export function doubleRaf(fn: FrameRequestCallback): void {
   raf(() => raf(fn));

--- a/packages/vant-use/src/utils.ts
+++ b/packages/vant-use/src/utils.ts
@@ -14,14 +14,6 @@ export function cancelRaf(id: number) {
   }
 }
 
-export function useRaf(fn: FrameRequestCallback): () => void {
-  if (inBrowser) {
-    const id = requestAnimationFrame(fn);
-    return () => cancelAnimationFrame(id);
-  }
-  return () => {};
-}
-
 // double raf for animation
 export function doubleRaf(fn: FrameRequestCallback): void {
   raf(() => raf(fn));

--- a/packages/vant/docs/markdown/use-raf.en-US.md
+++ b/packages/vant/docs/markdown/use-raf.en-US.md
@@ -2,7 +2,7 @@
 
 ### Intro
 
-Provide convenient call and cancellation of [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)
+Provide convenient call and cancellation of [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame), automatically wrapped by requestAnimationFrame, to ensure that the callback function will be executed in every frame, the second parameter interval can be used to control how long the interval is called, and return a cancelRaf function to stop the continued execution.
 
 ## Usage
 

--- a/packages/vant/docs/markdown/use-raf.en-US.md
+++ b/packages/vant/docs/markdown/use-raf.en-US.md
@@ -8,9 +8,9 @@ Provide convenient call and cancellation of [requestAnimationFrame](https://deve
 
 ### Basic Usage
 
-```js
-// Single call demo
+### Single call
 
+```js
 import { useRaf } from '@vant/use';
 
 export default {
@@ -25,8 +25,9 @@ export default {
 };
 ```
 
+### Unlimited calls
+
 ```js
-// Unlimited calls demo
 import { useRaf } from '@vant/use';
 
 export default {

--- a/packages/vant/docs/markdown/use-raf.en-US.md
+++ b/packages/vant/docs/markdown/use-raf.en-US.md
@@ -17,7 +17,7 @@ import { useRaf } from '@vant/use';
 
 export default {
   setup() {
-    const count = ref(0);
+    let count = 0;
     const cancelRaf = useRaf(() => {
       count++;
       if (count === 10) {

--- a/packages/vant/docs/markdown/use-raf.en-US.md
+++ b/packages/vant/docs/markdown/use-raf.en-US.md
@@ -8,11 +8,9 @@ Provide convenient call and cancellation of [requestAnimationFrame](https://deve
 
 ### Basic Usage
 
-```html
-<div ref="root" />
-```
-
 ```js
+// Single call demo
+
 import { useRaf } from '@vant/use';
 
 export default {
@@ -23,13 +21,23 @@ export default {
       count++;
       console.log(count); // It will only be executed once.
     });
+  },
+};
+```
+
+```js
+// Unlimited calls demo
+import { useRaf } from '@vant/use';
+
+export default {
+  setup() {
     // isLoop Turn on the cycle
-    let count1 = 0;
+    let count = 0;
     const cancelRaf = useRaf(
       () => {
-        count1++;
-        console.log(count1); // Unlimited execution until it is cancelled.
-        if (count1 === 5) {
+        count++;
+        console.log(count); // Unlimited execution until it is cancelled.
+        if (count === 5) {
           cancelRaf();
         }
       },
@@ -47,18 +55,18 @@ export default {
 ### Type Declarations
 
 ```ts
-function useRaf(): {
-  callback: () => void;
+function useRaf(
+  callback: () => void,
   options: {
     interval?: number;
     isLoop?: boolean;
-  };
-};
+  },
+) {}
 ```
 
-### Return Value
+### Params
 
 | Name | Description | Type | Default |
 | --- | --- | --- | --- |
 | callback | Callback | _() => void_ | _() => void_ |
-| options | Options | _{interval?: number; isLoop?: boolean}_ | _{interval: 0; isLoop: false}_ |
+| options | Options | _{ interval?: number; isLoop?: boolean }_ | _{ interval: 0; isLoop: false }_ |

--- a/packages/vant/docs/markdown/use-raf.en-US.md
+++ b/packages/vant/docs/markdown/use-raf.en-US.md
@@ -1,0 +1,47 @@
+# useRaf
+
+### Intro
+
+Provide convenient call and cancellation of [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame)
+
+## Usage
+
+### Basic Usage
+
+```html
+<div ref="root" />
+```
+
+```js
+import { useRaf } from '@vant/use';
+
+export default {
+  setup() {
+    const count = ref(0);
+    const cancelRaf = useRaf(() => {
+      count++;
+      if (count === 10) {
+        cancelRaf();
+      }
+    }, 1000);
+  },
+};
+```
+
+## API
+
+### Type Declarations
+
+```ts
+function useRaf(): {
+  callback: () => void;
+  interval: number;
+};
+```
+
+### Return Value
+
+| Name     | Description | Type         |
+| -------- | ----------- | ------------ |
+| callback | Callback    | _() => void_ |
+| interval | Intervals   | _number_     |

--- a/packages/vant/docs/markdown/use-raf.en-US.md
+++ b/packages/vant/docs/markdown/use-raf.en-US.md
@@ -2,7 +2,7 @@
 
 ### Intro
 
-Provide convenient call and cancellation of [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame), automatically wrapped by requestAnimationFrame, to ensure that the callback function will be executed in every frame, the second parameter interval can be used to control how long the interval is called, and return a cancelRaf function to stop the continued execution.
+Provide convenient call and cancellation of [requestAnimationFrame](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame).
 
 ## Usage
 
@@ -18,12 +18,26 @@ import { useRaf } from '@vant/use';
 export default {
   setup() {
     let count = 0;
-    const cancelRaf = useRaf(() => {
+    // A single call will be automatically canceledRaf after the callback is executed.
+    useRaf(() => {
       count++;
-      if (count === 10) {
-        cancelRaf();
-      }
-    }, 1000);
+      console.log(count); // It will only be executed once.
+    });
+    // isLoop Turn on the cycle
+    let count1 = 0;
+    const cancelRaf = useRaf(
+      () => {
+        count1++;
+        console.log(count1); // Unlimited execution until it is cancelled.
+        if (count1 === 5) {
+          cancelRaf();
+        }
+      },
+      {
+        interval: 0, // control interval to call this function
+        isLoop: true,
+      },
+    );
   },
 };
 ```
@@ -35,13 +49,16 @@ export default {
 ```ts
 function useRaf(): {
   callback: () => void;
-  interval: number;
+  options: {
+    interval?: number;
+    isLoop?: boolean;
+  };
 };
 ```
 
 ### Return Value
 
-| Name     | Description | Type         |
-| -------- | ----------- | ------------ |
-| callback | Callback    | _() => void_ |
-| interval | Intervals   | _number_     |
+| Name | Description | Type | Default |
+| --- | --- | --- | --- |
+| callback | Callback | _() => void_ | _() => void_ |
+| options | Options | _{interval?: number; isLoop?: boolean}_ | _{interval: 0; isLoop: false}_ |

--- a/packages/vant/docs/markdown/use-raf.zh-CN.md
+++ b/packages/vant/docs/markdown/use-raf.zh-CN.md
@@ -1,0 +1,43 @@
+# useRaf
+
+### 介绍
+
+提供便捷的[requestAnimationFrame](https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame)的调用和取消
+
+## 代码演示
+
+### 基本用法
+
+```js
+import { useRaf } from '@vant/use';
+
+export default {
+  setup() {
+    const count = ref(0);
+    const cancelRaf = useRaf(() => {
+      count++;
+      if (count === 10) {
+        cancelRaf();
+      }
+    }, 1000);
+  },
+};
+```
+
+## API
+
+### 类型定义
+
+```ts
+function useRaf(): {
+  callback: () => void;
+  interval: number;
+};
+```
+
+### 返回值
+
+| 参数     | 说明     | 类型         |
+| -------- | -------- | ------------ |
+| callback | 回调函数 | _() => void_ |
+| interval | 间隔时间 | _number_     |

--- a/packages/vant/docs/markdown/use-raf.zh-CN.md
+++ b/packages/vant/docs/markdown/use-raf.zh-CN.md
@@ -2,7 +2,7 @@
 
 ### 介绍
 
-提供便捷的[requestAnimationFrame](https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame)的调用和取消, 自动被requestAnimationFrame包裹, 保证在每一帧都会执行回调函数,可通过第二个参数interval来控制间隔多久去调用，并返回一个cancelRaf的函数，去停止继续的执行。
+提供便捷的[requestAnimationFrame](https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame)的调用和取消。
 
 ## 代码演示
 
@@ -14,12 +14,26 @@ import { useRaf } from '@vant/use';
 export default {
   setup() {
     let count = 0;
-    const cancelRaf = useRaf(() => {
+    // 单次调用在回调执行完后会被自动cancelRaf
+    useRaf(() => {
       count++;
-      if (count === 10) {
-        cancelRaf();
-      }
-    }, 1000);
+      console.log(count); // 只会执行1次
+    });
+    // isLoop 开启循环
+    let count1 = 0;
+    const cancelRaf = useRaf(
+      () => {
+        count1++;
+        console.log(count1); // 无限的执行，直到被cancel
+        if (count1 === 5) {
+          cancelRaf();
+        }
+      },
+      {
+        interval: 0, // 控制间隔多久去调用
+        isLoop: true,
+      },
+    );
   },
 };
 ```
@@ -31,13 +45,16 @@ export default {
 ```ts
 function useRaf(): {
   callback: () => void;
-  interval: number;
+  options: {
+    interval?: number;
+    isLoop?: boolean;
+  };
 };
 ```
 
 ### 返回值
 
-| 参数     | 说明     | 类型         |
-| -------- | -------- | ------------ |
-| callback | 回调函数 | _() => void_ |
-| interval | 间隔时间 | _number_     |
+| 参数 | 说明 | 类型 | 默认 |
+| --- | --- | --- | --- |
+| callback | 回调函数 | _() => void_ | _() => void_ |
+| options | 配置参数 | _{interval?: number; isLoop?: boolean}_ | _{interval: 0; isLoop: false}_ |

--- a/packages/vant/docs/markdown/use-raf.zh-CN.md
+++ b/packages/vant/docs/markdown/use-raf.zh-CN.md
@@ -13,7 +13,7 @@ import { useRaf } from '@vant/use';
 
 export default {
   setup() {
-    const count = ref(0);
+    let count = 0;
     const cancelRaf = useRaf(() => {
       count++;
       if (count === 10) {

--- a/packages/vant/docs/markdown/use-raf.zh-CN.md
+++ b/packages/vant/docs/markdown/use-raf.zh-CN.md
@@ -2,7 +2,7 @@
 
 ### 介绍
 
-提供便捷的[requestAnimationFrame](https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame)的调用和取消
+提供便捷的[requestAnimationFrame](https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame)的调用和取消, 自动被requestAnimationFrame包裹, 保证在每一帧都会执行回调函数,可通过第二个参数interval来控制间隔多久去调用，并返回一个cancelRaf的函数，去停止继续的执行。
 
 ## 代码演示
 

--- a/packages/vant/docs/markdown/use-raf.zh-CN.md
+++ b/packages/vant/docs/markdown/use-raf.zh-CN.md
@@ -8,8 +8,9 @@
 
 ### 基本用法
 
+### 单次调用
+
 ```js
-// 单次调用 demo
 import { useRaf } from '@vant/use';
 
 export default {
@@ -20,27 +21,13 @@ export default {
       count++;
       console.log(count); // 只会执行 1 次
     });
-    // isLoop 开启循环
-    let count = 0;
-    const cancelRaf = useRaf(
-      () => {
-        count++;
-        console.log(count); // 无限的执行，直到被 cancel
-        if (count === 5) {
-          cancelRaf();
-        }
-      },
-      {
-        interval: 0, // 控制间隔多久去调用
-        isLoop: true,
-      },
-    );
   },
 };
 ```
 
+### 循环调用
+
 ```js
-// 无限调用 demo
 import { useRaf } from '@vant/use';
 
 export default {

--- a/packages/vant/docs/markdown/use-raf.zh-CN.md
+++ b/packages/vant/docs/markdown/use-raf.zh-CN.md
@@ -2,30 +2,56 @@
 
 ### 介绍
 
-提供便捷的[requestAnimationFrame](https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame)的调用和取消。
+提供便捷的 [requestAnimationFrame](https://developer.mozilla.org/zh-CN/docs/Web/API/window/requestAnimationFrame) 的调用和取消。
 
 ## 代码演示
 
 ### 基本用法
 
 ```js
+// 单次调用 demo
 import { useRaf } from '@vant/use';
 
 export default {
   setup() {
     let count = 0;
-    // 单次调用在回调执行完后会被自动cancelRaf
+    // 单次调用在回调执行完后会被自动 cancelRaf
     useRaf(() => {
       count++;
-      console.log(count); // 只会执行1次
+      console.log(count); // 只会执行 1 次
     });
     // isLoop 开启循环
-    let count1 = 0;
+    let count = 0;
     const cancelRaf = useRaf(
       () => {
-        count1++;
-        console.log(count1); // 无限的执行，直到被cancel
-        if (count1 === 5) {
+        count++;
+        console.log(count); // 无限的执行，直到被 cancel
+        if (count === 5) {
+          cancelRaf();
+        }
+      },
+      {
+        interval: 0, // 控制间隔多久去调用
+        isLoop: true,
+      },
+    );
+  },
+};
+```
+
+```js
+// 无限调用 demo
+import { useRaf } from '@vant/use';
+
+export default {
+  setup() {
+    // isLoop 开启循环
+    let count = 0;
+    const cancelRaf = useRaf(
+      () => {
+        count++;
+        console.log(count); // 无限的执行，直到被 cancel
+        if (count === 5) {
           cancelRaf();
         }
       },
@@ -43,18 +69,18 @@ export default {
 ### 类型定义
 
 ```ts
-function useRaf(): {
-  callback: () => void;
+function useRaf(
+  callback: () => void,
   options: {
     interval?: number;
     isLoop?: boolean;
-  };
-};
+  },
+) {}
 ```
 
-### 返回值
+### 参数
 
 | 参数 | 说明 | 类型 | 默认 |
 | --- | --- | --- | --- |
 | callback | 回调函数 | _() => void_ | _() => void_ |
-| options | 配置参数 | _{interval?: number; isLoop?: boolean}_ | _{interval: 0; isLoop: false}_ |
+| options | 配置参数 | _{ interval?: number; isLoop?: boolean }_ | _{ interval: 0; isLoop: false }_ |

--- a/packages/vant/docs/markdown/vant-use-intro.en-US.md
+++ b/packages/vant/docs/markdown/vant-use-intro.en-US.md
@@ -47,3 +47,4 @@ console.log(height.value); // -> window height
 | [useScrollParent](#/en-US/use-scroll-parent) | Get the closest parent element that is scrollable |
 | [useToggle](#/en-US/use-toggle) | Used to switch between `true` and `false` |
 | [useWindowSize](#/en-US/use-window-size) | Get the viewport width and height of the browser window |
+| [useRaf](#/zh-CN/use-raf) | Used to manage the requestAnimationFrame |

--- a/packages/vant/docs/markdown/vant-use-intro.zh-CN.md
+++ b/packages/vant/docs/markdown/vant-use-intro.zh-CN.md
@@ -51,3 +51,4 @@ console.log(height.value); // -> 窗口高度
 | [useScrollParent](#/zh-CN/use-scroll-parent) | 获取元素最近的可滚动父元素 |
 | [useToggle](#/zh-CN/use-toggle) | 用于在布尔值之间进行切换 |
 | [useWindowSize](#/zh-CN/use-window-size) | 获取浏览器窗口的视口宽度和高度 |
+| [useRaf](#/zh-CN/use-raf) | 提供requestAnimationFrame管理能力 |

--- a/packages/vant/vant.config.mjs
+++ b/packages/vant/vant.config.mjs
@@ -503,6 +503,10 @@ location.href = location.href.replace('youzan.github.io', 'vant-ui.github.io');
                 path: 'use-window-size',
                 title: 'useWindowSize',
               },
+              {
+                path: 'use-raf',
+                title: 'useRaf',
+              },
             ],
           },
         ],
@@ -966,6 +970,10 @@ location.href = location.href.replace('youzan.github.io', 'vant-ui.github.io');
               {
                 path: 'use-window-size',
                 title: 'useWindowSize',
+              },
+              {
+                path: 'use-raf',
+                title: 'useRaf',
               },
             ],
           },


### PR DESCRIPTION
Do you like this way to cancelRaf ?
we don't need to import { cancelRaf } from 'vant-use'
it's very common to use this way in `vueuse`