### PR TITLE
fix: use declare module 'vue' instead of @vue/runtime-core

### DIFF
--- a/packages/vant/src/lazyload/vue-lazyload/index.d.ts
+++ b/packages/vant/src/lazyload/vue-lazyload/index.d.ts
@@ -44,7 +44,7 @@ export declare const Lazyload: {
   install(app: App, options?: LazyloadOptions): void;
 };
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentCustomProperties {
     $Lazyload: {
       $on: (event: string, handler: Callback) => void;


### PR DESCRIPTION
vue-router pinia has been replaced. 

https://github.com/vuejs/router/pull/2295
https://github.com/vuejs/router/commit/4f082cd05507f33c6d0e6c9dd042cbe75d38ccb5

https://github.com/vuejs/pinia/commit/8a6ce86db83b6315c067c8a98c898b3c74efe62e

Sometimes because vant is not replaced, `ComponentCustomProperties` cannot be used in vue-router and pinia (Only one of these two ways will work) I'm not familiar with Typescript and I don't know why.