### PR TITLE
fix(Tab): "scrollLeftTo" function could not handle decimal correctly

### DIFF
--- a/packages/vant/src/tabs/utils.ts
+++ b/packages/vant/src/tabs/utils.ts
@@ -10,13 +10,15 @@ export function scrollLeftTo(
   let count = 0;
   const from = scroller.scrollLeft;
   const frames = duration === 0 ? 1 : Math.round((duration * 1000) / 16);
+  let scrollLeft = from;
 
   function cancel() {
     cancelRaf(rafId);
   }
 
   function animate() {
-    scroller.scrollLeft += (to - from) / frames;
+    scrollLeft += (to - from) / frames;
+    scroller.scrollLeft = scrollLeft;
 
     if (++count < frames) {
       rafId = raf(animate);


### PR DESCRIPTION
旧的代码：

```
scroller.scrollLeft += (to - from) / frames;
```

当 `(to - from) / frames` 的计算结果为小数，比如 `(to - from) / frames === 0.9` 时，`scroller.scrollLeft` 将永远不会递增。因为在 Chrome 浏览器下，scroller.scrollLeft 的值将被向下取整。也就是说，如果 scroller.scrollLeft = 0.9 时，浏览器将会自动处理为 0。

这会导致两个情况：

1. 在某些情况下，比如动画时间 `duration` 设置为 `3` 时，`(to - from) / frames` 的计算结果为小数。此时点击 tab 后，该 tab 并不会自动居中
2. 由于 Chrome 浏览器会向下取整，那么会导致居中效果出现误差。比如 `(to - from) / frames === 1.5` 时，每帧滚动的像素可能并不是 1.5 而是 1

新的代码：

```
scrollLeft += (to - from) / frames;
scroller.scrollLeft = scrollLeft;
```

将每帧累计的值保存到变量 `scrollLeft` 上，直接将 `scrollLeft` 赋值给 `scroller.scrollLeft`