### PR TITLE
chore: bump pnpm v8.8.0

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,4 +2,3 @@ registry=https://registry.npmjs.org/
 
 strict-peer-dependencies=false
 auto-install-peers=false
-resolution-mode=highest

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "engines": {
     "pnpm": ">= 8.0.0"
   },
-  "packageManager": "pnpm@8.6.5",
+  "packageManager": "pnpm@8.8.0",
   "devDependencies": {
     "@vant/cli": "workspace:*",
     "@vant/eslint-config": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "*.{ts,tsx,js,vue}": "eslint --fix"
   },
   "engines": {
-    "pnpm": ">= 8.0.0"
+    "pnpm": ">= 8.8.0"
   },
   "packageManager": "pnpm@8.8.0",
   "devDependencies": {


### PR DESCRIPTION
No longer need `resolution-mode=highest` config
