### PR TITLE
docs(changelog): vant v4.8.8

### DIFF
--- a/packages/vant/docs/formatChangelog.mjs
+++ b/packages/vant/docs/formatChangelog.mjs
@@ -7,7 +7,45 @@
  */
 
 // paste changelog here
-const changelog = ``;
+const changelog = `> Please refer to [Changelog](https://vant-ui.github.io/vant/#/en-US/changelog) for all changes.  |  请访问 [更新日志](https://vant-ui.github.io/vant/#/zh-CN/changelog) 了解所有更新。
+
+<!-- Release notes generated using configuration in .github/release.yml at v4.8.8 -->
+
+## What's Changed
+### New Features 🎉
+* feat(image-preview): export onLoad and style for image slot by @chouchouji in https://github.com/youzan/vant/pull/12740
+* feat(AddressList): add event param for click-item by @chenjiahan in https://github.com/youzan/vant/pull/12748
+### Bug Fixes 🐞
+* fix(floating-bubble): update offset when the value changed by @chouchouji in https://github.com/youzan/vant/pull/12730
+* fix(vant-cli): support defineOptions named by @wChenonly in https://github.com/youzan/vant/pull/12734
+* fix(PickerGroup): rendering correctly when using v-for by @inottn in https://github.com/youzan/vant/pull/12732
+* fix(TextEllipsis): should recalculate the ellipsis state when the component is activated by @inottn in https://github.com/youzan/vant/pull/12741
+### Document 📖
+* docs(changelog): vant@4.8.7 by @chenjiahan in https://github.com/youzan/vant/pull/12707
+* docs(button): Keep Chinese and English documents consistent by @chouchouji in https://github.com/youzan/vant/pull/12708
+* docs(cell): correct the type of label by @chouchouji in https://github.com/youzan/vant/pull/12721
+* docs(ImagePreview): add image slot scale guide by @chenjiahan in https://github.com/youzan/vant/pull/12751
+### Other Changes
+* chore(deps): update dependency vue-router to v4.3.0 by @renovate in https://github.com/youzan/vant/pull/12702
+* chore(deps): update dependency esbuild to ^0.20.0 by @renovate in https://github.com/youzan/vant/pull/12696
+* chore(workflow): let renovate bump package.json by @chenjiahan in https://github.com/youzan/vant/pull/12714
+* chore(deps): update dependency eslint to ^8.57.0 by @renovate in https://github.com/youzan/vant/pull/12723
+* chore(docs): update the vue3-vant-mobile reference by @CharleeWa in https://github.com/youzan/vant/pull/12735
+* chore(deps): update dependency commander to ^11.1.0 by @renovate in https://github.com/youzan/vant/pull/12718
+* chore(deps): update dependency enquirer to v2.4.1 by @renovate in https://github.com/youzan/vant/pull/12695
+* chore(deps): update dependency @vue/test-utils to ^2.4.5 by @renovate in https://github.com/youzan/vant/pull/12716
+* chore(deps): bump Rsbuild v0.5 by @chenjiahan in https://github.com/youzan/vant/pull/12747
+* chore(deps): update dependency eslint-config-prettier to ^9.1.0 by @renovate in https://github.com/youzan/vant/pull/12724
+* chore(deps): update dependency fs-extra to ^11.2.0 by @renovate in https://github.com/youzan/vant/pull/12745
+* chore(deps): update dependency highlight.js to ^11.9.0 by @renovate in https://github.com/youzan/vant/pull/12746
+* chore(deps): update dependency fast-glob to ^3.3.2 by @renovate in https://github.com/youzan/vant/pull/12731
+* chore(deps): update dependency less to ^4.2.0 by @renovate in https://github.com/youzan/vant/pull/12752
+* chore(workflow): let renovate group patch updates by @chenjiahan in https://github.com/youzan/vant/pull/12754
+
+## New Contributors
+* @CharleeWa made their first contribution in https://github.com/youzan/vant/pull/12735
+
+**Full Changelog**: https://github.com/youzan/vant/compare/v4.8.7...v4.8.8`;
 
 changelog.split('\n').map((line) => {
   // Skip unused lines

--- a/packages/vant/docs/formatChangelog.mjs
+++ b/packages/vant/docs/formatChangelog.mjs
@@ -7,45 +7,7 @@
  */
 
 // paste changelog here
-const changelog = `> Please refer to [Changelog](https://vant-ui.github.io/vant/#/en-US/changelog) for all changes.  |  请访问 [更新日志](https://vant-ui.github.io/vant/#/zh-CN/changelog) 了解所有更新。
-
-<!-- Release notes generated using configuration in .github/release.yml at v4.8.8 -->
-
-## What's Changed
-### New Features 🎉
-* feat(image-preview): export onLoad and style for image slot by @chouchouji in https://github.com/youzan/vant/pull/12740
-* feat(AddressList): add event param for click-item by @chenjiahan in https://github.com/youzan/vant/pull/12748
-### Bug Fixes 🐞
-* fix(floating-bubble): update offset when the value changed by @chouchouji in https://github.com/youzan/vant/pull/12730
-* fix(vant-cli): support defineOptions named by @wChenonly in https://github.com/youzan/vant/pull/12734
-* fix(PickerGroup): rendering correctly when using v-for by @inottn in https://github.com/youzan/vant/pull/12732
-* fix(TextEllipsis): should recalculate the ellipsis state when the component is activated by @inottn in https://github.com/youzan/vant/pull/12741
-### Document 📖
-* docs(changelog): vant@4.8.7 by @chenjiahan in https://github.com/youzan/vant/pull/12707
-* docs(button): Keep Chinese and English documents consistent by @chouchouji in https://github.com/youzan/vant/pull/12708
-* docs(cell): correct the type of label by @chouchouji in https://github.com/youzan/vant/pull/12721
-* docs(ImagePreview): add image slot scale guide by @chenjiahan in https://github.com/youzan/vant/pull/12751
-### Other Changes
-* chore(deps): update dependency vue-router to v4.3.0 by @renovate in https://github.com/youzan/vant/pull/12702
-* chore(deps): update dependency esbuild to ^0.20.0 by @renovate in https://github.com/youzan/vant/pull/12696
-* chore(workflow): let renovate bump package.json by @chenjiahan in https://github.com/youzan/vant/pull/12714
-* chore(deps): update dependency eslint to ^8.57.0 by @renovate in https://github.com/youzan/vant/pull/12723
-* chore(docs): update the vue3-vant-mobile reference by @CharleeWa in https://github.com/youzan/vant/pull/12735
-* chore(deps): update dependency commander to ^11.1.0 by @renovate in https://github.com/youzan/vant/pull/12718
-* chore(deps): update dependency enquirer to v2.4.1 by @renovate in https://github.com/youzan/vant/pull/12695
-* chore(deps): update dependency @vue/test-utils to ^2.4.5 by @renovate in https://github.com/youzan/vant/pull/12716
-* chore(deps): bump Rsbuild v0.5 by @chenjiahan in https://github.com/youzan/vant/pull/12747
-* chore(deps): update dependency eslint-config-prettier to ^9.1.0 by @renovate in https://github.com/youzan/vant/pull/12724
-* chore(deps): update dependency fs-extra to ^11.2.0 by @renovate in https://github.com/youzan/vant/pull/12745
-* chore(deps): update dependency highlight.js to ^11.9.0 by @renovate in https://github.com/youzan/vant/pull/12746
-* chore(deps): update dependency fast-glob to ^3.3.2 by @renovate in https://github.com/youzan/vant/pull/12731
-* chore(deps): update dependency less to ^4.2.0 by @renovate in https://github.com/youzan/vant/pull/12752
-* chore(workflow): let renovate group patch updates by @chenjiahan in https://github.com/youzan/vant/pull/12754
-
-## New Contributors
-* @CharleeWa made their first contribution in https://github.com/youzan/vant/pull/12735
-
-**Full Changelog**: https://github.com/youzan/vant/compare/v4.8.7...v4.8.8`;
+const changelog = ``;
 
 changelog.split('\n').map((line) => {
   // Skip unused lines

--- a/packages/vant/docs/markdown/changelog.en-US.md
+++ b/packages/vant/docs/markdown/changelog.en-US.md
@@ -19,6 +19,50 @@ Vant follows [Semantic Versioning 2.0.0](https://semver.org/lang/zh-CN/).
 
 ## Details
 
+### v4.8.8
+
+`2024-03-31`
+
+#### New Features 🎉
+
+- feat(image-preview): export onLoad and style for image slot by [@chouchouji](https://github.com/chouchouji) in [#12740](https://github.com/youzan/vant/pull/12740)
+- feat(AddressList): add event param for click-item by [@chenjiahan](https://github.com/chenjiahan) in [#12748](https://github.com/youzan/vant/pull/12748)
+
+#### Bug Fixes 🐞
+
+- fix(floating-bubble): update offset when the value changed by [@chouchouji](https://github.com/chouchouji) in [#12730](https://github.com/youzan/vant/pull/12730)
+- fix(vant-cli): support defineOptions named by [@wChenonly](https://github.com/wChenonly) in [#12734](https://github.com/youzan/vant/pull/12734)
+- fix(PickerGroup): rendering correctly when using v-for by [@inottn](https://github.com/inottn) in [#12732](https://github.com/youzan/vant/pull/12732)
+- fix(TextEllipsis): should recalculate the ellipsis state when the component is activated by [@inottn](https://github.com/inottn) in [#12741](https://github.com/youzan/vant/pull/12741)
+
+#### Document 📖
+
+- docs(button): Keep Chinese and English documents consistent by [@chouchouji](https://github.com/chouchouji) in [#12708](https://github.com/youzan/vant/pull/12708)
+- docs(cell): correct the type of label by [@chouchouji](https://github.com/chouchouji) in [#12721](https://github.com/youzan/vant/pull/12721)
+- docs(ImagePreview): add image slot scale guide by [@chenjiahan](https://github.com/chenjiahan) in [#12751](https://github.com/youzan/vant/pull/12751)
+
+#### Other Changes
+
+- chore(deps): update dependency vue-router to v4.3.0 by [@renovate](https://github.com/renovate) in [#12702](https://github.com/youzan/vant/pull/12702)
+- chore(deps): update dependency esbuild to ^0.20.0 by [@renovate](https://github.com/renovate) in [#12696](https://github.com/youzan/vant/pull/12696)
+- chore(workflow): let renovate bump package.json by [@chenjiahan](https://github.com/chenjiahan) in [#12714](https://github.com/youzan/vant/pull/12714)
+- chore(deps): update dependency eslint to ^8.57.0 by [@renovate](https://github.com/renovate) in [#12723](https://github.com/youzan/vant/pull/12723)
+- chore(docs): update the vue3-vant-mobile reference by [@CharleeWa](https://github.com/CharleeWa) in [#12735](https://github.com/youzan/vant/pull/12735)
+- chore(deps): update dependency commander to ^11.1.0 by [@renovate](https://github.com/renovate) in [#12718](https://github.com/youzan/vant/pull/12718)
+- chore(deps): update dependency enquirer to v2.4.1 by [@renovate](https://github.com/renovate) in [#12695](https://github.com/youzan/vant/pull/12695)
+- chore(deps): update dependency [@vue](https://github.com/vue)/test-utils to ^2.4.5 by @renovate in [#12716](https://github.com/youzan/vant/pull/12716)
+- chore(deps): bump Rsbuild v0.5 by [@chenjiahan](https://github.com/chenjiahan) in [#12747](https://github.com/youzan/vant/pull/12747)
+- chore(deps): update dependency eslint-config-prettier to ^9.1.0 by [@renovate](https://github.com/renovate) in [#12724](https://github.com/youzan/vant/pull/12724)
+- chore(deps): update dependency fs-extra to ^11.2.0 by [@renovate](https://github.com/renovate) in [#12745](https://github.com/youzan/vant/pull/12745)
+- chore(deps): update dependency highlight.js to ^11.9.0 by [@renovate](https://github.com/renovate) in [#12746](https://github.com/youzan/vant/pull/12746)
+- chore(deps): update dependency fast-glob to ^3.3.2 by [@renovate](https://github.com/renovate) in [#12731](https://github.com/youzan/vant/pull/12731)
+- chore(deps): update dependency less to ^4.2.0 by [@renovate](https://github.com/renovate) in [#12752](https://github.com/youzan/vant/pull/12752)
+- chore(workflow): let renovate group patch updates by [@chenjiahan](https://github.com/chenjiahan) in [#12754](https://github.com/youzan/vant/pull/12754)
+
+#### New Contributors
+
+- [@CharleeWa](https://github.com/CharleeWa) made their first contribution in [#12735](https://github.com/youzan/vant/pull/12735)
+
 ### v4.8.7
 
 `2024-03-18`

--- a/packages/vant/docs/markdown/changelog.zh-CN.md
+++ b/packages/vant/docs/markdown/changelog.zh-CN.md
@@ -19,6 +19,50 @@ Vant 遵循 [Semver](https://semver.org/lang/zh-CN/) 语义化版本规范。
 
 ## 更新内容
 
+### v4.8.8
+
+`2024-03-31`
+
+#### 新特性 🎉
+
+- feat(image-preview): 导出 image 插槽的 onLoad 和 style 属性，由[@chouchouji](https://github.com/chouchouji) 在 [#12740](https://github.com/youzan/vant/pull/12740) 提交
+- feat(AddressList): 为 click-item 添加事件参数，由[@chenjiahan](https://github.com/chenjiahan) 在 [#12748](https://github.com/youzan/vant/pull/12748) 提交
+
+#### 故障修复 🐞
+
+- fix(floating-bubble): 当值更改时更新偏移量，由[@chouchouji](https://github.com/chouchouji) 在 [#12730](https://github.com/youzan/vant/pull/12730) 提交
+- fix(vant-cli): 支持以定义的选项命名，由[@wChenonly](https://github.com/wChenonly) 在 [#12734](https://github.com/youzan/vant/pull/12734) 提交
+- fix(PickerGroup): 使用 v-for 时能够正确渲染，由[@inottn](https://github.com/inottn) 在 [#12732](https://github.com/youzan/vant/pull/12732) 提交
+- fix(TextEllipsis): 当组件被激活时应重新计算省略状态，由[@inottn](https://github.com/inottn) 在 [#12741](https://github.com/youzan/vant/pull/12741) 提交
+
+#### 文档更新 📖
+
+- docs(button): 保持中英文文档一致，由[@chouchouji](https://github.com/chouchouji) 在 [#12708](https://github.com/youzan/vant/pull/12708) 提交
+- docs(cell): 更正 label 的类型，由[@chouchouji](https://github.com/chouchouji) 在 [#12721](https://github.com/youzan/vant/pull/12721) 提交
+- docs(ImagePreview): 添加图片插槽缩放指导，由[@chenjiahan](https://github.com/chenjiahan) 在 [#12751](https://github.com/youzan/vant/pull/12751) 提交
+
+#### 其他更改
+
+- chore(deps): 更新 vue-router 依赖至 v4.3.0，由[@renovate](https://github.com/renovate) 在 [#12702](https://github.com/youzan/vant/pull/12702) 提交
+- chore(deps): 更新 esbuild 依赖至 ^0.20.0，由[@renovate](https://github.com/renovate) 在 [#12696](https://github.com/youzan/vant/pull/12696) 提交
+- chore(workflow): 让 renovate 提升 package.json 版本，由[@chenjiahan](https://github.com/chenjiahan) 在 [#12714](https://github.com/youzan/vant/pull/12714) 提交
+- chore(deps): 更新 eslint 依赖至 ^8.57.0，由[@renovate](https://github.com/renovate) 在 [#12723](https://github.com/youzan/vant/pull/12723) 提交
+- chore(docs): 更新 vue3-vant-mobile 参考文档，由[@CharleeWa](https://github.com/CharleeWa) 在 [#12735](https://github.com/youzan/vant/pull/12735) 提交
+- chore(deps): 更新 commander 依赖至 ^11.1.0，由[@renovate](https://github.com/renovate) 在 [#12718](https://github.com/youzan/vant/pull/12718) 提交
+- chore(deps): 更新 enquirer 依赖至 v2.4.1，由[@renovate](https://github.com/renovate) 在 [#12695](https://github.com/youzan/vant/pull/12695) 提交
+- chore(deps): 更新 [@vue](https://github.com/vue)/test-utils 依赖至 ^2.4.5，由 @renovate 在 [#12716](https://github.com/youzan/vant/pull/12716) 提交
+- chore(deps): 版本升至 Rsbuild v0.5，由[@chenjiahan](https://github.com/chenjiahan) 在 [#12747](https://github.com/youzan/vant/pull/12747) 提交
+- chore(deps): 更新 eslint-config-prettier 依赖至 ^9.1.0，由[@renovate](https://github.com/renovate) 在 [#12724](https://github.com/youzan/vant/pull/12724) 提交
+- chore(deps): 更新 fs-extra 依赖至 ^11.2.0，由[@renovate](https://github.com/renovate) 在 [#12745](https://github.com/youzan/vant/pull/12745) 提交
+- chore(deps): 更新 highlight.js 依赖至 ^11.9.0，由[@renovate](https://github.com/renovate) 在 [#12746](https://github.com/youzan/vant/pull/12746) 提交
+- chore(deps): 更新 fast-glob 依赖至 ^3.3.2，由[@renovate](https://github.com/renovate) 在 [#12731](https://github.com/youzan/vant/pull/12731) 提交
+- chore(deps): 更新 less 依赖至 ^4.2.0，由[@renovate](https://github.com/renovate) 在 [#12752](https://github.com/youzan/vant/pull/12752) 提交
+- chore(workflow): 让 renovate 整合补丁更新，由[@chenjiahan](https://github.com/chenjiahan) 在 [#12754](https://github.com/youzan/vant/pull/12754) 提交
+
+#### 新贡献者
+
+- [@CharleeWa](https://github.com/CharleeWa) 在 [#12735](https://github.com/youzan/vant/pull/12735) 中首次贡献
+
 ### v4.8.7
 
 `2024-03-18`


### PR DESCRIPTION
### v4.8.8

`2024-03-31`

#### New Features 🎉

- feat(image-preview): export onLoad and style for image slot by [@chouchouji](https://github.com/chouchouji) in [#12740](https://github.com/youzan/vant/pull/12740)
- feat(AddressList): add event param for click-item by [@chenjiahan](https://github.com/chenjiahan) in [#12748](https://github.com/youzan/vant/pull/12748)

#### Bug Fixes 🐞

- fix(floating-bubble): update offset when the value changed by [@chouchouji](https://github.com/chouchouji) in [#12730](https://github.com/youzan/vant/pull/12730)
- fix(vant-cli): support defineOptions named by [@wChenonly](https://github.com/wChenonly) in [#12734](https://github.com/youzan/vant/pull/12734)
- fix(PickerGroup): rendering correctly when using v-for by [@inottn](https://github.com/inottn) in [#12732](https://github.com/youzan/vant/pull/12732)
- fix(TextEllipsis): should recalculate the ellipsis state when the component is activated by [@inottn](https://github.com/inottn) in [#12741](https://github.com/youzan/vant/pull/12741)

#### Document 📖

- docs(button): Keep Chinese and English documents consistent by [@chouchouji](https://github.com/chouchouji) in [#12708](https://github.com/youzan/vant/pull/12708)
- docs(cell): correct the type of label by [@chouchouji](https://github.com/chouchouji) in [#12721](https://github.com/youzan/vant/pull/12721)
- docs(ImagePreview): add image slot scale guide by [@chenjiahan](https://github.com/chenjiahan) in [#12751](https://github.com/youzan/vant/pull/12751)

#### Other Changes

- chore(deps): update dependency vue-router to v4.3.0 by [@renovate](https://github.com/renovate) in [#12702](https://github.com/youzan/vant/pull/12702)
- chore(deps): update dependency esbuild to ^0.20.0 by [@renovate](https://github.com/renovate) in [#12696](https://github.com/youzan/vant/pull/12696)
- chore(workflow): let renovate bump package.json by [@chenjiahan](https://github.com/chenjiahan) in [#12714](https://github.com/youzan/vant/pull/12714)
- chore(deps): update dependency eslint to ^8.57.0 by [@renovate](https://github.com/renovate) in [#12723](https://github.com/youzan/vant/pull/12723)
- chore(docs): update the vue3-vant-mobile reference by [@CharleeWa](https://github.com/CharleeWa) in [#12735](https://github.com/youzan/vant/pull/12735)
- chore(deps): update dependency commander to ^11.1.0 by [@renovate](https://github.com/renovate) in [#12718](https://github.com/youzan/vant/pull/12718)
- chore(deps): update dependency enquirer to v2.4.1 by [@renovate](https://github.com/renovate) in [#12695](https://github.com/youzan/vant/pull/12695)
- chore(deps): update dependency [@vue](https://github.com/vue)/test-utils to ^2.4.5 by @renovate in [#12716](https://github.com/youzan/vant/pull/12716)
- chore(deps): bump Rsbuild v0.5 by [@chenjiahan](https://github.com/chenjiahan) in [#12747](https://github.com/youzan/vant/pull/12747)
- chore(deps): update dependency eslint-config-prettier to ^9.1.0 by [@renovate](https://github.com/renovate) in [#12724](https://github.com/youzan/vant/pull/12724)
- chore(deps): update dependency fs-extra to ^11.2.0 by [@renovate](https://github.com/renovate) in [#12745](https://github.com/youzan/vant/pull/12745)
- chore(deps): update dependency highlight.js to ^11.9.0 by [@renovate](https://github.com/renovate) in [#12746](https://github.com/youzan/vant/pull/12746)
- chore(deps): update dependency fast-glob to ^3.3.2 by [@renovate](https://github.com/renovate) in [#12731](https://github.com/youzan/vant/pull/12731)
- chore(deps): update dependency less to ^4.2.0 by [@renovate](https://github.com/renovate) in [#12752](https://github.com/youzan/vant/pull/12752)
- chore(workflow): let renovate group patch updates by [@chenjiahan](https://github.com/chenjiahan) in [#12754](https://github.com/youzan/vant/pull/12754)

#### New Contributors

- [@CharleeWa](https://github.com/CharleeWa) made their first contribution in [#12735](https://github.com/youzan/vant/pull/12735)