### PR TITLE
fix(text-ellipsis): fix text-ellipsis not working in a flex box

### DIFF
--- a/packages/vant/src/text-ellipsis/TextEllipsis.tsx
+++ b/packages/vant/src/text-ellipsis/TextEllipsis.tsx
@@ -70,6 +70,7 @@ export default defineComponent({
       container.style.zIndex = '-9999';
       container.style.top = '-9999px';
       container.style.height = 'auto';
+      container.style.width = 'auto';
       container.style.minHeight = 'auto';
       container.style.maxHeight = 'auto';
 


### PR DESCRIPTION
当使用flex 布局包裹 text-ellipsis  组件的时候, 
代码中: const container = cloneContainer();
container复制的父元素宽度为0,  宽度为0,导致省略的内容(content)垂直排列.  具体表现如下图

![image](https://github.com/youzan/vant/assets/38552120/c8355279-8f8e-471e-843e-40dc18a6ef0f)

结果 导致 container.offsetHeight 高度不对

涉及到的代码里面逻辑判断:  

`   if (maxHeight < container.offsetHeight) {
        hasAction.value = true;
        text.value = calcEllipsisText(container, maxHeight);
      } else {
        hasAction.value = false;
        text.value = props.content;
      }
`