### PR TITLE
fix(@vant/area-data): add exports types

### DIFF
--- a/packages/vant-area-data/package.json
+++ b/packages/vant-area-data/package.json
@@ -7,9 +7,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.esm.mjs",
-      "require": "./dist/index.cjs.js",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.cjs.js"
     }
   },
   "sideEffects": false,

--- a/packages/vant-area-data/package.json
+++ b/packages/vant-area-data/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.esm.mjs",
-      "require": "./dist/index.cjs.js"
+      "require": "./dist/index.cjs.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "sideEffects": false,


### PR DESCRIPTION
When a project's tsconfig contains `"moduleResolution": "bundler"`, typescript error show 

`There are types at 'xxxxxx/node_modules/@vant/area-data/dist/index.d.ts', but this result could not be resolved when respecting package.json "exports". The '@vant/area-data' library may need to update its package.json or typing.`

After adding `types` in package.json, the error is fixed. Besides, if `moduleResolution` is `node` it works well.