### PR TITLE
feat(Row): gutter support vertical space

### DIFF
--- a/packages/vant/src/col/Col.tsx
+++ b/packages/vant/src/col/Col.tsx
@@ -31,13 +31,15 @@ export default defineComponent({
         return;
       }
 
-      const { spaces } = parent;
+      const { spaces, verticalSpaces } = parent;
 
       if (spaces && spaces.value && spaces.value[index.value]) {
         const { left, right } = spaces.value[index.value];
+        const { bottom } = verticalSpaces.value[index.value] || {};
         return {
           paddingLeft: left ? `${left}px` : null,
           paddingRight: right ? `${right}px` : null,
+          marginBottom: bottom ? `${bottom}px` : null,
         };
       }
     });

--- a/packages/vant/src/col/Col.tsx
+++ b/packages/vant/src/col/Col.tsx
@@ -43,10 +43,10 @@ export default defineComponent({
       }
 
       const { bottom } = verticalSpaces.value[index.value] || {};
-      extend(styles, {
+
+      return extend(styles, {
         marginBottom: bottom ? `${bottom}px` : null,
       });
-      return styles;
     });
 
     return () => {

--- a/packages/vant/src/col/Col.tsx
+++ b/packages/vant/src/col/Col.tsx
@@ -36,7 +36,6 @@ export default defineComponent({
       let styles = {};
       if (spaces && spaces.value && spaces.value[index.value]) {
         const { left, right } = spaces.value[index.value];
-
         styles = {
           paddingLeft: left ? `${left}px` : null,
           paddingRight: right ? `${right}px` : null,

--- a/packages/vant/src/col/Col.tsx
+++ b/packages/vant/src/col/Col.tsx
@@ -4,6 +4,7 @@ import {
   createNamespace,
   makeNumericProp,
   makeStringProp,
+  extend,
 } from '../utils';
 import { useParent } from '@vant/use';
 import { ROW_KEY } from '../row/Row';
@@ -32,16 +33,21 @@ export default defineComponent({
       }
 
       const { spaces, verticalSpaces } = parent;
-
+      let styles = {};
       if (spaces && spaces.value && spaces.value[index.value]) {
         const { left, right } = spaces.value[index.value];
-        const { bottom } = verticalSpaces.value[index.value] || {};
-        return {
+
+        styles = {
           paddingLeft: left ? `${left}px` : null,
           paddingRight: right ? `${right}px` : null,
-          marginBottom: bottom ? `${bottom}px` : null,
         };
       }
+
+      const { bottom } = verticalSpaces.value[index.value] || {};
+      extend(styles, {
+        marginBottom: bottom ? `${bottom}px` : null,
+      });
+      return styles;
     });
 
     return () => {

--- a/packages/vant/src/col/README.md
+++ b/packages/vant/src/col/README.md
@@ -99,7 +99,7 @@ If you want to set the vertical spacing, you can set `[horizontal,vertical]` as 
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| gutter | Grid spacing（px） | _number \| \_string_ \| Array\_ | - |
+| gutter | Grid spacing（px） | _number \| string \| Array_ | - |
 | tag | Custom element tag | _string_ | `div` |
 | justify | Flex main axis, can be set to end/center/space-around/space-between | _string_ | `start` |
 | align | Flex cross axis, be set to center/bottom | _string_ | `top` |

--- a/packages/vant/src/col/README.md
+++ b/packages/vant/src/col/README.md
@@ -45,15 +45,19 @@ Layout are based on 24-column. The attribute `span` in `Col` means the number of
 
 Set grid spacing using `gutter` attribute. The default value is 0.
 
-If you want to set the vertical spacing, you can set `[horizontal,vertical]` as an array.
-
 ```html
 <van-row gutter="20">
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
 </van-row>
+```
 
+### Vertical Spacing
+
+If you want to set the vertical spacing, you can set `[horizontal, vertical]` as an array.
+
+```html
 <!-- set the vertical spacing -->
 <van-row :gutter="[20, 20]">
   <van-col span="12">span: 12</van-col>

--- a/packages/vant/src/col/README.md
+++ b/packages/vant/src/col/README.md
@@ -55,13 +55,11 @@ If you want to set the vertical spacing, you can set `[horizontal,vertical]` as 
 </van-row>
 
 <!-- set the vertical spacing -->
-<van-row :gutter="[20,20]">
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
+<van-row :gutter="[20, 20]">
+  <van-col span="12">span: 12</van-col>
+  <van-col span="12">span: 12</van-col>
+  <van-col span="12">span: 12</van-col>
+  <van-col span="12">span: 12</van-col>
 </van-row>
 ```
 

--- a/packages/vant/src/col/README.md
+++ b/packages/vant/src/col/README.md
@@ -45,8 +45,20 @@ Layout are based on 24-column. The attribute `span` in `Col` means the number of
 
 Set grid spacing using `gutter` attribute. The default value is 0.
 
+If you want to set the vertical spacing, you can set `[horizontal,vertical]` as an array.
+
 ```html
 <van-row gutter="20">
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
+</van-row>
+
+<!-- set the vertical spacing -->
+<van-row :gutter="[20,20]">
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
@@ -87,7 +99,7 @@ Set grid spacing using `gutter` attribute. The default value is 0.
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| gutter | Grid spacing（px） | _number \| string_ | - |
+| gutter | Grid spacing（px） | _number \| \_string_ \| Array\_ | - |
 | tag | Custom element tag | _string_ | `div` |
 | justify | Flex main axis, can be set to end/center/space-around/space-between | _string_ | `start` |
 | align | Flex cross axis, be set to center/bottom | _string_ | `top` |

--- a/packages/vant/src/col/README.zh-CN.md
+++ b/packages/vant/src/col/README.zh-CN.md
@@ -44,8 +44,20 @@ Layout 组件提供了 `24列栅格`，通过在 `Col` 上添加 `span` 属性�
 
 通过 `gutter` 属性可以设置列元素之间的间距，默认间距为 0。
 
+如果需要设置垂直间距，可以使用数组形式设置 `[水平间距,垂直间距]`。
+
 ```html
 <van-row gutter="20">
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
+</van-row>
+
+<!-- 设置垂直间距 -->
+<van-row :gutter="[20,20]">
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
+  <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
@@ -92,7 +104,7 @@ Layout 组件提供了 `24列栅格`，通过在 `Col` 上添加 `span` 属性�
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| gutter | 列元素之间的间距（单位为 px） | _number \| string_ | - |
+| gutter | 列元素之间的间距（单位为 px） | _number \| \_string_ \| Array\_ | - |
 | tag | 自定义元素标签 | _string_ | `div` |
 | justify | 主轴对齐方式，可选值为 `end` `center` <br> `space-around` `space-between` | _string_ | `start` |
 | align | 交叉轴对齐方式，可选值为 `center` `bottom` | _string_ | `top` |

--- a/packages/vant/src/col/README.zh-CN.md
+++ b/packages/vant/src/col/README.zh-CN.md
@@ -54,13 +54,11 @@ Layout 组件提供了 `24列栅格`，通过在 `Col` 上添加 `span` 属性�
 </van-row>
 
 <!-- 设置垂直间距 -->
-<van-row :gutter="[20,20]">
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
-  <van-col span="8">span: 8</van-col>
+<van-row :gutter="[20, 20]">
+  <van-col span="12">span: 12</van-col>
+  <van-col span="12">span: 12</van-col>
+  <van-col span="12">span: 12</van-col>
+  <van-col span="12">span: 12</van-col>
 </van-row>
 ```
 

--- a/packages/vant/src/col/README.zh-CN.md
+++ b/packages/vant/src/col/README.zh-CN.md
@@ -104,7 +104,7 @@ Layout 组件提供了 `24列栅格`，通过在 `Col` 上添加 `span` 属性�
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| gutter | 列元素之间的间距（单位为 px） | _number \| \_string_ \| Array\_ | - |
+| gutter | 列元素之间的间距（单位为 px） | _number \| string \| Array_ | - |
 | tag | 自定义元素标签 | _string_ | `div` |
 | justify | 主轴对齐方式，可选值为 `end` `center` <br> `space-around` `space-between` | _string_ | `start` |
 | align | 交叉轴对齐方式，可选值为 `center` `bottom` | _string_ | `top` |

--- a/packages/vant/src/col/README.zh-CN.md
+++ b/packages/vant/src/col/README.zh-CN.md
@@ -44,15 +44,19 @@ Layout 组件提供了 `24列栅格`，通过在 `Col` 上添加 `span` 属性�
 
 通过 `gutter` 属性可以设置列元素之间的间距，默认间距为 0。
 
-如果需要设置垂直间距，可以使用数组形式设置 `[水平间距,垂直间距]`。
-
 ```html
 <van-row gutter="20">
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
   <van-col span="8">span: 8</van-col>
 </van-row>
+```
 
+### 垂直间距
+
+如果需要设置垂直间距，可以使用数组形式设置 `[水平间距, 垂直间距]`。
+
+```html
 <!-- 设置垂直间距 -->
 <van-row :gutter="[20, 20]">
   <van-col span="12">span: 12</van-col>

--- a/packages/vant/src/col/demo/index.vue
+++ b/packages/vant/src/col/demo/index.vue
@@ -39,6 +39,15 @@ const t = useTranslate({
       <van-col span="8">span: 8</van-col>
       <van-col span="8">span: 8</van-col>
     </van-row>
+
+    <van-row :gutter="[20, 20]">
+      <van-col span="8">span: 8</van-col>
+      <van-col span="8">span: 8</van-col>
+      <van-col span="8">span: 8</van-col>
+      <van-col span="8">span: 8</van-col>
+      <van-col span="8">span: 8</van-col>
+      <van-col span="8">span: 8</van-col>
+    </van-row>
   </demo-block>
 
   <demo-block :title="t('justify')">
@@ -76,6 +85,12 @@ const t = useTranslate({
 
   .van-doc-demo-block__title {
     padding-left: 0;
+  }
+
+  .van-row[style='row-gap: 20px;'] {
+    .van-col {
+      margin-bottom: 0;
+    }
   }
 
   .van-col {

--- a/packages/vant/src/col/demo/index.vue
+++ b/packages/vant/src/col/demo/index.vue
@@ -40,14 +40,14 @@ const t = useTranslate({
       <van-col span="8">span: 8</van-col>
     </van-row>
 
-    <van-row :gutter="[20, 20]">
-      <van-col span="8">span: 8</van-col>
-      <van-col span="8">span: 8</van-col>
-      <van-col span="8">span: 8</van-col>
-      <van-col span="8">span: 8</van-col>
-      <van-col span="8">span: 8</van-col>
-      <van-col span="8">span: 8</van-col>
-    </van-row>
+    <div class="demo-vertical-space">
+      <van-row :gutter="[20, 20]">
+        <van-col span="12">span: 12</van-col>
+        <van-col span="12">span: 12</van-col>
+        <van-col span="12">span: 12</van-col>
+        <van-col span="12">span: 12</van-col>
+      </van-row>
+    </div>
   </demo-block>
 
   <demo-block :title="t('justify')">
@@ -87,12 +87,6 @@ const t = useTranslate({
     padding-left: 0;
   }
 
-  .van-row[style='row-gap: 20px;'] {
-    .van-col {
-      margin-bottom: 0;
-    }
-  }
-
   .van-col {
     margin-bottom: 10px;
     color: var(--van-white);
@@ -108,6 +102,12 @@ const t = useTranslate({
     &:nth-child(even) {
       background-color: #66c6f2;
     }
+  }
+}
+
+.demo-vertical-space {
+  .van-col {
+    margin-bottom: 0;
   }
 }
 </style>

--- a/packages/vant/src/col/demo/index.vue
+++ b/packages/vant/src/col/demo/index.vue
@@ -7,10 +7,12 @@ const t = useTranslate({
   'zh-CN': {
     title2: '在列元素之间增加间距',
     justify: '对齐方式',
+    vertical: '垂直间距',
   },
   'en-US': {
     title2: 'Column Spacing',
     justify: 'Justify Content',
+    vertical: 'Vertical Spacing',
   },
 });
 </script>
@@ -39,7 +41,9 @@ const t = useTranslate({
       <van-col span="8">span: 8</van-col>
       <van-col span="8">span: 8</van-col>
     </van-row>
+  </demo-block>
 
+  <demo-block :title="t('vertical')">
     <div class="demo-vertical-space">
       <van-row :gutter="[20, 20]">
         <van-col span="12">span: 12</van-col>

--- a/packages/vant/src/col/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/col/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -82,6 +82,9 @@ exports[`should render demo and match snapshot 1`] = `
       span: 8
     </div>
   </div>
+</div>
+<div>
+  <!--[-->
   <div class="demo-vertical-space">
     <div class="van-row">
       <!--[-->

--- a/packages/vant/src/col/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/col/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -82,6 +82,54 @@ exports[`should render demo and match snapshot 1`] = `
       span: 8
     </div>
   </div>
+  <div
+    class="van-row"
+    style="row-gap:20px;"
+  >
+    <!--[-->
+    <div
+      style
+      class="van-col van-col--8"
+    >
+      <!--[-->
+      span: 8
+    </div>
+    <div
+      style
+      class="van-col van-col--8"
+    >
+      <!--[-->
+      span: 8
+    </div>
+    <div
+      style
+      class="van-col van-col--8"
+    >
+      <!--[-->
+      span: 8
+    </div>
+    <div
+      style
+      class="van-col van-col--8"
+    >
+      <!--[-->
+      span: 8
+    </div>
+    <div
+      style
+      class="van-col van-col--8"
+    >
+      <!--[-->
+      span: 8
+    </div>
+    <div
+      style
+      class="van-col van-col--8"
+    >
+      <!--[-->
+      span: 8
+    </div>
+  </div>
 </div>
 <div>
   <!--[-->

--- a/packages/vant/src/col/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/col/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -82,52 +82,37 @@ exports[`should render demo and match snapshot 1`] = `
       span: 8
     </div>
   </div>
-  <div
-    class="van-row"
-    style="row-gap:20px;"
-  >
-    <!--[-->
-    <div
-      style
-      class="van-col van-col--8"
-    >
+  <div class="demo-vertical-space">
+    <div class="van-row">
       <!--[-->
-      span: 8
-    </div>
-    <div
-      style
-      class="van-col van-col--8"
-    >
-      <!--[-->
-      span: 8
-    </div>
-    <div
-      style
-      class="van-col van-col--8"
-    >
-      <!--[-->
-      span: 8
-    </div>
-    <div
-      style
-      class="van-col van-col--8"
-    >
-      <!--[-->
-      span: 8
-    </div>
-    <div
-      style
-      class="van-col van-col--8"
-    >
-      <!--[-->
-      span: 8
-    </div>
-    <div
-      style
-      class="van-col van-col--8"
-    >
-      <!--[-->
-      span: 8
+      <div
+        style
+        class="van-col van-col--12"
+      >
+        <!--[-->
+        span: 12
+      </div>
+      <div
+        style
+        class="van-col van-col--12"
+      >
+        <!--[-->
+        span: 12
+      </div>
+      <div
+        style
+        class="van-col van-col--12"
+      >
+        <!--[-->
+        span: 12
+      </div>
+      <div
+        style
+        class="van-col van-col--12"
+      >
+        <!--[-->
+        span: 12
+      </div>
     </div>
   </div>
 </div>

--- a/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
@@ -48,6 +48,8 @@ exports[`should render demo and match snapshot 1`] = `
       span: 8
     </div>
   </div>
+</div>
+<div>
   <div class="demo-vertical-space">
     <div class="van-row">
       <div

--- a/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
@@ -48,6 +48,47 @@ exports[`should render demo and match snapshot 1`] = `
       span: 8
     </div>
   </div>
+  <div
+    class="van-row"
+    style="row-gap: 20px;"
+  >
+    <div
+      class="van-col van-col--8"
+      style="padding-right: 13.333333333333334px;"
+    >
+      span: 8
+    </div>
+    <div
+      style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
+      class="van-col van-col--8"
+    >
+      span: 8
+    </div>
+    <div
+      style="padding-left: 13.333333333333332px;"
+      class="van-col van-col--8"
+    >
+      span: 8
+    </div>
+    <div
+      class="van-col van-col--8"
+      style="padding-right: 13.333333333333334px;"
+    >
+      span: 8
+    </div>
+    <div
+      style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
+      class="van-col van-col--8"
+    >
+      span: 8
+    </div>
+    <div
+      style="padding-left: 13.333333333333332px;"
+      class="van-col van-col--8"
+    >
+      span: 8
+    </div>
+  </div>
 </div>
 <div>
   <div class="van-row van-row--justify-center">

--- a/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/col/test/__snapshots__/demo.spec.ts.snap
@@ -48,45 +48,32 @@ exports[`should render demo and match snapshot 1`] = `
       span: 8
     </div>
   </div>
-  <div
-    class="van-row"
-    style="row-gap: 20px;"
-  >
-    <div
-      class="van-col van-col--8"
-      style="padding-right: 13.333333333333334px;"
-    >
-      span: 8
-    </div>
-    <div
-      style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
-      class="van-col van-col--8"
-    >
-      span: 8
-    </div>
-    <div
-      style="padding-left: 13.333333333333332px;"
-      class="van-col van-col--8"
-    >
-      span: 8
-    </div>
-    <div
-      class="van-col van-col--8"
-      style="padding-right: 13.333333333333334px;"
-    >
-      span: 8
-    </div>
-    <div
-      style="padding-left: 6.666666666666666px; padding-right: 6.666666666666668px;"
-      class="van-col van-col--8"
-    >
-      span: 8
-    </div>
-    <div
-      style="padding-left: 13.333333333333332px;"
-      class="van-col van-col--8"
-    >
-      span: 8
+  <div class="demo-vertical-space">
+    <div class="van-row">
+      <div
+        class="van-col van-col--12"
+        style="padding-right: 10px; margin-bottom: 20px;"
+      >
+        span: 12
+      </div>
+      <div
+        style="padding-left: 10px; margin-bottom: 20px;"
+        class="van-col van-col--12"
+      >
+        span: 12
+      </div>
+      <div
+        class="van-col van-col--12"
+        style="padding-right: 10px;"
+      >
+        span: 12
+      </div>
+      <div
+        style="padding-left: 10px;"
+        class="van-col van-col--12"
+      >
+        span: 12
+      </div>
     </div>
   </div>
 </div>

--- a/packages/vant/src/col/test/index.spec.tsx
+++ b/packages/vant/src/col/test/index.spec.tsx
@@ -42,7 +42,7 @@ test('should render gutter correctly', () => {
   expect(wrapper.html()).toMatchSnapshot();
 });
 
-test('should render vertical gap when gutter is an array and provide the second parameter', () => {
+test('should render vertical space when gutter is an array and provide the second parameter', () => {
   const wrapper = mount({
     render: () => (
       <Row gutter={[16, 16]}>
@@ -55,7 +55,7 @@ test('should render vertical gap when gutter is an array and provide the second 
   expect(wrapper.find('.van-row').style.rowGap).toEqual('16px');
 });
 
-test('should not render vertical gap when gutter is an array and provide the second parameter as negative number', () => {
+test('should not render vertical space when gutter is an array and provide the second parameter as negative number', () => {
   const wrapper = mount({
     render: () => (
       <Row gutter={[16, -16]}>
@@ -66,4 +66,19 @@ test('should not render vertical gap when gutter is an array and provide the sec
   });
 
   expect(wrapper.find('.van-row').style.rowGap).toBeFalsy();
+});
+
+test('should not render space when gutter is an empty array', () => {
+  const wrapper = mount({
+    render: () => (
+      <Row gutter={[]}>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
+      </Row>
+    ),
+  });
+
+  const colList = wrapper.findAll('.van-col');
+  expect(colList[0].style.paddingRight).toBeFalsy();
+  expect(colList[1].style.paddingLeft).toBeFalsy();
 });

--- a/packages/vant/src/col/test/index.spec.tsx
+++ b/packages/vant/src/col/test/index.spec.tsx
@@ -1,6 +1,7 @@
 import { Col } from '..';
 import { Row } from '../../row';
 import { mount } from '../../../test';
+import { nextTick } from 'vue';
 
 test('should render Col correctly', () => {
   const wrapper = mount(Col, {
@@ -42,43 +43,59 @@ test('should render gutter correctly', () => {
   expect(wrapper.html()).toMatchSnapshot();
 });
 
-test('should render vertical space when gutter is an array and provide the second parameter', () => {
+test('should render vertical space when gutter is an array and provide the second parameter', async () => {
   const wrapper = mount({
     render: () => (
-      <Row gutter={[16, 16]}>
+      <Row gutter={[20, 20]}>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
         <Col span="12">12</Col>
         <Col span="12">12</Col>
       </Row>
     ),
   });
 
-  expect(wrapper.find('.van-row').style.rowGap).toEqual('16px');
+  const fields = wrapper.findAll('.van-col');
+  await nextTick();
+  expect(fields[0].style.marginBottom).toEqual('20px');
+  expect(fields[1].style.marginBottom).toEqual('20px');
+  expect(fields[2].style.marginBottom).toBeFalsy();
+  expect(fields[3].style.marginBottom).toBeFalsy();
 });
 
-test('should not render vertical space when gutter is an array and provide the second parameter as negative number', () => {
+test('should not render vertical space when gutter is an array and provide the second parameter as negative number', async () => {
   const wrapper = mount({
     render: () => (
       <Row gutter={[16, -16]}>
         <Col span="12">12</Col>
         <Col span="12">12</Col>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
       </Row>
     ),
   });
 
-  expect(wrapper.find('.van-row').style.rowGap).toBeFalsy();
+  const fields = wrapper.findAll('.van-col');
+  await nextTick();
+  fields.forEach((field) => {
+    expect(field.style.marginBottom).toBeFalsy();
+  });
 });
 
-test('should not render space when gutter is an empty array', () => {
+test('should not render space when gutter is an empty array', async () => {
   const wrapper = mount({
     render: () => (
       <Row gutter={[]}>
         <Col span="12">12</Col>
         <Col span="12">12</Col>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
       </Row>
     ),
   });
 
-  const colList = wrapper.findAll('.van-col');
-  expect(colList[0].style.paddingRight).toBeFalsy();
-  expect(colList[1].style.paddingLeft).toBeFalsy();
+  const field = wrapper.findAll('.van-col')[0];
+  await nextTick();
+  expect(field.style.paddingRight).toBeFalsy();
+  expect(field.style.marginBottom).toBeFalsy();
 });

--- a/packages/vant/src/col/test/index.spec.tsx
+++ b/packages/vant/src/col/test/index.spec.tsx
@@ -55,7 +55,6 @@ test('should render vertical gap when gutter is an array and provide the second 
   expect(wrapper.find('.van-row').style.rowGap).toEqual('16px');
 });
 
-// 垂直间距设置为负数的时候，不应该设置 rowGap
 test('should not render vertical gap when gutter is an array and provide the second parameter as negative number', () => {
   const wrapper = mount({
     render: () => (

--- a/packages/vant/src/col/test/index.spec.tsx
+++ b/packages/vant/src/col/test/index.spec.tsx
@@ -41,3 +41,30 @@ test('should render gutter correctly', () => {
 
   expect(wrapper.html()).toMatchSnapshot();
 });
+
+test('should render vertical gap when gutter is an array and provide the second parameter', () => {
+  const wrapper = mount({
+    render: () => (
+      <Row gutter={[16, 16]}>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
+      </Row>
+    ),
+  });
+
+  expect(wrapper.find('.van-row').style.rowGap).toEqual('16px');
+});
+
+// 垂直间距设置为负数的时候，不应该设置 rowGap
+test('should not render vertical gap when gutter is an array and provide the second parameter as negative number', () => {
+  const wrapper = mount({
+    render: () => (
+      <Row gutter={[16, -16]}>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
+      </Row>
+    ),
+  });
+
+  expect(wrapper.find('.van-row').style.rowGap).toBeFalsy();
+});

--- a/packages/vant/src/col/test/index.spec.tsx
+++ b/packages/vant/src/col/test/index.spec.tsx
@@ -46,7 +46,7 @@ test('should render gutter correctly', () => {
 test('should render vertical space when gutter is an array and provide the second parameter', async () => {
   const wrapper = mount({
     render: () => (
-      <Row gutter={[20, 20]}>
+      <Row gutter={[0, 20]}>
         <Col span="12">12</Col>
         <Col span="12">12</Col>
         <Col span="12">12</Col>
@@ -97,5 +97,21 @@ test('should not render space when gutter is an empty array', async () => {
   const field = wrapper.findAll('.van-col')[0];
   await nextTick();
   expect(field.style.paddingRight).toBeFalsy();
+  expect(field.style.marginBottom).toBeFalsy();
+});
+
+test('should not render vertical space when gutter is an array and provide the second parameter as NaN', async () => {
+  const wrapper = mount({
+    render: () => (
+      <Row gutter={[0, 'invalid']}>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
+        <Col span="12">12</Col>
+      </Row>
+    ),
+  });
+  const field = wrapper.findAll('.van-col')[0];
+  await nextTick();
   expect(field.style.marginBottom).toBeFalsy();
 });

--- a/packages/vant/src/col/test/index.spec.tsx
+++ b/packages/vant/src/col/test/index.spec.tsx
@@ -100,7 +100,7 @@ test('should not render space when gutter is an empty array', async () => {
   expect(field.style.marginBottom).toBeFalsy();
 });
 
-test('should not render vertical space when gutter is an array and provide the second parameter as NaN', async () => {
+test('should not render vertical space when gutter is an array and provide the second parameter as invalid number', async () => {
   const wrapper = mount({
     render: () => (
       <Row gutter={[0, 'invalid']}>
@@ -111,6 +111,7 @@ test('should not render vertical space when gutter is an array and provide the s
       </Row>
     ),
   });
+
   const field = wrapper.findAll('.van-col')[0];
   await nextTick();
   expect(field.style.marginBottom).toBeFalsy();

--- a/packages/vant/src/row/Row.tsx
+++ b/packages/vant/src/row/Row.tsx
@@ -12,9 +12,11 @@ import { useChildren } from '@vant/use';
 const [name, bem] = createNamespace('row');
 
 export type RowSpaces = { left?: number; right: number }[];
+export type VerticalSpaces = { bottom?: number }[];
 
 export type RowProvide = {
   spaces: ComputedRef<RowSpaces>;
+  verticalSpaces: ComputedRef<VerticalSpaces>;
 };
 
 export const ROW_KEY: InjectionKey<RowProvide> = Symbol(name);
@@ -99,21 +101,29 @@ export default defineComponent({
       return spaces;
     });
 
-    const rowGap = computed(() => {
+    const verticalSpaces = computed(() => {
       const { gutter } = props;
+      const spaces: VerticalSpaces = [];
       if (Array.isArray(gutter) && gutter.length > 1) {
-        const rowGutter = Number(gutter[1]);
-        if (rowGutter > 0) {
-          return `${rowGutter}px`;
+        const bottom = Number(gutter[1]) || 0;
+        if (bottom <= 0) {
+          return spaces;
         }
+        groups.value.forEach((group, index) => {
+          group.forEach(() => {
+            if (index !== groups.value.length - 1) {
+              spaces.push({ bottom: bottom });
+            }
+          });
+        });
       }
+      return spaces;
     });
 
-    linkChildren({ spaces });
+    linkChildren({ spaces, verticalSpaces });
 
     return () => {
       const { tag, wrap, align, justify } = props;
-      const tagProps = rowGap.value ? { style: { rowGap: rowGap.value } } : {};
       return (
         <tag
           class={bem({
@@ -121,7 +131,6 @@ export default defineComponent({
             [`justify-${justify}`]: justify,
             nowrap: !wrap,
           })}
-          {...tagProps}
         >
           {slots.default?.()}
         </tag>

--- a/packages/vant/src/row/Row.tsx
+++ b/packages/vant/src/row/Row.tsx
@@ -110,10 +110,9 @@ export default defineComponent({
           return spaces;
         }
         groups.value.forEach((group, index) => {
+          if (index === groups.value.length - 1) return;
           group.forEach(() => {
-            if (index !== groups.value.length - 1) {
-              spaces.push({ bottom });
-            }
+            spaces.push({ bottom });
           });
         });
       }

--- a/packages/vant/src/row/Row.tsx
+++ b/packages/vant/src/row/Row.tsx
@@ -112,7 +112,7 @@ export default defineComponent({
         groups.value.forEach((group, index) => {
           group.forEach(() => {
             if (index !== groups.value.length - 1) {
-              spaces.push({ bottom: bottom });
+              spaces.push({ bottom });
             }
           });
         });


### PR DESCRIPTION
The `gutter` property of the `Row` component supports setting both horizontal and vertical spacing as an array.

close #12431 