### PR TITLE
fix(ImagePreview): double-scale and close-on-click-overlay may not work in certain scenarios

### DIFF
--- a/packages/vant/src/image-preview/ImagePreviewItem.tsx
+++ b/packages/vant/src/image-preview/ImagePreviewItem.tsx
@@ -251,6 +251,14 @@ export default defineComponent({
       }
     };
 
+    const checkClose = (event: TouchEvent) => {
+      const isClickOverlay = event.target === swipeItem.value?.$el;
+
+      if (!props.closeOnClickOverlay && isClickOverlay) return;
+
+      emit('close');
+    };
+
     const checkTap = (event: TouchEvent) => {
       if (fingerNum > 1) {
         return;
@@ -272,19 +280,13 @@ export default defineComponent({
               doubleTapTimer = null;
               toggleScale();
             } else {
-              if (
-                !props.closeOnClickOverlay &&
-                event.target === swipeItem.value?.$el
-              ) {
-                return;
-              }
               doubleTapTimer = setTimeout(() => {
-                emit('close');
+                checkClose(event);
                 doubleTapTimer = null;
               }, TAP_TIME);
             }
           } else {
-            emit('close');
+            checkClose(event);
           }
         }
         // long press

--- a/packages/vant/src/image-preview/test/shared.ts
+++ b/packages/vant/src/image-preview/test/shared.ts
@@ -1,6 +1,7 @@
+import { nextTick } from 'vue';
 import { DOMWrapper } from '@vue/test-utils/dist/domWrapper';
 import { cdnURL } from '../../../docs/site';
-import { trigger } from '../../../test';
+import { trigger, triggerDrag } from '../../../test';
 
 export const images = [
   cdnURL('apple-1.jpeg'),
@@ -37,4 +38,15 @@ export function triggerZoom(
   }
 
   trigger(el, 'touchend', 0, 0, { touchList: [] });
+}
+
+export function triggerDoubleTap(
+  el: HTMLElement | DOMWrapper<Element>,
+  x: number = 0,
+  y: number = 0,
+) {
+  triggerDrag(el, x, y);
+  triggerDrag(el, x, y);
+
+  return nextTick();
 }


### PR DESCRIPTION
Fix the two issues below:
1. When `double-scale` is set to false, `close-on-click-overlay` will not work.
2. When `close-on-click-overlay` is set to false, double-click zooming will not work.