### PR TITLE
docs(ImagePreview): fix missing parameters

### DIFF
--- a/packages/vant/src/image-preview/README.md
+++ b/packages/vant/src/image-preview/README.md
@@ -194,7 +194,7 @@ When you customize the image through the `image` slot, you can bind the `style` 
   :close-on-click-image="false"
 >
   <template #image="{ src, style, onLoad }">
-    <img :style="[{ width: '100%' }, style]" @load="onLoad" />
+    <img :src="src" :style="[{ width: '100%' }, style]" @load="onLoad" />
   </template>
 </van-image-preview>
 ```

--- a/packages/vant/src/image-preview/README.zh-CN.md
+++ b/packages/vant/src/image-preview/README.zh-CN.md
@@ -195,7 +195,7 @@ export default {
   :close-on-click-image="false"
 >
   <template #image="{ src, style, onLoad }">
-    <img :style="[{ width: '100%' }, style]" @load="onLoad" />
+    <img :src="src" :style="[{ width: '100%' }, style]" @load="onLoad" />
   </template>
 </van-image-preview>
 ```


### PR DESCRIPTION
fix missing parameters(src) when  using image slot