### PR TITLE
feat(RollingText): add `RollingTextGroup`

### DIFF
--- a/packages/vant/src/rolling-text/RollingText.tsx
+++ b/packages/vant/src/rolling-text/RollingText.tsx
@@ -8,7 +8,7 @@ import {
 } from 'vue';
 
 // Utils
-import { raf, useChildren } from '@vant/use';
+import { raf, useParent } from '@vant/use';
 import {
   padZero,
   truthProp,
@@ -23,6 +23,7 @@ import { useExpose } from '../composables/use-expose';
 
 // Components
 import RollingTextItem from './RollingTextItem';
+import { ROLLING_TEXT_GROUP_KEY } from './RollingTextGroup';
 
 // Types
 import {
@@ -42,6 +43,7 @@ export const rollingTextProps = {
   direction: makeStringProp<RollingTextDirection>('down'),
   stopOrder: makeStringProp<RollingTextStopOrder>('ltr'),
   height: makeNumberProp(40),
+  delay: makeNumberProp(0),
 };
 
 const CIRCLE_NUM = 2;
@@ -54,8 +56,7 @@ export default defineComponent({
 
   props: rollingTextProps,
 
-  setup(props, { slots }) {
-    const { children, linkChildren } = useChildren(ROLLING_TEXT_KEY);
+  setup(props) {
 
     const isCustomType = computed(
       () => Array.isArray(props.textList) && props.textList.length,
@@ -129,37 +130,26 @@ export default defineComponent({
       },
     );
 
+    useParent(ROLLING_TEXT_GROUP_KEY);
     useExpose<RollingTextExpose>({
       start,
       reset,
     });
 
-    if (slots.default) {
-      console.log(slots.default());
-    }
-
-    const renderContent = () => {
-      if (slots.default) {
-        return slots.default()
-      }
-      console.log(isCustomType.value ? getTextArrByIdx(0) : getFigureArr(0));
-      return targetNumArr.value.map((_, i) => (
-        <RollingTextItem
-          figureArr={
-            isCustomType.value ? getTextArrByIdx(i) : getFigureArr(i)
-          }
-          duration={props.duration}
-          direction={props.direction}
-          isStart={rolling.value}
-          height={props.height}
-          delay={getDelay(i, itemLength.value)}
-        />
-      ))
-    }
-
     return () => (
       <div class={bem()}>
-        {renderContent()}
+        {targetNumArr.value.map((_, i) => (
+          <RollingTextItem
+            figureArr={
+              isCustomType.value ? getTextArrByIdx(i) : getFigureArr(i)
+            }
+            duration={props.duration}
+            direction={props.direction}
+            isStart={rolling.value}
+            height={props.height}
+            delay={getDelay(i, itemLength.value)}
+          />
+        ))}
       </div>
     );
   },

--- a/packages/vant/src/rolling-text/RollingTextGroup.tsx
+++ b/packages/vant/src/rolling-text/RollingTextGroup.tsx
@@ -1,0 +1,36 @@
+import { defineComponent, type InjectionKey } from 'vue';
+
+// Utils
+import { createNamespace } from '../utils';
+
+// Composables
+import { useChildren } from '@vant/use';
+
+const [name, bem] = createNamespace('rolling-text-group');
+
+export type RollingTextGroupProvide = Record<string, string>;
+export const ROLLING_TEXT_GROUP_KEY: InjectionKey<RollingTextGroupProvide> =
+  Symbol(name);
+
+export default defineComponent({
+  name,
+
+  setup(_, { slots }) {
+    const { children, linkChildren } = useChildren(ROLLING_TEXT_GROUP_KEY);
+    linkChildren();
+
+    const start = () => {
+      children.map(ins => {
+        ins.start()
+      })
+    };
+    if (slots.default) {
+      return () => (
+        <div class={bem()}>
+          <button onClick={start}>start</button>
+          {slots.default!()}
+        </div>
+      );
+    }
+  },
+});

--- a/packages/vant/src/rolling-text/index.ts
+++ b/packages/vant/src/rolling-text/index.ts
@@ -1,7 +1,9 @@
 import { withInstall } from '../utils';
 import _RollingText from './RollingText';
+import _RollingTextItem from './RollingTextItem';
 
 export const RollingText = withInstall(_RollingText);
+export const RollingTextItem = withInstall(_RollingTextItem);
 export default RollingText;
 export { rollingTextProps } from './RollingText';
 export type { RollingTextProps } from './RollingText';
@@ -15,5 +17,6 @@ export type {
 declare module 'vue' {
   export interface GlobalComponents {
     VanRollingText: typeof _RollingText;
+    VanRollingTextItem: typeof _RollingTextItem;
   }
 }

--- a/packages/vant/src/rolling-text/index.ts
+++ b/packages/vant/src/rolling-text/index.ts
@@ -1,9 +1,11 @@
 import { withInstall } from '../utils';
 import _RollingText from './RollingText';
 import _RollingTextItem from './RollingTextItem';
+import _RollingTextGroup from './RollingTextGroup';
 
 export const RollingText = withInstall(_RollingText);
 export const RollingTextItem = withInstall(_RollingTextItem);
+export const RollingTextGroup = withInstall(_RollingTextGroup);
 export default RollingText;
 export { rollingTextProps } from './RollingText';
 export type { RollingTextProps } from './RollingText';
@@ -18,5 +20,6 @@ declare module 'vue' {
   export interface GlobalComponents {
     VanRollingText: typeof _RollingText;
     VanRollingTextItem: typeof _RollingTextItem;
+    VanRollingTextGroup: typeof _RollingTextGroup;
   }
 }


### PR DESCRIPTION
issue: #12477

# ⚠️ under development!

# Demo Preview
```html
<RollingTextGroup>
  <VanRollingText :start-num="0" :target-num="6" :delay="0" :auto-start="false" />
  <VanRollingText :start-num="0" :target-num="6" :delay="1" :auto-start="false" />
  <span style="display: inline;">.</span>
  <VanRollingText :start-num="0" :target-num="6" :delay="0.5" :auto-start="false" />
  <VanRollingText :start-num="0" :target-num="6" :delay="0.3" :auto-start="false" />
</RollingTextGroup>
```

# TODO
- [ ] support control multi `rolling-text`
- [ ] `rolling-text` add `delay` prop
- [ ] update README
- [ ] update demo
- [ ] pass unit test