### PR TITLE
docs(changelog): vant@4.8.6

### DIFF
--- a/packages/vant/docs/markdown/changelog.en-US.md
+++ b/packages/vant/docs/markdown/changelog.en-US.md
@@ -19,6 +19,45 @@ Vant follows [Semantic Versioning 2.0.0](https://semver.org/lang/zh-CN/).
 
 ## Details
 
+### v4.8.6
+
+`2024-03-17`
+
+#### New Features 🎉
+
+- feat(ImagePreview): add vertical prop by [@suncohey](https://github.com/suncohey) in [#12660](https://github.com/youzan/vant/pull/12660)
+- feat(signature): export clear and submit method by [@chouchouji](https://github.com/chouchouji) in [#12654](https://github.com/youzan/vant/pull/12654)
+- feat: support unplugin-auto-import plugin by [@DragonnZhang](https://github.com/DragonnZhang) in [#12679](https://github.com/youzan/vant/pull/12679)
+- feat(ActionSheet): add icon support to the actions data by [@wjw-gavin](https://github.com/wjw-gavin) in [#12671](https://github.com/youzan/vant/pull/12671)
+
+#### Bug Fixes 🐞
+
+- fix(ImagePreview): allow user to swipe to next image when the current image is moved to the edge by [@inottn](https://github.com/inottn) in [#12666](https://github.com/youzan/vant/pull/12666)
+- fix(ActionSheet): icon class name by [@chenjiahan](https://github.com/chenjiahan) in [#12701](https://github.com/youzan/vant/pull/12701)
+
+#### Document 📖
+
+- docs(ImagePreview): add vertical prop by [@chenjiahan](https://github.com/chenjiahan) in [#12663](https://github.com/youzan/vant/pull/12663)
+- docs: change tab's 'Before Change' into a real async function by [@gxy5202](https://github.com/gxy5202) in [#12693](https://github.com/youzan/vant/pull/12693)
+
+#### Other Changes
+
+- chore(deps): bump Rsbuild 0.4.12 by [@chenjiahan](https://github.com/chenjiahan) in [#12665](https://github.com/youzan/vant/pull/12665)
+- chore(deps): update dependency [@vue](https://github.com/vue)/test-utils to v2.4.5 by @renovate in [#12681](https://github.com/youzan/vant/pull/12681)
+- chore(deps): update dependency autoprefixer to v10.4.18 by [@renovate](https://github.com/renovate) in [#12682](https://github.com/youzan/vant/pull/12682)
+- chore(workflow): disable dependency dashboard by [@chenjiahan](https://github.com/chenjiahan) in [#12686](https://github.com/youzan/vant/pull/12686)
+- chore(deps): update dependency prettier to v3.2.5 by [@renovate](https://github.com/renovate) in [#12685](https://github.com/youzan/vant/pull/12685)
+- chore(deps): update rsbuild to v0.4.15 by [@renovate](https://github.com/renovate) in [#12688](https://github.com/youzan/vant/pull/12688)
+- chore(deps): update dependency eslint to v8.57.0 by [@renovate](https://github.com/renovate) in [#12697](https://github.com/youzan/vant/pull/12697)
+- chore(deps): update dependency typescript to v5.4.2 by [@renovate](https://github.com/renovate) in [#12700](https://github.com/youzan/vant/pull/12700)
+
+#### New Contributors
+
+- [@chouchouji](https://github.com/chouchouji) made their first contribution in [#12654](https://github.com/youzan/vant/pull/12654)
+- [@renovate](https://github.com/renovate) made their first contribution in [#12681](https://github.com/youzan/vant/pull/12681)
+- [@gxy5202](https://github.com/gxy5202) made their first contribution in [#12693](https://github.com/youzan/vant/pull/12693)
+- [@DragonnZhang](https://github.com/DragonnZhang) made their first contribution in [#12679](https://github.com/youzan/vant/pull/12679)
+
 ### v4.8.5
 
 `2024-02-25`

--- a/packages/vant/docs/markdown/changelog.zh-CN.md
+++ b/packages/vant/docs/markdown/changelog.zh-CN.md
@@ -19,6 +19,45 @@ Vant 遵循 [Semver](https://semver.org/lang/zh-CN/) 语义化版本规范。
 
 ## 更新内容
 
+### v4.8.6
+
+`2024-03-17`
+
+#### 新功能 🎉
+
+- feat(ImagePreview)：添加 vertical 属性 [@suncohey](https://github.com/suncohey) 在 [#12660](https://github.com/youzan/vant/pull/12660)
+- feat(signature)：导出 clear 和 submit 方法 [@chouchouji](https://github.com/chouchouji) 在 [#12654](https://github.com/youzan/vant/pull/12654)
+- feat：支持 unplugin-auto-import 插件 [@DragonnZhang](https://github.com/DragonnZhang) 在 [#12679](https://github.com/youzan/vant/pull/12679)
+- feat(ActionSheet)：在 actions 数据中添加图标支持 [@wjw-gavin](https://github.com/wjw-gavin) 在 [#12671](https://github.com/youzan/vant/pull/12671)
+
+#### Bug 修复 🐞
+
+- fix(ImagePreview)：在当前图片被移动到边缘时，允许用户滑动到下一张图片 [@inottn](https://github.com/inottn) 在 [#12666](https://github.com/youzan/vant/pull/12666)
+- fix(ActionSheet)：图标类名 [@chenjiahan](https://github.com/chenjiahan) 在 [#12701](https://github.com/youzan/vant/pull/12701)
+
+#### 文档更新 📖
+
+- docs(ImagePreview)：添加 vertical 属性 [@chenjiahan](https://github.com/chenjiahan) 在 [#12663](https://github.com/youzan/vant/pull/12663)
+- docs：将 tab 的 'Before Change' 改为一个真正的异步函数 [@gxy5202](https://github.com/gxy5202) 在 [#12693](https://github.com/youzan/vant/pull/12693)
+
+#### 其他更改
+
+- chore(deps)：Rsbuild 升级到 0.4.12 [@chenjiahan](https://github.com/chenjiahan) 在 [#12665](https://github.com/youzan/vant/pull/12665)
+- chore(deps)：更新依赖 [@vue](https://github.com/vue)/test-utils 到 v2.4.5 @renovate 在 [#12681](https://github.com/youzan/vant/pull/12681)
+- chore(deps)：更新依赖 autoprefixer 到 v10.4.18 [@renovate](https://github.com/renovate) 在 [#12682](https://github.com/youzan/vant/pull/12682)
+- chore(workflow)：禁用依赖仪表板 [@chenjiahan](https://github.com/chenjiahan) 在 [#12686](https://github.com/youzan/vant/pull/12686)
+- chore(deps)：更新依赖 prettier 到 v3.2.5 [@renovate](https://github.com/renovate) 在 [#12685](https://github.com/youzan/vant/pull/12685)
+- chore(deps)：更新 Rsbuild 到 v0.4.15 [@renovate](https://github.com/renovate) 在 [#12688](https://github.com/youzan/vant/pull/12688)
+- chore(deps)：更新依赖 eslint 到 v8.57.0 [@renovate](https://github.com/renovate) 在 [#12697](https://github.com/youzan/vant/pull/12697)
+- chore(deps)：更新依赖 typescript 到 v5.4.2 [@renovate](https://github.com/renovate) 在 [#12700](https://github.com/youzan/vant/pull/12700)
+
+#### 新贡献者
+
+- [@chouchouji](https://github.com/chouchouji) 在 [#12654](https://github.com/youzan/vant/pull/12654) 做出了首次贡献
+- [@renovate](https://github.com/renovate) 在 [#12681](https://github.com/youzan/vant/pull/12681) 做出了首次贡献
+- [@gxy5202](https://github.com/gxy5202) 在 [#12693](https://github.com/youzan/vant/pull/12693) 做出了首次贡献
+- [@DragonnZhang](https://github.com/DragonnZhang) 在 [#12679](https://github.com/youzan/vant/pull/12679) 做出了首次贡献
+
 ### v4.8.5
 
 `2024-02-25`


### PR DESCRIPTION
> Please refer to [Changelog](https://vant-ui.github.io/vant/#/en-US/changelog) for all changes.  |  请访问 [更新日志](https://vant-ui.github.io/vant/#/zh-CN/changelog) 了解所有更新。

<!-- Release notes generated using configuration in .github/release.yml at v4.8.6 -->

## What's Changed
### New Features 🎉
* feat(ImagePreview): add vertical prop by @suncohey in https://github.com/youzan/vant/pull/12660
* feat(signature): export clear and submit method by @chouchouji in https://github.com/youzan/vant/pull/12654
* feat: support unplugin-auto-import plugin by @DragonnZhang in https://github.com/youzan/vant/pull/12679
* feat(ActionSheet): add icon support to the actions data by @wjw-gavin in https://github.com/youzan/vant/pull/12671
### Bug Fixes 🐞
* fix(ImagePreview): allow user to swipe to next image when the current image is moved to the edge by @inottn in https://github.com/youzan/vant/pull/12666
* fix(ActionSheet): icon class name by @chenjiahan in https://github.com/youzan/vant/pull/12701
### Document 📖
* docs(ImagePreview): add vertical prop by @chenjiahan in https://github.com/youzan/vant/pull/12663
* docs: change tab's 'Before Change' into a real async function by @gxy5202 in https://github.com/youzan/vant/pull/12693
### Other Changes
* chore(deps): bump Rsbuild 0.4.12 by @chenjiahan in https://github.com/youzan/vant/pull/12665
* chore(deps): update dependency @vue/test-utils to v2.4.5 by @renovate in https://github.com/youzan/vant/pull/12681
* chore(deps): update dependency autoprefixer to v10.4.18 by @renovate in https://github.com/youzan/vant/pull/12682
* chore(workflow): disable dependency dashboard by @chenjiahan in https://github.com/youzan/vant/pull/12686
* chore(deps): update dependency prettier to v3.2.5 by @renovate in https://github.com/youzan/vant/pull/12685
* chore(deps): update rsbuild to v0.4.15 by @renovate in https://github.com/youzan/vant/pull/12688
* chore(deps): update dependency eslint to v8.57.0 by @renovate in https://github.com/youzan/vant/pull/12697
* chore(deps): update dependency typescript to v5.4.2 by @renovate in https://github.com/youzan/vant/pull/12700

## New Contributors
* @chouchouji made their first contribution in https://github.com/youzan/vant/pull/12654
* @renovate made their first contribution in https://github.com/youzan/vant/pull/12681
* @gxy5202 made their first contribution in https://github.com/youzan/vant/pull/12693
* @DragonnZhang made their first contribution in https://github.com/youzan/vant/pull/12679

**Full Changelog**: https://github.com/youzan/vant/compare/v4.8.5...v4.8.6