### PR TITLE
docs(SwitchCell): remove SwitchCell in the form component

### DIFF
--- a/vant.config.js
+++ b/vant.config.js
@@ -569,10 +569,6 @@ module.exports = {
                 title: 'Switch',
               },
               {
-                path: 'switch-cell',
-                title: 'SwitchCell',
-              },
-              {
                 path: 'uploader',
                 title: 'Uploader',
               },


### PR DESCRIPTION
删除 Vant 2 英文文档中位于表单组件中的 `SwitchCell` 组件 。

`SwitchCell` 组件在 Vant 2 文档中已被归类到 废弃 模块。