### PR TITLE
chore(vant-cli): drop NodeJS 14 support

### DIFF
--- a/packages/vant-cli/package.json
+++ b/packages/vant-cli/package.json
@@ -8,7 +8,7 @@
     "vant-cli": "./bin.js"
   },
   "engines": {
-    "node": "^14.16.0 || >=16.0.0"
+    "node": ">=16.0.0"
   },
   "scripts": {
     "dev": "tsc --watch",


### PR DESCRIPTION
consistent with Rsbuild