### PR TITLE
chore: add exports fields

### DIFF
--- a/packages/vant/package.json
+++ b/packages/vant/package.json
@@ -8,6 +8,13 @@
   "typings": "lib/index.d.ts",
   "unpkg": "lib/vant.min.js",
   "jsdelivr": "lib/vant.min.js",
+  "exports": {
+    ".": {
+      "import": "./es/index.mjs",
+      "require": "./lib/vant.cjs.js",
+      "types": "./lib/index.d.ts"
+    }
+  },
   "files": [
     "es",
     "lib"

--- a/packages/vant/package.json
+++ b/packages/vant/package.json
@@ -13,7 +13,25 @@
       "import": "./es/index.mjs",
       "require": "./lib/vant.cjs.js",
       "types": "./lib/index.d.ts"
-    }
+    },
+    "./lib": {
+      "import": "./lib/vant.es.js",
+      "require": "./lib/vant.cjs.js",
+      "types": "./lib/index.d.ts"
+    },
+    "./es": {
+      "import": "./es/index.mjs",
+      "types": "./es/index.d.ts"
+    },
+    "./lib/*.js": {
+      "require": "./lib/*.js",
+      "types": "./lib/*.d.ts"
+    },
+    "./es/*.mjs": {
+      "import": "./es/*.mjs",
+      "types": "./es/*.d.ts"
+    },
+    "./*": "./*"
   },
   "files": [
     "es",

--- a/packages/vant/package.json
+++ b/packages/vant/package.json
@@ -31,6 +31,14 @@
       "import": "./es/*.mjs",
       "types": "./es/*.d.ts"
     },
+    "./lib/*": {
+      "require": "./lib/*/index.js",
+      "types": "./lib/*/index.d.ts"
+    },
+    "./es/*": {
+      "import": "./es/*/index.mjs",
+      "types": "./es/*/index.d.ts"
+    },
     "./*": "./*"
   },
   "files": [


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-ui.github.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。

[fix vant-nuxt#31](https://github.com/vant-ui/vant-nuxt/issues/31)

unimport 中解析 vant 的目录大致为 `../../../node_modules/.pnpm/vant@4.9.1_vue@3.4.29/node_modules/vant/lib/vant.cjs`，这使得自动导入的方法没有类型提示

增加导入后解析的目录变为 `../../../node_modules/.pnpm/vant@4.9.1_vue@3.4.29/node_modules/vant` 类型提示正常