### PR TITLE
chore: forked repo, skip CI running

### DIFF
--- a/.github/workflows/sync-gitee.yml
+++ b/.github/workflows/sync-gitee.yml
@@ -13,6 +13,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'youzan/vant'
     runs-on: ubuntu-latest
     steps:
       - name: Sync to Gitee


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-contrib.gitee.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-contrib.gitee.io/vant/#/zh-CN/contribution)。

fork vant 仓库后, 每天都有很多该CI失败的邮件提醒, 添加if, 非原始仓库不跑该CI.