### PR TITLE
docs: improve the menu position of back-top

### DIFF
--- a/packages/vant/vant.config.mjs
+++ b/packages/vant/vant.config.mjs
@@ -378,6 +378,10 @@ location.href = location.href.replace('youzan.github.io', 'vant-ui.github.io');
                 title: 'ActionBar 动作栏',
               },
               {
+                path: 'back-top',
+                title: 'BackTop 回到顶部',
+              },
+              {
                 path: 'grid',
                 title: 'Grid 宫格',
               },
@@ -408,10 +412,6 @@ location.href = location.href.replace('youzan.github.io', 'vant-ui.github.io');
               {
                 path: 'tree-select',
                 title: 'TreeSelect 分类选择',
-              },
-              {
-                path: 'back-top',
-                title: 'BackTop 回到顶部',
               },
             ],
           },
@@ -842,6 +842,10 @@ location.href = location.href.replace('youzan.github.io', 'vant-ui.github.io');
                 title: 'ActionBar',
               },
               {
+                path: 'back-top',
+                title: 'BackTop',
+              },
+              {
                 path: 'grid',
                 title: 'Grid',
               },
@@ -872,10 +876,6 @@ location.href = location.href.replace('youzan.github.io', 'vant-ui.github.io');
               {
                 path: 'tree-select',
                 title: 'TreeSelect',
-              },
-              {
-                path: 'back-top',
-                title: 'BackTop',
               },
             ],
           },


### PR DESCRIPTION
貌似文档的菜单导航，只有 `BackTop` 没有按字母排序，给修改下。