### PR TITLE
fix(vant-compat): [Toast][Dialog] fix missed and incorrect export error #12952

### DIFF
--- a/packages/vant-compat/src/dialog.ts
+++ b/packages/vant-compat/src/dialog.ts
@@ -13,7 +13,7 @@ export const Dialog = (...args: Parameters<typeof showDialog>) =>
 
 Dialog.Component = VanDialog;
 Dialog.alert = Dialog;
-Dialog.config = showConfirmDialog;
+Dialog.confirm = showConfirmDialog;
 Dialog.close = closeDialog;
 Dialog.setDefaultOptions = setDialogDefaultOptions;
 Dialog.resetDefaultOptions = resetDialogDefaultOptions;

--- a/packages/vant-compat/src/toast.ts
+++ b/packages/vant-compat/src/toast.ts
@@ -3,6 +3,7 @@ import {
   closeToast,
   showFailToast,
   showSuccessToast,
+  showLoadingToast,
   allowMultipleToast,
   setToastDefaultOptions,
   resetToastDefaultOptions,
@@ -32,6 +33,14 @@ Toast.success = (...args: Parameters<typeof showSuccessToast>) => {
     ...toast,
   };
 };
+
+Toast.loading = (...args: Parameters<typeof showLoadingToast>) => {
+  const toast = showLoadingToast(...args);
+  return {
+    clear: toast.close,
+    ...toast,
+  }
+}
 
 Toast.clear = closeToast;
 Toast.allowMultiple = allowMultipleToast;


### PR DESCRIPTION
- fix #12952 
- add Toast.loading in vant-compat/src/toast.ts
- correct  Dialog.confirm function name in vant-compat/src/dialog.ts （Dialog.config to Dialog.confirm）
