### PR TITLE
fix(ImagePreview): allow user to swipe to next image when the current image is moved to the edge

### DIFF
--- a/packages/vant/src/image-preview/ImagePreview.tsx
+++ b/packages/vant/src/image-preview/ImagePreview.tsx
@@ -190,6 +190,7 @@ export default defineComponent({
             doubleScale={props.doubleScale}
             closeOnClickImage={props.closeOnClickImage}
             closeOnClickOverlay={props.closeOnClickOverlay}
+            vertical={props.vertical}
             onScale={emitScale}
             onClose={emitClose}
             onLongPress={() => emit('longPress', { index })}

--- a/packages/vant/src/image-preview/ImagePreviewItem.tsx
+++ b/packages/vant/src/image-preview/ImagePreviewItem.tsx
@@ -56,6 +56,7 @@ const imagePreviewItemProps = {
   doubleScale: Boolean,
   closeOnClickImage: Boolean,
   closeOnClickOverlay: Boolean,
+  vertical: Boolean,
 };
 
 export type ImagePreviewItemProps = ExtractPropTypes<
@@ -225,9 +226,10 @@ export default defineComponent({
         // if the image is moved to the edge, no longer trigger move,
         // allow user to swipe to next image
         if (
-          (moveX > maxMoveX.value || moveX < -maxMoveX.value) &&
-          !isImageMoved &&
-          touch.isHorizontal()
+          (props.vertical
+            ? touch.isVertical() && Math.abs(moveY) > maxMoveY.value
+            : touch.isHorizontal() && Math.abs(moveX) > maxMoveX.value) &&
+          !isImageMoved
         ) {
           state.moving = false;
           return;


### PR DESCRIPTION
relate PR: #12660

Vertical scrolling also involves the logic when the image is moved to the edge.