### PR TITLE
fix(Calendar): fix watch 'defaultDate' error

### DIFF
--- a/packages/vant/src/calendar/Calendar.tsx
+++ b/packages/vant/src/calendar/Calendar.tsx
@@ -617,9 +617,8 @@ export default defineComponent({
     );
     watch(
       () => props.defaultDate,
-      (value = null) => {
-        currentDate.value = value;
-        scrollToCurrentDate();
+      (value) => {
+        reset(value);
       },
     );
 

--- a/packages/vant/src/calendar/test/prop.spec.ts
+++ b/packages/vant/src/calendar/test/prop.spec.ts
@@ -308,3 +308,30 @@ test('should allow default date to be maxDate when using allowSameDay prop', () 
   wrapper.find('.van-calendar__confirm').trigger('click');
   expect(wrapper.emitted<[Date]>('confirm')![0][0]).toEqual([maxDate, maxDate]);
 });
+
+test('should call reset when defaultDate prop changes', async () => {
+  const wrapper = mount(Calendar, {
+    props: {
+      poppable: false,
+      defaultDate: undefined,
+      minDate,
+      maxDate,
+    },
+  });
+
+  wrapper.find('.van-calendar__confirm').trigger('click');
+  expect(wrapper.emitted<[Date]>('confirm')![0][0]).toEqual(maxDate);
+
+  await wrapper.setProps({ defaultDate: minDate });
+  wrapper.find('.van-calendar__confirm').trigger('click');
+  expect(wrapper.emitted<[Date]>('confirm')![1][0]).toEqual(minDate);
+
+  await wrapper.setProps({ defaultDate: null });
+  expect(wrapper.find('.van-calendar__confirm').classes()).toContain(
+    'van-button--disabled',
+  );
+
+  await wrapper.setProps({ defaultDate: undefined });
+  wrapper.find('.van-calendar__confirm').trigger('click');
+  expect(wrapper.emitted<[Date]>('confirm')![2][0]).toEqual(maxDate);
+});


### PR DESCRIPTION
当 defaultDate 为 undefined 时，现有的 watch 会将其重置为 null，逻辑如下：

```js
    watch(
      () => props.defaultDate,
      (value = null) => {
        currentDate.value = value;
        scrollToCurrentDate();
      },
    );
```

而在该日历组件中，undefined 表示「今天」，null 表示 「不选择」。如果业务层将 defaultDate 重置为 undefined，这时候日历组件将会表现为「不选择」，业务层必须手动调用一次 reset 方法才能实现日历上选中「今天」

所以该侦听器逻辑应该是：

```js
    watch(
      () => props.defaultDate,
      (value) => {
        if (value === undefined) {
          value = getInitialDate();
        }
        currentDate.value = value;
        scrollToCurrentDate();
      },
    );
```

简化一下：

```js
    watch(
      () => props.defaultDate,
      (value) => {
        reset(value);
      },
    );
```