### PR TITLE
docs(Tab): keep docs and example the same

### DIFF
--- a/packages/vant/src/tab/README.md
+++ b/packages/vant/src/tab/README.md
@@ -57,7 +57,7 @@ import { ref } from 'vue';
 
 export default {
   setup() {
-    const activeName = ref('a');
+    const activeName = ref('b');
     return { activeName };
   },
 };

--- a/packages/vant/src/tab/README.zh-CN.md
+++ b/packages/vant/src/tab/README.zh-CN.md
@@ -60,7 +60,7 @@ import { ref } from 'vue';
 
 export default {
   setup() {
-    const activeName = ref('a');
+    const activeName = ref('b');
     return { activeName };
   },
 };


### PR DESCRIPTION
示例选中的是第二个
<img width="379" alt="image" src="https://github.com/youzan/vant/assets/19986739/d5614df6-cb4b-4dea-941b-2886ccebe938">
