### PR TITLE
fix(Highlight): render correctly when keywords is empty

### DIFF
--- a/packages/vant/src/highlight/Highlight.tsx
+++ b/packages/vant/src/highlight/Highlight.tsx
@@ -100,6 +100,14 @@ export default defineComponent({
 
       const lastChunk = chunks[chunks.length - 1];
 
+      if (!lastChunk) {
+        chunks.push({
+          start: 0,
+          end: sourceString.length,
+          highlight: false,
+        });
+      }
+
       if (lastChunk && lastChunk.end < sourceString.length) {
         chunks.push({
           start: lastChunk.end,

--- a/packages/vant/src/highlight/test/index.spec.ts
+++ b/packages/vant/src/highlight/test/index.spec.ts
@@ -95,3 +95,18 @@ test('empty text should not be matched', () => {
 
   expect(tags[0].text()).toEqual('bc');
 });
+
+test('empty keywords should correctly rendered', () => {
+  const wrapper = mount(Highlight, {
+    props: {
+      keywords: '',
+      sourceString: 'abcd',
+    },
+  });
+
+  const highlight = wrapper.find('.van-highlight');
+  const tags = highlight.findAll('.van-highlight__tag');
+
+  expect(highlight.text()).toEqual('abcd');
+  expect(tags.length).toEqual(0);
+});


### PR DESCRIPTION
fix: #12826 