### PR TITLE
fix(eslint): eslint 不再支持.eslintignore文件, 需要在.eslintrc配置ignorePatterns

### DIFF
--- a/packages/vant/.eslintignore
+++ b/packages/vant/.eslintignore
@@ -1,4 +1,0 @@
-es
-lib
-dist
-node_modules

--- a/packages/vant/.eslintrc
+++ b/packages/vant/.eslintrc
@@ -7,6 +7,11 @@
   "globals": {
     "vi": true
   },
+  "ignorePatterns": [
+    "es",
+    "lib",
+    "node_modules"
+  ],
   "overrides": [
     {
       "files": ["src/**/*"],


### PR DESCRIPTION
我看了看，eslint 更新到比较新的版本，需要更改忽略的写法
https://github.com/eslint/eslint/issues/16264