### PR TITLE
docs(list):  update Error loading module code

### DIFF
--- a/packages/vant/src/list/README.md
+++ b/packages/vant/src/list/README.md
@@ -86,6 +86,7 @@ export default {
     const loading = ref(false);
     const onLoad = () => {
       fetchSomeThing().catch(() => {
+        loading.value = false;
         error.value = true;
       });
     };

--- a/packages/vant/src/list/README.zh-CN.md
+++ b/packages/vant/src/list/README.zh-CN.md
@@ -95,6 +95,7 @@ export default {
     const loading = ref(false);
     const onLoad = () => {
       fetchSomeThing().catch(() => {
+        loading.value = false;
         error.value = true;
       });
     };


### PR DESCRIPTION
resolve #12777 


demo里头的代码在列表加载失败时有设置 `loading`为`false`

https://github.com/youzan/vant/blob/c857d1fbcb15053fc936df714e93ba8815ddfc4f/packages/vant/src/list/demo/index.vue#L64

但是演示`code`里头没有

![image](https://github.com/youzan/vant/assets/24707417/448ec312-5a6d-4bba-99fd-f881772f8947)
