### PR TITLE
chore: avoid workflow running on forked repo

### DIFF
--- a/.github/workflows/deploy-v4-site.yml
+++ b/.github/workflows/deploy-v4-site.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   build-and-deploy:
+    if: github.repository == 'youzan/vant'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️


### PR DESCRIPTION
在 fork 的项目中同步 Vant 代码后会执行 deploy-v4-site，然后运行失败

我想它不应该被执行

Before submitting a pull request, please read the [contributing guide](https://vant-contrib.gitee.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-contrib.gitee.io/vant/#/zh-CN/contribution)。
