### PR TITLE
docs(changelog): vant v4.8.10

### DIFF
--- a/packages/vant/docs/markdown/changelog.en-US.md
+++ b/packages/vant/docs/markdown/changelog.en-US.md
@@ -19,6 +19,34 @@ Vant follows [Semantic Versioning 2.0.0](https://semver.org/lang/zh-CN/).
 
 ## Details
 
+### v4.8.10
+
+`2024-04-06`
+
+#### New Features 🎉
+
+- feat(TimePicker): support confirm and getSelectedTime methods by [@bluesky335](https://github.com/bluesky335) in [#12761](https://github.com/youzan/vant/pull/12761)
+- feat(DatePicker): support confirm and getSelectedDate method by [@bluesky335](https://github.com/bluesky335) in [#12762](https://github.com/youzan/vant/pull/12762)
+- feat(Coupon): support for checkbox usage by [@CatsAndMice](https://github.com/CatsAndMice) in [#12744](https://github.com/youzan/vant/pull/12744)
+
+#### Other Changes
+
+- chore(deps): update dependency vite to v5.0.13 [security] by [@renovate](https://github.com/renovate) in [#12767](https://github.com/youzan/vant/pull/12767)
+- chore(deps): update all patch dependencies by [@renovate](https://github.com/renovate) in [#12756](https://github.com/youzan/vant/pull/12756)
+- chore(deps): update dependency [@types](https://github.com/types)/lodash to ^4.17.0 by @renovate in [#12757](https://github.com/youzan/vant/pull/12757)
+- chore: correct return type of getSelectedTime by [@chenjiahan](https://github.com/chenjiahan) in [#12768](https://github.com/youzan/vant/pull/12768)
+- refactor(Coupon): simplify the checkbox usage by [@chenjiahan](https://github.com/chenjiahan) in [#12771](https://github.com/youzan/vant/pull/12771)
+
+#### New Contributors
+
+- [@bluesky335](https://github.com/bluesky335) made their first contribution in [#12761](https://github.com/youzan/vant/pull/12761)
+
+### v4.8.9
+
+`2024-04-06`
+
+Invalid version, please do not use it.
+
 ### v4.8.8
 
 `2024-03-31`

--- a/packages/vant/docs/markdown/changelog.zh-CN.md
+++ b/packages/vant/docs/markdown/changelog.zh-CN.md
@@ -19,6 +19,34 @@ Vant 遵循 [Semver](https://semver.org/lang/zh-CN/) 语义化版本规范。
 
 ## 更新内容
 
+### v4.8.10
+
+`2024-04-06`
+
+#### 新功能 🎉
+
+- feat(TimePicker)：支持 confirm 和 getSelectedTime 方法，由 [@bluesky335](https://github.com/bluesky335) 在 [#12761](https://github.com/youzan/vant/pull/12761) 提供
+- feat(DatePicker)：支持 confirm 和 getSelectedDate 方法，由 [@bluesky335](https://github.com/bluesky335) 在 [#12762](https://github.com/youzan/vant/pull/12762) 提供
+- feat(Coupon)：支持复选框用法，由 [@CatsAndMice](https://github.com/CatsAndMice) 在 [#12744](https://github.com/youzan/vant/pull/12744) 提供
+
+#### 其他变更
+
+- chore(deps)：更新依赖 vite 至 v5.0.13 [安全]，由 [@renovate](https://github.com/renovate) 在 [#12767](https://github.com/youzan/vant/pull/12767) 提供
+- chore(deps)：更新所有补丁依赖项，由 [@renovate](https://github.com/renovate) 在 [#12756](https://github.com/youzan/vant/pull/12756) 提供
+- chore(deps)：更新依赖项 [@types](https://github.com/types)/lodash 至 ^4.17.0，由 [@renovate](https://github.com/renovate) 在 [#12757](https://github.com/youzan/vant/pull/12757) 提供
+- chore：修正 getSelectedTime 的返回类型，由 [@chenjiahan](https://github.com/chenjiahan) 在 [#12768](https://github.com/youzan/vant/pull/12768) 提供
+- refactor(Coupon)：简化复选框用法，由 [@chenjiahan](https://github.com/chenjiahan) 在 [#12771](https://github.com/youzan/vant/pull/12771) 提供
+
+#### 新贡献者
+
+- [@bluesky335](https://github.com/bluesky335) 在 [#12761](https://github.com/youzan/vant/pull/12761) 中首次贡献
+
+### v4.8.9
+
+`2024-04-06`
+
+无效版本，请勿使用。
+
 ### v4.8.8
 
 `2024-03-31`


### PR DESCRIPTION
### v4.8.10

`2024-04-06`

#### New Features 🎉

- feat(TimePicker): support confirm and getSelectedTime methods by [@bluesky335](https://github.com/bluesky335) in [#12761](https://github.com/youzan/vant/pull/12761)
- feat(DatePicker): support confirm and getSelectedDate method by [@bluesky335](https://github.com/bluesky335) in [#12762](https://github.com/youzan/vant/pull/12762)
- feat(Coupon): support for checkbox usage by [@CatsAndMice](https://github.com/CatsAndMice) in [#12744](https://github.com/youzan/vant/pull/12744)

#### Other Changes

- chore(deps): update dependency vite to v5.0.13 [security] by [@renovate](https://github.com/renovate) in [#12767](https://github.com/youzan/vant/pull/12767)
- chore(deps): update all patch dependencies by [@renovate](https://github.com/renovate) in [#12756](https://github.com/youzan/vant/pull/12756)
- chore(deps): update dependency [@types](https://github.com/types)/lodash to ^4.17.0 by @renovate in [#12757](https://github.com/youzan/vant/pull/12757)
- chore: correct return type of getSelectedTime by [@chenjiahan](https://github.com/chenjiahan) in [#12768](https://github.com/youzan/vant/pull/12768)
- refactor(Coupon): simplify the checkbox usage by [@chenjiahan](https://github.com/chenjiahan) in [#12771](https://github.com/youzan/vant/pull/12771)

#### New Contributors

- [@bluesky335](https://github.com/bluesky335) made their first contribution in [#12761](https://github.com/youzan/vant/pull/12761)