### PR TITLE
refactor(docs): mobile document title pinned to top

### DIFF
--- a/packages/vant-cli/site/mobile/components/DemoNav.vue
+++ b/packages/vant-cli/site/mobile/components/DemoNav.vue
@@ -37,12 +37,14 @@ export default {
 
 <style lang="less">
 .demo-nav {
-  position: relative;
+  position: sticky;
+  top: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   height: 56px;
   background-color: var(--van-doc-background-3);
+  z-index: 100;
 
   &__title {
     font-weight: 600;


### PR DESCRIPTION
before:
<img width="541" alt="image" src="https://github.com/youzan/vant/assets/47295879/16e78c24-a6e3-4059-a36e-4d04a028342c">

after:
<img width="449" alt="image" src="https://github.com/youzan/vant/assets/47295879/96a904c9-22d4-4715-a05d-6770576b6f5f">

