### PR TITLE
fix(floating-panel): 解决到最大可移动高度时往下拉会带动整个页面的问题

### DIFF
--- a/packages/vant/src/floating-panel/FloatingPanel.tsx
+++ b/packages/vant/src/floating-panel/FloatingPanel.tsx
@@ -120,7 +120,7 @@ export default defineComponent({
           return;
         }
       }
-
+      preventDefault(e, true);
       const moveY = touch.deltaY.value + startY;
       height.value = -ease(moveY);
     };


### PR DESCRIPTION
解决到最大可移动高度时往下拉会带动整个页面的问题

https://github.com/youzan/vant/assets/43991889/91b76b56-a46e-4469-a964-03243d0d8703

