### PR TITLE
fix(auto-import-resolver): type mismatch in TS projects

### DIFF
--- a/packages/vant-auto-import-resolver/src/index.ts
+++ b/packages/vant-auto-import-resolver/src/index.ts
@@ -43,7 +43,7 @@ export function VantResolver(options: VantResolverOptions = {}) {
   const moduleType = getModuleType(ssr);
 
   return {
-    type: 'component',
+    type: 'component' as const,
     resolve: (name: string) => {
       if (name.startsWith('Van')) {
         const partialName = name.slice(3);


### PR DESCRIPTION
Fix:

```text
Type '{ type: string; resolve: (name: string) => { name: string; from: string; sideEffects: string; }; }' is not assignable to type 'ComponentResolver | ComponentResolver[]'.
  Type '{ type: string; resolve: (name: string) => { name: string; from: string; sideEffects: string; }; }' is not assignable to type 'ComponentResolverObject'.
    Types of property 'type' are incompatible.
      Type 'string' is not assignable to type '"component" | "directive"'.ts(2322)
```