### PR TITLE
perf: disable source map to make compilation faster

### DIFF
--- a/packages/vant-cli/src/compiler/compile-site.ts
+++ b/packages/vant-cli/src/compiler/compile-site.ts
@@ -58,6 +58,8 @@ export async function compileSite(isProd = false) {
     },
     output: {
       assetPrefix,
+      // make compilation faster
+      disableSourceMap: true,
       distPath: {
         root: vantConfig.build?.site?.outputDir || SITE_DIST_DIR,
       },


### PR DESCRIPTION
Disable source map to make compilation faster.

Compile time: 7s -> 4.5s.

![image](https://github.com/youzan/vant/assets/7237365/1d3759b1-67df-45d7-acc6-3507741f5fd2)

We will provide a better solution to enable dev source map, such as Rspack lazy compilation.
