### PR TITLE
feat(Calendar): add title to callback parameter for 'panel-change' event

### DIFF
--- a/packages/vant/src/calendar/Calendar.tsx
+++ b/packages/vant/src/calendar/Calendar.tsx
@@ -3,6 +3,7 @@ import {
   watch,
   computed,
   defineComponent,
+  nextTick,
   type PropType,
   type TeleportProps,
   type ExtractPropTypes,
@@ -387,7 +388,9 @@ export default defineComponent({
 
     const onPanelChange = (date: Date) => {
       currentPanelDate.value = date;
-      emit('panelChange', { date });
+      nextTick(() => {
+        emit('panelChange', { date, title: currentMonthRef.value?.getTitle() });
+      });
     };
 
     const onConfirm = () =>

--- a/packages/vant/src/calendar/README.md
+++ b/packages/vant/src/calendar/README.md
@@ -334,11 +334,11 @@ Following props are supported when the type is multiple
 | opened | Emitted when Popup is opened | - |
 | closed | Emitted when Popup is closed | - |
 | unselect | Emitted when unselect date when type is multiple | _value: Date_ |
-| month-show | Emitted when a month enters the visible area | _value: { date: Date, title: string }_ |
+| month-show | Emitted when a month enters the visible area (effective when `switch mode` is `none`) | _value: { date: Date, title: string }_ |
 | over-range | Emitted when exceeded max range | - |
 | click-subtitle | Emitted when clicking the subtitle | _event: MouseEvent_ |
 | click-disabled-date `v4.7.0` | Emitted when clicking disabled date | _value: Date \| Date[]_ |
-| panel-change | Emitted when switching calendar panel | _{ date: Date }_ |
+| panel-change | Emitted when switching calendar panel (effective when `switch mode` is not `none`) | _{ date: Date, title: string }_ |
 
 ### Slots
 

--- a/packages/vant/src/calendar/README.zh-CN.md
+++ b/packages/vant/src/calendar/README.zh-CN.md
@@ -340,11 +340,11 @@ export default {
 | opened | 打开弹出层且动画结束后触发 | - |
 | closed | 关闭弹出层且动画结束后触发 | - |
 | unselect | 当日历组件的 `type` 为 `multiple` 时，取消选中日期时触发 | _value: Date_ |
-| month-show | 当某个月份进入可视区域时触发 | _{ date: Date, title: string }_ |
+| month-show | 当某个月份进入可视区域时触发（`switch-mode` 为 `none` 时生效） | _{ date: Date, title: string }_ |
 | over-range | 范围选择超过最多可选天数时触发 | - |
 | click-subtitle | 点击日历副标题时触发 | _event: MouseEvent_ |
 | click-disabled-date `v4.7.0` | 点击禁用日期时触发 | _value: Date \| Date[]_ |
-| panel-change | 日历面板切换时触发 | _{ date: Date }_ |
+| panel-change | 日历面板切换时触发（`switch-mode` 不为 `none` 时生效） | _{ date: Date, title: string }_ |
 
 ### Slots
 

--- a/packages/vant/src/calendar/test/switch-mode.spec.ts
+++ b/packages/vant/src/calendar/test/switch-mode.spec.ts
@@ -212,19 +212,31 @@ test('should emit panelChange event', async () => {
 
   await prevMonth.trigger('click');
   currentDate = getPrevMonth(currentDate);
-  expect(onPanelChange).toHaveBeenLastCalledWith({ date: currentDate });
+  expect(onPanelChange).toHaveBeenLastCalledWith({
+    date: currentDate,
+    title: '2019/12',
+  });
 
   await prevYear.trigger('click');
   currentDate = getPrevYear(currentDate);
-  expect(onPanelChange).toHaveBeenLastCalledWith({ date: currentDate });
+  expect(onPanelChange).toHaveBeenLastCalledWith({
+    date: currentDate,
+    title: '2018/12',
+  });
 
   await nextYear.trigger('click');
   currentDate = getNextYear(currentDate);
-  expect(onPanelChange).toHaveBeenLastCalledWith({ date: currentDate });
+  expect(onPanelChange).toHaveBeenLastCalledWith({
+    date: currentDate,
+    title: '2019/12',
+  });
 
   await nextMonth.trigger('click');
   currentDate = getNextMonth(currentDate);
-  expect(onPanelChange).toHaveBeenLastCalledWith({ date: currentDate });
+  expect(onPanelChange).toHaveBeenLastCalledWith({
+    date: currentDate,
+    title: '2020/1',
+  });
 });
 
 test('correctly change the panelDate when the selected date is the last day of each month', async () => {
@@ -245,7 +257,10 @@ test('correctly change the panelDate when the selected date is the last day of e
   await nextMonth.trigger('click');
   let panelDate = getNextMonth(defaultDate);
   expect(panelDate).toEqual(new Date(2024, 5, 30));
-  expect(onPanelChange).toHaveBeenLastCalledWith({ date: panelDate });
+  expect(onPanelChange).toHaveBeenLastCalledWith({
+    date: panelDate,
+    title: '2024/6',
+  });
 
   defaultDate = new Date(2024, 1, 29);
   await wrapper.setProps({
@@ -257,5 +272,8 @@ test('correctly change the panelDate when the selected date is the last day of e
   await nextYear.trigger('click');
   panelDate = getNextYear(defaultDate);
   expect(panelDate).toEqual(new Date(2025, 1, 28));
-  expect(onPanelChange).toHaveBeenLastCalledWith({ date: panelDate });
+  expect(onPanelChange).toHaveBeenLastCalledWith({
+    date: panelDate,
+    title: '2025/2',
+  });
 });


### PR DESCRIPTION
`panel-change` 和 `month-show` 事件是非常相似的两个事件，它们只是在不同的模式下触发，所以可以将两者的回调参数保持一致