### PR TITLE
fix(vant-compat): [Field] Fix the false positive empty value when the value is boolean false

### DIFF
--- a/packages/vant/src/field/utils.ts
+++ b/packages/vant/src/field/utils.ts
@@ -12,7 +12,7 @@ export function isEmptyValue(value: unknown) {
   if (Array.isArray(value)) {
     return !value.length;
   }
-  if (value === 0) {
+  if (value === 0 || typeof value === 'boolean') {
     return false;
   }
   return !value;


### PR DESCRIPTION
Fix the false positive empty value when the value is boolean false.
当值为布尔值的false时错误认为空值。
eg. 
```
<van-radio-group v-model="checked">
  <van-radio name="true">是</van-radio>
  <van-radio name="false">否</van-radio>
</van-radio-group>
```