### PR TITLE
fix(Calendar): fix the issue where disabled dates can be selected und…

### DIFF
--- a/packages/vant/src/calendar/Calendar.tsx
+++ b/packages/vant/src/calendar/Calendar.tsx
@@ -459,11 +459,11 @@ export default defineComponent({
           const compareToStart = compareDay(date, startDay);
 
           if (compareToStart === 1) {
-            const disabledDay = getDisabledDate(
-              disabledDays.value,
-              startDay,
-              date,
-            );
+            const _disabledDays = canSwitch.value
+              ? currentMonthRef.value!.disabledDays.value
+              : disabledDays.value;
+
+            const disabledDay = getDisabledDate(_disabledDays, startDay, date);
 
             if (disabledDay) {
               const endDay = getPrevDay(disabledDay);


### PR DESCRIPTION
在 `switch-mode` 为 `none` 时不存在该问题。

当为 `month` 或 `year-month` 时，如果用户选择的「开始日期」和「结束日期」中间包含了「禁用日期」，那么该范围依旧能被选中，预期是无论如何都不能选中「禁用日期」

该 PR 保证了 `none`、`month`、`year-month` 三个模式下 UI 行为是一致的。