### PR TITLE
fix(Tab): incorrect style

### DIFF
--- a/packages/vant/src/tabs/index.less
+++ b/packages/vant/src/tabs/index.less
@@ -60,7 +60,7 @@
       background-color: var(--van-tabs-default-color);
     }
 
-    &--disabled {
+    &.van-tab--disabled {
       color: var(--van-tab-disabled-text-color);
     }
   }


### PR DESCRIPTION
在开启 type="card" 后，如果对 tab 进行 disabled 处理，那么 disabled 之后的 tab 项样式和正常样式并无差异。检查代码发现是因为一行 css 未生效，具体可见 commit。

```
<van-tabs v-model:active="active" type="card">
  <van-tab title="标签 1">内容 1</van-tab>
  <van-tab title="标签 2" disabled>内容 2</van-tab>
  <van-tab title="标签 3">内容 3</van-tab>
</van-tabs>
```

之前：

![image](https://github.com/youzan/vant/assets/49087880/99a2ccd0-d88f-445b-b9cb-e5ca2df711dd)

现在：

![image](https://github.com/youzan/vant/assets/49087880/23affbd0-2a06-43b6-a87b-ea90217dec4d)
