### PR TITLE
fix(Signature): fix checking if canvas is empty when backgoundColor is set

### DIFF
--- a/packages/vant/src/signature/Signature.tsx
+++ b/packages/vant/src/signature/Signature.tsx
@@ -97,11 +97,11 @@ export default defineComponent({
       const empty = document.createElement('canvas');
       empty.width = canvas.width;
       empty.height = canvas.height;
-      // if(props.backgroundColor){
-      //   const emptyCtx = empty.getContext('2d');
-      //   emptyCtx!.fillStyle = props.backgroundColor;
-      //   emptyCtx!.fillRect(0, 0, empty.width, empty.height);
-      // }
+      if (props.backgroundColor) {
+        const emptyCtx = empty.getContext('2d');
+        emptyCtx!.fillStyle = props.backgroundColor;
+        emptyCtx!.fillRect(0, 0, empty.width, empty.height);
+      }
       return canvas.toDataURL() === empty.toDataURL();
     };
 
@@ -129,8 +129,6 @@ export default defineComponent({
             }[props.type] as () => string
           )?.() || canvas.toDataURL(`image/${props.type}`);
 
-      console.log(canvas);
-      console.log(canvas.toDataURL('image/jpeg', 0.8));
       emit('submit', {
         image,
         canvas,

--- a/packages/vant/src/signature/Signature.tsx
+++ b/packages/vant/src/signature/Signature.tsx
@@ -97,6 +97,11 @@ export default defineComponent({
       const empty = document.createElement('canvas');
       empty.width = canvas.width;
       empty.height = canvas.height;
+      // if(props.backgroundColor){
+      //   const emptyCtx = empty.getContext('2d');
+      //   emptyCtx!.fillStyle = props.backgroundColor;
+      //   emptyCtx!.fillRect(0, 0, empty.width, empty.height);
+      // }
       return canvas.toDataURL() === empty.toDataURL();
     };
 
@@ -124,6 +129,8 @@ export default defineComponent({
             }[props.type] as () => string
           )?.() || canvas.toDataURL(`image/${props.type}`);
 
+      console.log(canvas);
+      console.log(canvas.toDataURL('image/jpeg', 0.8));
       emit('submit', {
         image,
         canvas,

--- a/packages/vant/src/signature/Signature.tsx
+++ b/packages/vant/src/signature/Signature.tsx
@@ -99,16 +99,17 @@ export default defineComponent({
       empty.height = canvas.height;
       if (props.backgroundColor) {
         const emptyCtx = empty.getContext('2d');
-        emptyCtx!.fillStyle = props.backgroundColor;
-        emptyCtx!.fillRect(0, 0, empty.width, empty.height);
+        setCanvasBgColor(emptyCtx);
       }
       return canvas.toDataURL() === empty.toDataURL();
     };
 
-    const setCanvasBgColor = () => {
-      if (state.ctx && props.backgroundColor) {
-        state.ctx.fillStyle = props.backgroundColor;
-        state.ctx.fillRect(0, 0, state.width, state.height);
+    const setCanvasBgColor = (
+      ctx: CanvasRenderingContext2D | null | undefined,
+    ) => {
+      if (ctx && props.backgroundColor) {
+        ctx.fillStyle = props.backgroundColor;
+        ctx.fillRect(0, 0, state.width, state.height);
       }
     };
 
@@ -139,7 +140,7 @@ export default defineComponent({
       if (state.ctx) {
         state.ctx.clearRect(0, 0, state.width, state.height);
         state.ctx.closePath();
-        setCanvasBgColor();
+        setCanvasBgColor(state.ctx);
       }
       emit('clear');
     };
@@ -152,7 +153,7 @@ export default defineComponent({
 
         // ensure canvas is rendered
         nextTick(() => {
-          setCanvasBgColor();
+          setCanvasBgColor(state.ctx);
         });
       }
     });


### PR DESCRIPTION
Signature 组件在设置了背景色以后，如果未签名时直接点击submit，输出的image中会自带背景颜色的base64值，而实际并未进行签名，这样会导致判断是否已经签名不准确。