### PR TITLE
chore(Field): required label css will active when rules contain required

### DIFF
--- a/packages/vant/src/contact-edit/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/contact-edit/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -8,7 +8,7 @@ exports[`should render demo and match snapshot 1`] = `
     <div class="van-contact-edit__fields">
       <div class="van-cell van-field">
         <div
-          class="van-cell__title van-field__label"
+          class="van-cell__title van-field__label van-field__label--required"
           style
         >
           <!--[-->

--- a/packages/vant/src/contact-edit/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/contact-edit/test/__snapshots__/demo.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`should render demo and match snapshot 1`] = `
   <form class="van-form van-contact-edit">
     <div class="van-contact-edit__fields">
       <div class="van-cell van-field">
-        <div class="van-cell__title van-field__label">
+        <div class="van-cell__title van-field__label van-field__label--required">
           <label
             id="van-field-label"
             for="van-field-input"

--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -193,6 +193,10 @@ export default defineComponent({
       return props.modelValue;
     });
 
+    const isRequired = computed(() => {
+      return props.rules?.some((rule: FieldRule) => rule.required);
+    });
+
     const runRules = (rules: FieldRule[]) =>
       rules.reduce(
         (promise, rule) =>
@@ -696,7 +700,10 @@ export default defineComponent({
           titleStyle={labelStyle.value}
           valueClass={bem('value')}
           titleClass={[
-            bem('label', [labelAlign, { required: props.required }]),
+            bem('label', [
+              labelAlign,
+              { required: isRequired.value || props.required },
+            ]),
             props.labelClass,
           ]}
           arrowDirection={props.arrowDirection}

--- a/packages/vant/src/field/test/index.spec.js
+++ b/packages/vant/src/field/test/index.spec.js
@@ -106,7 +106,19 @@ test('should render textarea when type is textarea', async () => {
   await later();
   expect(wrapper.html()).toMatchSnapshot();
 });
+test('should show required icon when using rules which contian required', async () => {
+  const wrapper = mount(Field, {
+    props: {
+      modelValue: '123',
+      label: '123',
+      rules: [{ required: false }],
+    },
+  });
 
+  expect(wrapper.find('.van-field__label--required').exists()).toBeFalsy();
+  await wrapper.setProps({ rules: [{ required: true }] });
+  expect(wrapper.find('.van-field__label--required').exists()).toBeTruthy();
+});
 test('should autosize textarea field', async () => {
   const wrapper = mount(Field, {
     props: {

--- a/packages/vant/src/form/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/form/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`should render demo and match snapshot 1`] = `
       <!--[-->
       <div class="van-cell van-field">
         <div
-          class="van-cell__title van-field__label"
+          class="van-cell__title van-field__label van-field__label--required"
           style
         >
           <!--[-->
@@ -38,7 +38,7 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div
-          class="van-cell__title van-field__label"
+          class="van-cell__title van-field__label van-field__label--required"
           style
         >
           <!--[-->

--- a/packages/vant/src/form/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/form/test/__snapshots__/demo.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`should render demo and match snapshot 1`] = `
   <form class="van-form">
     <div class="van-cell-group van-cell-group--inset">
       <div class="van-cell van-field">
-        <div class="van-cell__title van-field__label">
+        <div class="van-cell__title van-field__label van-field__label--required">
           <label
             id="van-field-label"
             for="van-field-input"
@@ -27,7 +27,7 @@ exports[`should render demo and match snapshot 1`] = `
         </div>
       </div>
       <div class="van-cell van-field">
-        <div class="van-cell__title van-field__label">
+        <div class="van-cell__title van-field__label van-field__label--required">
           <label
             id="van-field-label"
             for="van-field-input"


### PR DESCRIPTION
当使用field时填写rules，如果rule 中required为true，希望看见label带星号。而不是专门再写required 为true的prop。</br>
这次改动参考 element-plus form item中label是否带星号的计算。