### PR TITLE
fix(NumberKeyboard): render delete slot correctly when theme is custom

### DIFF
--- a/packages/vant/src/number-keyboard/NumberKeyboard.tsx
+++ b/packages/vant/src/number-keyboard/NumberKeyboard.tsx
@@ -237,7 +237,7 @@ export default defineComponent({
           <div class={bem('sidebar')}>
             {props.showDeleteKey && (
               <NumberKeyboardKey
-                v-slots={{ delete: slots.delete }}
+                v-slots={{ default: slots.delete }}
                 large
                 text={props.deleteButtonText}
                 type="delete"

--- a/packages/vant/src/number-keyboard/test/__snapshots__/index.spec.ts.snap
+++ b/packages/vant/src/number-keyboard/test/__snapshots__/index.spec.ts.snap
@@ -1,5 +1,25 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`should render delete slot correctly 1`] = `
+<div
+  role="button"
+  tabindex="0"
+  class="van-key van-key--delete"
+>
+  Custom Delete Key
+</div>
+`;
+
+exports[`should render delete slot correctly when theme is custom 1`] = `
+<div
+  role="button"
+  tabindex="0"
+  class="van-key van-key--large van-key--delete"
+>
+  Custom Delete Key
+</div>
+`;
+
 exports[`should render extra key correctly when using extra-key prop 1`] = `
 <div
   role="button"

--- a/packages/vant/src/number-keyboard/test/index.spec.ts
+++ b/packages/vant/src/number-keyboard/test/index.spec.ts
@@ -105,6 +105,29 @@ test('should render extra-key slot correctly', () => {
   expect(wrapper.findAll('.van-key')[9].html()).toMatchSnapshot();
 });
 
+test('should render delete slot correctly', () => {
+  const wrapper = mount(NumberKeyboard, {
+    slots: {
+      delete: () => 'Custom Delete Key',
+    },
+  });
+
+  expect(wrapper.find('.van-key--delete').html()).toMatchSnapshot();
+});
+
+test('should render delete slot correctly when theme is custom', () => {
+  const wrapper = mount(NumberKeyboard, {
+    props: {
+      theme: 'custom',
+    },
+    slots: {
+      delete: () => 'Custom Delete Key',
+    },
+  });
+
+  expect(wrapper.find('.van-key--delete').html()).toMatchSnapshot();
+});
+
 test('should emit blur event after clicking outside', () => {
   const wrapper = mount(NumberKeyboard, {
     props: {


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-contrib.gitee.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-contrib.gitee.io/vant/#/zh-CN/contribution)。
