### PR TITLE
fix: (Field)textarea scroll bar is abnormal

### DIFF
--- a/packages/vant/src/field/utils.ts
+++ b/packages/vant/src/field/utils.ts
@@ -93,11 +93,9 @@ export function resizeTextarea(
 
   if (height) {
     input.style.height = `${height}px`;
+    if (parentFieldEl) parentFieldEl.scrollTop = parentFieldElScrollTop;
     // https://github.com/vant-ui/vant/issues/9178
     setRootScrollTop(scrollTop);
-  }
-  if (parentFieldEl && parentFieldElScrollTop) {
-    parentFieldEl.scrollTop = parentFieldElScrollTop;
   }
 }
 

--- a/packages/vant/src/field/utils.ts
+++ b/packages/vant/src/field/utils.ts
@@ -72,6 +72,14 @@ export function resizeTextarea(
 ) {
   const scrollTop = getRootScrollTop();
 
+  let parentFieldEl: HTMLElement | null = input;
+  while (parentFieldEl && !parentFieldEl.classList.contains('van-field')) {
+    parentFieldEl = parentFieldEl.parentElement;
+  }
+  const parentFieldElScrollTop = parentFieldEl?.scrollTop ?? 0;
+
+  input.style.height = 'auto';
+
   let height = input.scrollHeight;
   if (isObject(autosize)) {
     const { maxHeight, minHeight } = autosize;
@@ -85,10 +93,9 @@ export function resizeTextarea(
 
   if (height) {
     input.style.height = `${height}px`;
+    if (parentFieldEl) parentFieldEl.scrollTop = parentFieldElScrollTop;
     // https://github.com/vant-ui/vant/issues/9178
     setRootScrollTop(scrollTop);
-  } else {
-    input.style.height = 'auto';
   }
 }
 

--- a/packages/vant/src/field/utils.ts
+++ b/packages/vant/src/field/utils.ts
@@ -71,7 +71,6 @@ export function resizeTextarea(
   autosize: true | FieldAutosizeConfig,
 ) {
   const scrollTop = getRootScrollTop();
-  input.style.height = 'auto';
 
   let height = input.scrollHeight;
   if (isObject(autosize)) {
@@ -88,6 +87,8 @@ export function resizeTextarea(
     input.style.height = `${height}px`;
     // https://github.com/vant-ui/vant/issues/9178
     setRootScrollTop(scrollTop);
+  } else {
+    input.style.height = 'auto';
   }
 }
 

--- a/packages/vant/src/field/utils.ts
+++ b/packages/vant/src/field/utils.ts
@@ -93,9 +93,11 @@ export function resizeTextarea(
 
   if (height) {
     input.style.height = `${height}px`;
-    if (parentFieldEl) parentFieldEl.scrollTop = parentFieldElScrollTop;
     // https://github.com/vant-ui/vant/issues/9178
     setRootScrollTop(scrollTop);
+  }
+  if (parentFieldEl && parentFieldElScrollTop) {
+    parentFieldEl.scrollTop = parentFieldElScrollTop;
   }
 }
 


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-ui.github.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。

### bugfix 
[#12859](https://github.com/youzan/vant/issues/12859)

### 问题复现：
失去焦点、获取焦点、输入中文都能复现，滚动条会滚动到顶部

![textarea问题复现](https://github.com/youzan/vant/assets/25085178/c387c49a-80a6-46c8-b58b-277b22c0ab1e)

### 原因分析
![image](https://github.com/youzan/vant/assets/25085178/6021dce1-8d54-4242-b6a1-f2ecc9c43948)

这里对 `input` 的 `height` 进行了两次赋值，`height=auto` 意思是高度撑满父容器，不会出现滚动条，第二次赋值滚动条才会出现，此时滚动条的位置就会被初始化，回到顶部

### 修复方案
#### 方案一
> 设置 `height=auto` 前先记录滚动条位置，第二次设置 `height`后，将滚动条位置还原

![image](https://github.com/youzan/vant/assets/25085178/f9a9c6ee-e472-4dfc-a924-069cbd6daea5)

```diff
+    // 向上查找父节点，直到找到类名为"van-field"的父节点
+    let parentFieldEl = input;
+    while (parentFieldEl && !parentFieldEl.classList.contains("van-field")) {
+      parentFieldEl = parentFieldEl.parentNode;
+    }
+    const parentFieldElScrollTop = parentFieldEl?.scrollTop || 0
  
    input.style.height = 'auto'

    ......

    input.style.height = `${height}px`;
+    parentFieldEl.scrollTop = parentFieldElScrollTop;
```

#### 方案二
> 只设置一次`height`
```diff
- input.style.height = 'auto'

......

if (height) {
    input.style.height = `${height}px`;
    // https://github.com/vant-ui/vant/issues/9178
    setRootScrollTop(scrollTop);
+  } else {
+   input.style.height = 'auto'
+  }
````

方案二代码简洁些，选择了方案二

### 修复后效果：
![textarea修复](https://github.com/youzan/vant/assets/25085178/296c1713-f050-47d0-8b72-870d961099ba)



