### PR TITLE
docs(changelog): vant@4.8.7

### DIFF
--- a/packages/vant/docs/markdown/changelog.en-US.md
+++ b/packages/vant/docs/markdown/changelog.en-US.md
@@ -19,6 +19,15 @@ Vant follows [Semantic Versioning 2.0.0](https://semver.org/lang/zh-CN/).
 
 ## Details
 
+### v4.8.7
+
+`2024-03-18`
+
+#### Other Changes
+
+- Revert "chore(deps): update dependency typescript to v5.4.2" by [@renovate](https://github.com/renovate) in [#12700](https://github.com/youzan/vant/pull/12700)
+- chore: Update homepage by [@yoyo837](https://github.com/yoyo837) in [#12704](https://github.com/youzan/vant/pull/12704)
+
 ### v4.8.6
 
 `2024-03-17`

--- a/packages/vant/docs/markdown/changelog.zh-CN.md
+++ b/packages/vant/docs/markdown/changelog.zh-CN.md
@@ -19,6 +19,15 @@ Vant 遵循 [Semver](https://semver.org/lang/zh-CN/) 语义化版本规范。
 
 ## 更新内容
 
+### v4.8.7
+
+`2024-03-18`
+
+#### 其他更改
+
+- 回退 "chore(deps)：更新依赖 typescript 到 v5.4.2" by [@renovate](https://github.com/renovate) in [#12700](https://github.com/youzan/vant/pull/12700)
+- 更新 `@vant/auto-import-resolver` homepage by [@yoyo837](https://github.com/yoyo837) in [#12704](https://github.com/youzan/vant/pull/12704)
+
 ### v4.8.6
 
 `2024-03-17`


### PR DESCRIPTION

`2024-03-18`

#### Other Changes

- Revert "chore(deps): update dependency typescript to v5.4.2" by [@renovate](https://github.com/renovate) in [#12700](https://github.com/youzan/vant/pull/12700)
- chore: Update homepage by [@yoyo837](https://github.com/yoyo837) in [#12704](https://github.com/youzan/vant/pull/12704)
