### PR TITLE
feat(Calendar): trigger the 'month-show' event every time entering the visible area

### DIFF
--- a/packages/vant/src/calendar/Calendar.tsx
+++ b/packages/vant/src/calendar/Calendar.tsx
@@ -294,6 +294,8 @@ export default defineComponent({
               title: month.getTitle(),
             });
           }
+        } else {
+          monthRefs.value[i].showed = false;
         }
 
         height += heights[i];


### PR DESCRIPTION
解决 issue https://github.com/youzan/vant/issues/12238 中提到的问题。

在该 PR 之前，只有月份首次进入可视区域时才会触发 `month-show` 事件，该 PR 使得月份「每次」进入可视区域都将触发  `month-show` 事件。这也更加符合 `month-show` 事件本身的描述「当某个月份进入可视区域时触发」，否则就应该将描述修改为「当某个月份首次进入可视区域时触发」

由于「进入可视区域」这个判定发生在 DOM 刚进入时，比如下图：

![img_v3_02dp_1d2ab26c-8b82-41cd-a749-36556994104g](https://github.com/user-attachments/assets/18a49709-b18f-42b2-aa23-59be78f7f4a2)

此时事件回调参数是 3 月份，但是内容却依旧大量显示 2 月份内容。

为了解决这种问题，其实我建议新增一个监听副标题 subtitle 变化的的事件。这样应该能应付更多的场景？