### PR TITLE
fix(Popup): auto focus after popup opened

### DIFF
--- a/packages/vant/src/popup/Popup.tsx
+++ b/packages/vant/src/popup/Popup.tsx
@@ -234,11 +234,11 @@ export default defineComponent({
         if (show && !opened) {
           open();
 
-          if (attrs.tabindex === 0) {
-            nextTick(() => {
-              popupRef.value?.focus();
-            });
-          }
+          nextTick(() => {
+            if (popupRef.value?.tabIndex === 0) {
+              popupRef.value.focus();
+            }
+          });
         }
         if (!show && opened) {
           opened = false;


### PR DESCRIPTION
目前代码中是通过组件的`attr.tabindex === 0`进行判断，但实际上如果不手动设置组件的`tabindex`，默认设置的`tabindex`是在组件内的div里的，`attr.tabindex`为`undefined`。
不知道是作者有意为之还是疏忽了，目前这种实现方式需要开发者手动指定`tabindex`为0才能自动聚焦，不太友好，应该让它变成默认行为。

Currently, the code judges by the component’s `attr.tabindex === 0`, but in fact, if the component’s `tabindex` is not manually set, the default `tabindex` is in the div inside the component, and `attr.tabindex` is undefined. I don’t know if the author did this intentionally or neglected it, but this implementation method requires developers to manually specify `tabindex` as 0 to achieve automatic focus, which is not very user-friendly. It should be made a default behavior.