### PR TITLE
fix(cli): CSS preprocessor for scoped

### DIFF
--- a/packages/vant-cli/src/compiler/compile-sfc.ts
+++ b/packages/vant-cli/src/compiler/compile-sfc.ts
@@ -140,6 +140,9 @@ export async function compileSfc(filePath: string): Promise<any> {
         filename: path.basename(cssFilePath),
         scoped: style.scoped,
         id: scopeId,
+        preprocessLang: style.lang as Parameters<
+          typeof compileStyle
+        >[0]['preprocessLang'],
       });
 
       return outputFile(cssFilePath, trim(styleSource.code));


### PR DESCRIPTION
There's a hole here 🥲, if you don't set `preprocessLang` compileStyle to css by default, scopedId will be added for each class name

```css
// raw set scoped
.hello{
  &-title{
     color:red;
  }
}
```

```css
// expect
.hello-title[data-v-7578cda5] {
  color: red;
}
```
```css
// preprocessLang is not set
.hello[data-v-7578cda5] {
  &-title[data-v-7578cda5] {
    color: red;
  }
}
// to
.hello[data-v-7578cda5]-title[data-v-7578cda5] {
  color: red;
}
```
But it's the equivalent of going through two CSS preprocessor compilations

fix #12844