### PR TITLE
docs(TreeSelect): fix incorrect activeIds variable name

### DIFF
--- a/packages/vant/src/tree-select/README.md
+++ b/packages/vant/src/tree-select/README.md
@@ -79,7 +79,7 @@ import { ref } from 'vue';
 
 export default {
   setup() {
-    const activeId = ref([1, 2]);
+    const activeIds = ref([1, 2]);
     const activeIndex = ref(0);
     const items = [
       {
@@ -103,7 +103,7 @@ export default {
 
     return {
       items,
-      activeId,
+      activeIds,
       activeIndex,
     };
   },

--- a/packages/vant/src/tree-select/README.zh-CN.md
+++ b/packages/vant/src/tree-select/README.zh-CN.md
@@ -83,7 +83,7 @@ import { ref } from 'vue';
 
 export default {
   setup() {
-    const activeId = ref([1, 2]);
+    const activeIds = ref([1, 2]);
     const activeIndex = ref(0);
     const items = [
       {
@@ -107,7 +107,7 @@ export default {
 
     return {
       items,
-      activeId,
+      activeIds,
       activeIndex,
     };
   },


### PR DESCRIPTION
TreeSelect 组件的多选模式，activeId 变量修改为 activeIds
resolve #12474 