### PR TITLE
docs(Badge): refine the description of 'props'

### DIFF
--- a/packages/vant/src/badge/README.md
+++ b/packages/vant/src/badge/README.md
@@ -135,7 +135,7 @@ Use `position` prop to set the position of badge.
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| content | Badge content | _number \| string_ | - |
+| content | Badge content (Effective when `dot` is `false`) | _number \| string_ | - |
 | color | Background color | _string_ | `#ee0a24` |
 | dot | Whether to show dot | _boolean_ | `false` |
 | max | Max value, show `{max}+` when exceed, only works when content is number | _number \| string_ | - |

--- a/packages/vant/src/badge/README.zh-CN.md
+++ b/packages/vant/src/badge/README.zh-CN.md
@@ -143,7 +143,7 @@ app.use(Badge);
 
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
-| content | 徽标内容 | _number \| string_ | - |
+| content | 徽标内容（`dot` 为 `fasle` 时生效） | _number \| string_ | - |
 | color | 徽标背景颜色 | _string_ | `#ee0a24` |
 | dot | 是否展示为小红点 | _boolean_ | `false` |
 | max | 最大值，超过最大值会显示 `{max}+`，仅当 content 为数字时有效 | _number \| string_ | - |


### PR DESCRIPTION
根据以下 Badge.tsx 的源码，完善文档对应 content 的描述：


```
    const renderContent = () => {
      const { dot, max, content } = props;

      if (!dot && hasContent()) {
        if (slots.content) {
          return slots.content();
        }

        if (isDef(max) && isNumeric(content!) && +content > +max) {
          return `${max}+`;
        }

        return content;
      }
    };
```