### PR TITLE
fix(vant-area-data): export package.json

### DIFF
--- a/packages/vant-area-data/package.json
+++ b/packages/vant-area-data/package.json
@@ -10,7 +10,8 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.esm.mjs",
       "require": "./dist/index.cjs.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
目前 exports 没有声明 package.json，会导致构建工具无法读取这个包的 package.json

参考 1：https://github.com/vue-mini/create-vue-mini/issues/16
参考 2：https://github.com/nodejs/node/issues/33460