### PR TITLE
docs(nav-bar): replace click-right with click-left for second example

### DIFF
--- a/packages/vant/src/nav-bar/demo/index.vue
+++ b/packages/vant/src/nav-bar/demo/index.vue
@@ -33,7 +33,7 @@ const onClickRight = () => showToast(t('button'));
       :title="t('title')"
       :left-text="t('back')"
       left-arrow
-      @click-right="onClickRight"
+      @click-left="onClickLeft"
     />
   </demo-block>
 


### PR DESCRIPTION
文档里第二个实例定义的左侧按钮的点击事件
![image](https://github.com/youzan/vant/assets/70570907/92140889-7541-4e6d-a3f2-2bd3e36b585b)

而示例代码写的右侧按钮的点击事件
![image](https://github.com/youzan/vant/assets/70570907/bda9892c-67d8-49ea-8fd2-31a2fd8a82f4)


