### PR TITLE
perf(TextEllipsis): reuse windowWidth to avoid repeat calculations

### DIFF
--- a/packages/vant/src/text-ellipsis/TextEllipsis.tsx
+++ b/packages/vant/src/text-ellipsis/TextEllipsis.tsx
@@ -7,11 +7,13 @@ import {
   type ExtractPropTypes,
 } from 'vue';
 
-// Composables
-import { useEventListener } from '@vant/use';
-
 // Utils
-import { makeNumericProp, makeStringProp, createNamespace } from '../utils';
+import {
+  makeNumericProp,
+  makeStringProp,
+  createNamespace,
+  windowWidth,
+} from '../utils';
 
 const [name, bem] = createNamespace('text-ellipsis');
 
@@ -196,9 +198,10 @@ export default defineComponent({
 
     onMounted(calcEllipsised);
 
-    watch(() => [props.content, props.rows, props.position], calcEllipsised);
-
-    useEventListener('resize', calcEllipsised);
+    watch(
+      [windowWidth, () => [props.content, props.rows, props.position]],
+      calcEllipsised,
+    );
 
     return () => (
       <div ref={root} class={bem()}>


### PR DESCRIPTION
1. Recalculation is only needed when the window width changes.
2. By reusing the windowWidth variable, we can avoid registering event listeners multiple times.