### PR TITLE
fix: use data-allow-mismatch to suppress hydration mismatch warnings

### DIFF
--- a/packages/vant/src/address-edit/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/address-edit/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Name
@@ -29,6 +30,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Name"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -42,6 +44,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Phone
@@ -56,6 +59,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -73,6 +77,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Area
@@ -88,6 +93,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Area"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -108,6 +114,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Address
@@ -122,6 +129,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Address"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
             </textarea>
           </div>

--- a/packages/vant/src/address-edit/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/address-edit/test/__snapshots__/demo.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Name
           </label>
@@ -21,6 +22,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Name"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -30,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Phone
           </label>
@@ -42,6 +45,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -55,6 +59,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Area
           </label>
@@ -68,6 +73,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Area"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -79,6 +85,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Address
           </label>
@@ -91,6 +98,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Address"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
               style="height: auto;"
             >
             </textarea>

--- a/packages/vant/src/address-edit/test/__snapshots__/index.spec.ts.snap
+++ b/packages/vant/src/address-edit/test/__snapshots__/index.spec.ts.snap
@@ -14,6 +14,7 @@ exports[`should render AddressEdit correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Name
         </label>
@@ -26,6 +27,7 @@ exports[`should render AddressEdit correctly 1`] = `
             class="van-field__control"
             placeholder="Name"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -35,6 +37,7 @@ exports[`should render AddressEdit correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Phone
         </label>
@@ -47,6 +50,7 @@ exports[`should render AddressEdit correctly 1`] = `
             class="van-field__control"
             placeholder="Phone"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -60,6 +64,7 @@ exports[`should render AddressEdit correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Area
         </label>
@@ -73,6 +78,7 @@ exports[`should render AddressEdit correctly 1`] = `
             readonly
             placeholder="Area"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -84,6 +90,7 @@ exports[`should render AddressEdit correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Address
         </label>
@@ -96,6 +103,7 @@ exports[`should render AddressEdit correctly 1`] = `
             class="van-field__control"
             placeholder="Address"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
           </textarea>
         </div>
@@ -125,6 +133,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Name
         </label>
@@ -137,6 +146,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
             class="van-field__control"
             placeholder="Name"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -146,6 +156,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Phone
         </label>
@@ -158,6 +169,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
             class="van-field__control"
             placeholder="Phone"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -171,6 +183,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Area
         </label>
@@ -184,6 +197,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
             readonly
             placeholder="Area"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -195,6 +209,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Address
         </label>
@@ -207,6 +222,7 @@ exports[`should render AddressEdit with props correctly 1`] = `
             class="van-field__control"
             placeholder="Address"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
           </textarea>
         </div>
@@ -250,6 +266,7 @@ exports[`should valid address detail and render error message correctly 1`] = `
     <label
       id="van-field-label"
       for="van-field-input"
+      data-allow-mismatch="attribute"
     >
       Address
     </label>
@@ -262,6 +279,7 @@ exports[`should valid address detail and render error message correctly 1`] = `
         class="van-field__control"
         placeholder="Address"
         aria-labelledby="van-field-label"
+        data-allow-mismatch="attribute"
         style="height: auto;"
       >
       </textarea>
@@ -283,6 +301,7 @@ exports[`should valid area code and render error message correctly 1`] = `
     <label
       id="van-field-label"
       for="van-field-input"
+      data-allow-mismatch="attribute"
     >
       Area
     </label>
@@ -296,6 +315,7 @@ exports[`should valid area code and render error message correctly 1`] = `
         readonly
         placeholder="Area"
         aria-labelledby="van-field-label"
+        data-allow-mismatch="attribute"
       >
     </div>
   </div>
@@ -310,6 +330,7 @@ exports[`should valid name and render error message correctly 1`] = `
     <label
       id="van-field-label"
       for="van-field-input"
+      data-allow-mismatch="attribute"
     >
       Name
     </label>
@@ -322,6 +343,7 @@ exports[`should valid name and render error message correctly 1`] = `
         class="van-field__control"
         placeholder="Name"
         aria-labelledby="van-field-label"
+        data-allow-mismatch="attribute"
       >
     </div>
     <div class="van-field__error-message">
@@ -337,6 +359,7 @@ exports[`should valid tel and render error message correctly 1`] = `
     <label
       id="van-field-label"
       for="van-field-input"
+      data-allow-mismatch="attribute"
     >
       Phone
     </label>
@@ -349,6 +372,7 @@ exports[`should valid tel and render error message correctly 1`] = `
         class="van-field__control"
         placeholder="Phone"
         aria-labelledby="van-field-label"
+        data-allow-mismatch="attribute"
       >
     </div>
     <div class="van-field__error-message">

--- a/packages/vant/src/back-top/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/back-top/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -22,6 +22,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -31,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -40,6 +42,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -49,6 +52,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-3"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -58,6 +62,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-4"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>

--- a/packages/vant/src/back-top/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/back-top/test/__snapshots__/demo.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text">
           Basic Usage
@@ -27,6 +28,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text">
           Custom Position
@@ -39,6 +41,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text">
           Custom Content
@@ -51,6 +54,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text">
           Set Scroll Target
@@ -63,6 +67,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text">
           Immediate Scroll
@@ -82,6 +87,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       <div class="van-cell">
@@ -443,6 +449,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -452,6 +459,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -461,6 +469,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-3"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -470,6 +479,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-4"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>

--- a/packages/vant/src/cascader/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/cascader/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         Area
@@ -32,6 +33,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -58,6 +60,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         Area
@@ -73,6 +76,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -99,6 +103,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         Area
@@ -114,6 +119,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -140,6 +146,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         Area
@@ -155,6 +162,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -181,6 +189,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         Area
@@ -196,6 +205,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/cascader/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/cascader/test/__snapshots__/demo.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Area
       </label>
@@ -24,6 +25,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -41,6 +43,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Area
       </label>
@@ -54,6 +57,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -71,6 +75,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Area
       </label>
@@ -84,6 +89,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -101,6 +107,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Area
       </label>
@@ -114,6 +121,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -131,6 +139,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Area
       </label>
@@ -144,6 +153,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Select Area"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/cascader/test/__snapshots__/index.spec.ts.snap
+++ b/packages/vant/src/cascader/test/__snapshots__/index.spec.ts.snap
@@ -87,6 +87,7 @@ exports[`should update tabs when previous tab is clicked 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Jiangsu
@@ -99,6 +100,7 @@ exports[`should update tabs when previous tab is clicked 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Select
@@ -124,6 +126,7 @@ exports[`should update tabs when previous tab is clicked 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-0"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
             <div class="van-tab__panel">
@@ -163,6 +166,7 @@ exports[`should update tabs when previous tab is clicked 1`] = `
             tabindex="0"
             aria-hidden="false"
             aria-labelledby="van-tabs-1"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
             <div class="van-tab__panel">

--- a/packages/vant/src/config-provider/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/config-provider/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -27,6 +27,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Rate
@@ -138,6 +139,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Slider
@@ -210,6 +212,7 @@ exports[`should render demo and match snapshot 1`] = `
             <!--[-->
             <label
               id="van-field-label"
+              data-allow-mismatch="attribute"
               style
             >
               Rate
@@ -321,6 +324,7 @@ exports[`should render demo and match snapshot 1`] = `
             <!--[-->
             <label
               id="van-field-label"
+              data-allow-mismatch="attribute"
               style
             >
               Slider

--- a/packages/vant/src/config-provider/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/config-provider/test/__snapshots__/demo.spec.ts.snap
@@ -15,7 +15,10 @@ exports[`should render demo and match snapshot 1`] = `
     <form class="van-form">
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Rate
           </label>
         </div>
@@ -91,7 +94,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Slider
           </label>
         </div>
@@ -143,7 +149,10 @@ exports[`should render demo and match snapshot 1`] = `
       <form class="van-form">
         <div class="van-cell van-field">
           <div class="van-cell__title van-field__label">
-            <label id="van-field-label">
+            <label
+              id="van-field-label"
+              data-allow-mismatch="attribute"
+            >
               Rate
             </label>
           </div>
@@ -219,7 +228,10 @@ exports[`should render demo and match snapshot 1`] = `
         </div>
         <div class="van-cell van-field">
           <div class="van-cell__title van-field__label">
-            <label id="van-field-label">
+            <label
+              id="van-field-label"
+              data-allow-mismatch="attribute"
+            >
               Slider
             </label>
           </div>

--- a/packages/vant/src/contact-edit/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/contact-edit/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Name
@@ -29,6 +30,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Name"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -42,6 +44,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Phone
@@ -56,6 +59,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>

--- a/packages/vant/src/contact-edit/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/contact-edit/test/__snapshots__/demo.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Name
           </label>
@@ -21,6 +22,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Name"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -30,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Phone
           </label>
@@ -42,6 +45,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>

--- a/packages/vant/src/coupon-list/test/__snapshots__/index.spec.ts.snap
+++ b/packages/vant/src/coupon-list/test/__snapshots__/index.spec.ts.snap
@@ -11,6 +11,7 @@ exports[`should be the sames as the last snapshot when render coupon list 1`] = 
             id="van-field-input"
             class="van-field__control"
             placeholder="Coupon code"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -41,6 +42,7 @@ exports[`should be the sames as the last snapshot when render coupon list 1`] = 
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Available (6)
@@ -53,6 +55,7 @@ exports[`should be the sames as the last snapshot when render coupon list 1`] = 
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Unavailable (2)
@@ -72,6 +75,7 @@ exports[`should be the sames as the last snapshot when render coupon list 1`] = 
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         <div
@@ -288,6 +292,7 @@ exports[`should be the sames as the last snapshot when render coupon list 1`] = 
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -319,6 +324,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
             id="van-field-input"
             class="van-field__control"
             placeholder="Coupon code"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -349,6 +355,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Available (0)
@@ -361,6 +368,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Unavailable (0)
@@ -380,6 +388,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
         <div
@@ -389,7 +398,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
           <div class="van-empty">
             <div class="van-empty__image">
               <svg viewbox="0 0 160 160">
-                <defs>
+                <defs data-allow-mismatch="children">
                   <linearGradient
                     x1="50%"
                     x2="50%"
@@ -449,6 +458,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     x1="64%"
                     y1="100%"
                     x2="64%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#FFF"
@@ -463,7 +473,10 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M36 131V53H16v20H2v58h34z"
                     fill="url(#van-empty-a)"
@@ -482,6 +495,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     y1="97%"
                     x2="64%"
                     y2="0%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#F2F3F5"
@@ -496,7 +510,10 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
                     fill="url(#van-empty-b)"
@@ -528,6 +545,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                       width="64"
                       height="66"
                       rx="2"
+                      data-allow-mismatch="attribute"
                     >
                     </rect>
                     <rect
@@ -542,6 +560,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     <g
                       transform="translate(15 17)"
                       fill="url(#van-empty-6)"
+                      data-allow-mismatch="attribute"
                     >
                       <rect
                         width="34"
@@ -566,6 +585,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     width="88"
                     height="28"
                     rx="1"
+                    data-allow-mismatch="attribute"
                   >
                   </rect>
                   <rect
@@ -594,6 +614,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style
       >
         <div
@@ -603,7 +624,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
           <div class="van-empty">
             <div class="van-empty__image">
               <svg viewbox="0 0 160 160">
-                <defs>
+                <defs data-allow-mismatch="children">
                   <linearGradient
                     x1="50%"
                     x2="50%"
@@ -663,6 +684,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     x1="64%"
                     y1="100%"
                     x2="64%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#FFF"
@@ -677,7 +699,10 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M36 131V53H16v20H2v58h34z"
                     fill="url(#van-empty-a)"
@@ -696,6 +721,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     y1="97%"
                     x2="64%"
                     y2="0%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#F2F3F5"
@@ -710,7 +736,10 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
                     fill="url(#van-empty-b)"
@@ -742,6 +771,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                       width="64"
                       height="66"
                       rx="2"
+                      data-allow-mismatch="attribute"
                     >
                     </rect>
                     <rect
@@ -756,6 +786,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     <g
                       transform="translate(15 17)"
                       fill="url(#van-empty-6)"
+                      data-allow-mismatch="attribute"
                     >
                       <rect
                         width="34"
@@ -780,6 +811,7 @@ exports[`should have two "van-coupon-list__empty" classes when render coupon lis
                     width="88"
                     height="28"
                     rx="1"
+                    data-allow-mismatch="attribute"
                   >
                   </rect>
                   <rect
@@ -830,6 +862,7 @@ exports[`should render list-footer slot correctly 1`] = `
             id="van-field-input"
             class="van-field__control"
             placeholder="Coupon code"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -860,6 +893,7 @@ exports[`should render list-footer slot correctly 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Available (0)
@@ -872,6 +906,7 @@ exports[`should render list-footer slot correctly 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Unavailable (0)
@@ -891,6 +926,7 @@ exports[`should render list-footer slot correctly 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
         <div
@@ -900,7 +936,7 @@ exports[`should render list-footer slot correctly 1`] = `
           <div class="van-empty">
             <div class="van-empty__image">
               <svg viewbox="0 0 160 160">
-                <defs>
+                <defs data-allow-mismatch="children">
                   <linearGradient
                     x1="50%"
                     x2="50%"
@@ -960,6 +996,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     x1="64%"
                     y1="100%"
                     x2="64%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#FFF"
@@ -974,7 +1011,10 @@ exports[`should render list-footer slot correctly 1`] = `
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M36 131V53H16v20H2v58h34z"
                     fill="url(#van-empty-a)"
@@ -993,6 +1033,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     y1="97%"
                     x2="64%"
                     y2="0%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#F2F3F5"
@@ -1007,7 +1048,10 @@ exports[`should render list-footer slot correctly 1`] = `
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
                     fill="url(#van-empty-b)"
@@ -1039,6 +1083,7 @@ exports[`should render list-footer slot correctly 1`] = `
                       width="64"
                       height="66"
                       rx="2"
+                      data-allow-mismatch="attribute"
                     >
                     </rect>
                     <rect
@@ -1053,6 +1098,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     <g
                       transform="translate(15 17)"
                       fill="url(#van-empty-6)"
+                      data-allow-mismatch="attribute"
                     >
                       <rect
                         width="34"
@@ -1077,6 +1123,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     width="88"
                     height="28"
                     rx="1"
+                    data-allow-mismatch="attribute"
                   >
                   </rect>
                   <rect
@@ -1106,6 +1153,7 @@ exports[`should render list-footer slot correctly 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style
       >
         <div
@@ -1115,7 +1163,7 @@ exports[`should render list-footer slot correctly 1`] = `
           <div class="van-empty">
             <div class="van-empty__image">
               <svg viewbox="0 0 160 160">
-                <defs>
+                <defs data-allow-mismatch="children">
                   <linearGradient
                     x1="50%"
                     x2="50%"
@@ -1175,6 +1223,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     x1="64%"
                     y1="100%"
                     x2="64%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#FFF"
@@ -1189,7 +1238,10 @@ exports[`should render list-footer slot correctly 1`] = `
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M36 131V53H16v20H2v58h34z"
                     fill="url(#van-empty-a)"
@@ -1208,6 +1260,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     y1="97%"
                     x2="64%"
                     y2="0%"
+                    data-allow-mismatch="attribute"
                   >
                     <stop
                       stop-color="#F2F3F5"
@@ -1222,7 +1275,10 @@ exports[`should render list-footer slot correctly 1`] = `
                     </stop>
                   </linearGradient>
                 </defs>
-                <g opacity=".8">
+                <g
+                  opacity=".8"
+                  data-allow-mismatch="children"
+                >
                   <path
                     d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
                     fill="url(#van-empty-b)"
@@ -1254,6 +1310,7 @@ exports[`should render list-footer slot correctly 1`] = `
                       width="64"
                       height="66"
                       rx="2"
+                      data-allow-mismatch="attribute"
                     >
                     </rect>
                     <rect
@@ -1268,6 +1325,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     <g
                       transform="translate(15 17)"
                       fill="url(#van-empty-6)"
+                      data-allow-mismatch="attribute"
                     >
                       <rect
                         width="34"
@@ -1292,6 +1350,7 @@ exports[`should render list-footer slot correctly 1`] = `
                     width="88"
                     height="28"
                     rx="1"
+                    data-allow-mismatch="attribute"
                   >
                   </rect>
                   <rect
@@ -1343,6 +1402,7 @@ exports[`should use custom src when using empty-image prop 1`] = `
             id="van-field-input"
             class="van-field__control"
             placeholder="Coupon code"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -1373,6 +1433,7 @@ exports[`should use custom src when using empty-image prop 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Available (0)
@@ -1385,6 +1446,7 @@ exports[`should use custom src when using empty-image prop 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Unavailable (0)
@@ -1404,6 +1466,7 @@ exports[`should use custom src when using empty-image prop 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         <div
@@ -1428,6 +1491,7 @@ exports[`should use custom src when using empty-image prop 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>

--- a/packages/vant/src/dropdown-item/DropdownItem.tsx
+++ b/packages/vant/src/dropdown-item/DropdownItem.tsx
@@ -216,6 +216,7 @@ export default defineComponent({
             lazyRender={props.lazyRender}
             overlayStyle={{ position: 'absolute' }}
             aria-labelledby={`${parent.id}-${index.value}`}
+            data-allow-mismatch="attribute"
             closeOnClickOverlay={closeOnClickOverlay}
             onOpen={onOpen}
             onClose={onClose}

--- a/packages/vant/src/dropdown-menu/DropdownMenu.tsx
+++ b/packages/vant/src/dropdown-menu/DropdownMenu.tsx
@@ -130,6 +130,7 @@ export default defineComponent({
           id={`${id}-${index}`}
           role="button"
           tabindex={disabled ? undefined : 0}
+          data-allow-mismatch="attribute"
           class={[
             bem('item', { disabled, grow: scrollable.value }),
             { [HAPTICS_FEEDBACK]: !disabled },

--- a/packages/vant/src/dropdown-menu/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/dropdown-menu/test/__snapshots__/demo.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-0"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -20,6 +21,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-1"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -80,6 +82,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-0"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -92,6 +95,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-1"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -152,6 +156,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-0"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -164,6 +169,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-1"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -224,6 +230,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-0"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-dropdown-menu__item--grow van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -236,6 +243,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-1"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-dropdown-menu__item--grow van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -248,6 +256,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-2"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-dropdown-menu__item--grow van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -260,6 +269,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-3"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-dropdown-menu__item--grow van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -272,6 +282,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-4"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-dropdown-menu__item--grow van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title">
@@ -395,6 +406,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-0"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title van-dropdown-menu__title--down">
@@ -407,6 +419,7 @@ exports[`should render demo and match snapshot 1`] = `
         id="van-dropdown-menu-1"
         role="button"
         tabindex="0"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-haptics-feedback"
       >
         <span class="van-dropdown-menu__title van-dropdown-menu__title--down">
@@ -466,6 +479,7 @@ exports[`should render demo and match snapshot 1`] = `
       <div
         id="van-dropdown-menu-0"
         role="button"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-dropdown-menu__item--disabled"
       >
         <span class="van-dropdown-menu__title">
@@ -477,6 +491,7 @@ exports[`should render demo and match snapshot 1`] = `
       <div
         id="van-dropdown-menu-1"
         role="button"
+        data-allow-mismatch="attribute"
         class="van-dropdown-menu__item van-dropdown-menu__item--disabled"
       >
         <span class="van-dropdown-menu__title">

--- a/packages/vant/src/dropdown-menu/test/__snapshots__/index.spec.tsx.snap
+++ b/packages/vant/src/dropdown-menu/test/__snapshots__/index.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`click option 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -19,6 +20,7 @@ exports[`click option 1`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -58,6 +60,7 @@ exports[`click option 1`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -121,6 +124,7 @@ exports[`close-on-click-outside 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -133,6 +137,7 @@ exports[`close-on-click-outside 1`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -172,6 +177,7 @@ exports[`close-on-click-outside 1`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -235,6 +241,7 @@ exports[`destroy one item 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -275,6 +282,7 @@ exports[`direction up 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--down">
@@ -287,6 +295,7 @@ exports[`direction up 1`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--down">
@@ -348,6 +357,7 @@ exports[`direction up 2`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--active">
@@ -360,6 +370,7 @@ exports[`direction up 2`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--down">
@@ -399,6 +410,7 @@ exports[`direction up 2`] = `
         tabindex="0"
         class="van-popup van-popup--bottom van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -462,6 +474,7 @@ exports[`disable close-on-click-outside 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--down van-dropdown-menu__title--active">
@@ -474,6 +487,7 @@ exports[`disable close-on-click-outside 1`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -513,6 +527,7 @@ exports[`disable close-on-click-outside 1`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -575,6 +590,7 @@ exports[`disable dropdown item 1`] = `
     <div
       id="van-dropdown-menu-0"
       role="button"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-dropdown-menu__item--disabled"
     >
       <span class="van-dropdown-menu__title">
@@ -615,6 +631,7 @@ exports[`render option icon 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--down van-dropdown-menu__title--active">
@@ -627,6 +644,7 @@ exports[`render option icon 1`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -666,6 +684,7 @@ exports[`render option icon 1`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -733,6 +752,7 @@ exports[`show dropdown item 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--down van-dropdown-menu__title--active">
@@ -745,6 +765,7 @@ exports[`show dropdown item 1`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -784,6 +805,7 @@ exports[`show dropdown item 1`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -847,6 +869,7 @@ exports[`show dropdown item 2`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -859,6 +882,7 @@ exports[`show dropdown item 2`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title van-dropdown-menu__title--down van-dropdown-menu__title--active">
@@ -898,6 +922,7 @@ exports[`show dropdown item 2`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -960,6 +985,7 @@ exports[`show dropdown item 2`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-1"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -1002,6 +1028,7 @@ exports[`show dropdown item 3`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -1014,6 +1041,7 @@ exports[`show dropdown item 3`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -1053,6 +1081,7 @@ exports[`show dropdown item 3`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-0"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -1115,6 +1144,7 @@ exports[`show dropdown item 3`] = `
         tabindex="0"
         class="van-popup van-popup--top van-dropdown-item__content"
         aria-labelledby="van-dropdown-menu-1"
+        data-allow-mismatch="attribute"
       >
         <div
           class="van-cell van-cell--clickable van-dropdown-item__option van-dropdown-item__option--active"
@@ -1157,6 +1187,7 @@ exports[`title prop 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -1169,6 +1200,7 @@ exports[`title prop 1`] = `
       id="van-dropdown-menu-1"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">
@@ -1230,6 +1262,7 @@ exports[`title slot 1`] = `
       id="van-dropdown-menu-0"
       role="button"
       tabindex="0"
+      data-allow-mismatch="attribute"
       class="van-dropdown-menu__item van-haptics-feedback"
     >
       <span class="van-dropdown-menu__title">

--- a/packages/vant/src/empty/Empty.tsx
+++ b/packages/vant/src/empty/Empty.tsx
@@ -62,6 +62,7 @@ export default defineComponent({
           fy="54%"
           r="297%"
           gradientTransform="matrix(-.16 0 0 -.33 .58 .72)"
+          data-allow-mismatch="attribute"
         >
           {renderStop('#EBEDF0', 0)}
           {renderStop('#F2F3F5', 100, 0.3)}
@@ -74,17 +75,24 @@ export default defineComponent({
         cy="140"
         rx="46"
         ry="8"
+        data-allow-mismatch="attribute"
       />,
     ];
 
     const renderBuilding = () => [
       <defs>
-        <linearGradient id={getId('a')} x1="64%" y1="100%" x2="64%">
+        <linearGradient
+          id={getId('a')}
+          x1="64%"
+          y1="100%"
+          x2="64%"
+          data-allow-mismatch="attribute"
+        >
           {renderStop('#FFF', 0, 0.5)}
           {renderStop('#F2F3F5', 100)}
         </linearGradient>
       </defs>,
-      <g opacity=".8">
+      <g opacity=".8" data-allow-mismatch="children">
         <path d="M36 131V53H16v20H2v58h34z" fill={getUrlById('a')} />
         <path d="M123 15h22v14h9v77h-31V15z" fill={getUrlById('a')} />
       </g>,
@@ -92,12 +100,19 @@ export default defineComponent({
 
     const renderCloud = () => [
       <defs>
-        <linearGradient id={getId('b')} x1="64%" y1="97%" x2="64%" y2="0%">
+        <linearGradient
+          id={getId('b')}
+          x1="64%"
+          y1="97%"
+          x2="64%"
+          y2="0%"
+          data-allow-mismatch="attribute"
+        >
           {renderStop('#F2F3F5', 0, 0.3)}
           {renderStop('#F2F3F5', 100)}
         </linearGradient>
       </defs>,
-      <g opacity=".8">
+      <g opacity=".8" data-allow-mismatch="children">
         <path
           d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
           fill={getUrlById('b')}
@@ -111,7 +126,7 @@ export default defineComponent({
 
     const renderNetwork = () => (
       <svg viewBox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient id={getId(1)} x1="64%" y1="100%" x2="64%">
             {renderStop('#FFF', 0, 0.5)}
             {renderStop('#F2F3F5', 100)}
@@ -138,12 +153,22 @@ export default defineComponent({
         </defs>
         <g fill="none">
           {renderBuilding()}
-          <path fill={getUrlById(4)} d="M0 139h160v21H0z" />
+          <path
+            fill={getUrlById(4)}
+            d="M0 139h160v21H0z"
+            data-allow-mismatch="attribute"
+          />
           <path
             d="M80 54a7 7 0 0 1 3 13v27l-2 2h-2a2 2 0 0 1-2-2V67a7 7 0 0 1 3-13z"
             fill={getUrlById(2)}
+            data-allow-mismatch="attribute"
           />
-          <g opacity=".6" stroke-linecap="round" stroke-width="7">
+          <g
+            opacity=".6"
+            stroke-linecap="round"
+            stroke-width="7"
+            data-allow-mismatch="children"
+          >
             <path
               d="M64 47a19 19 0 0 0-5 13c0 5 2 10 5 13"
               stroke={getUrlById(3)}
@@ -166,7 +191,7 @@ export default defineComponent({
 
     const renderMaterial = () => (
       <svg viewBox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient x1="50%" x2="50%" y2="100%" id={getId(5)}>
             {renderStops('#F2F3F5', '#DCDEE0')}
           </linearGradient>
@@ -190,15 +215,32 @@ export default defineComponent({
               height="53"
               rx="2"
             />
-            <rect fill={getUrlById(5)} width="64" height="66" rx="2" />
+            <rect
+              fill={getUrlById(5)}
+              width="64"
+              height="66"
+              rx="2"
+              data-allow-mismatch="attribute"
+            />
             <rect fill="#FFF" x="6" y="6" width="52" height="55" rx="1" />
-            <g transform="translate(15 17)" fill={getUrlById(6)}>
+            <g
+              transform="translate(15 17)"
+              fill={getUrlById(6)}
+              data-allow-mismatch="attribute"
+            >
               <rect width="34" height="6" rx="1" />
               <path d="M0 14h34v6H0z" />
               <rect y="28" width="34" height="6" rx="1" />
             </g>
           </g>
-          <rect fill={getUrlById(7)} y="61" width="88" height="28" rx="1" />
+          <rect
+            fill={getUrlById(7)}
+            y="61"
+            width="88"
+            height="28"
+            rx="1"
+            data-allow-mismatch="attribute"
+          />
           <rect fill="#F7F8FA" x="29" y="72" width="30" height="6" rx="1" />
         </g>
       </svg>
@@ -207,7 +249,13 @@ export default defineComponent({
     const renderError = () => (
       <svg viewBox="0 0 160 160">
         <defs>
-          <linearGradient x1="50%" x2="50%" y2="100%" id={getId(8)}>
+          <linearGradient
+            x1="50%"
+            x2="50%"
+            y2="100%"
+            id={getId(8)}
+            data-allow-mismatch="attribute"
+          >
             {renderStops('#EAEDF1', '#DCDEE0')}
           </linearGradient>
         </defs>
@@ -217,13 +265,14 @@ export default defineComponent({
         <path
           d="m59 60 21 21 21-21h3l9 9v3L92 93l21 21v3l-9 9h-3l-21-21-21 21h-3l-9-9v-3l21-21-21-21v-3l9-9h3Z"
           fill={getUrlById(8)}
+          data-allow-mismatch="attribute"
         />
       </svg>
     );
 
     const renderSearch = () => (
       <svg viewBox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient x1="50%" y1="100%" x2="50%" id={getId(9)}>
             {renderStops('#EEE', '#D8D8D8')}
           </linearGradient>
@@ -240,7 +289,11 @@ export default defineComponent({
         {renderBuilding()}
         {renderCloud()}
         {renderShadow('d')}
-        <g transform="rotate(-45 113 -4)" fill="none">
+        <g
+          transform="rotate(-45 113 -4)"
+          fill="none"
+          data-allow-mismatch="children"
+        >
           <rect
             fill={getUrlById(9)}
             x="24"

--- a/packages/vant/src/empty/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/empty/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`should render demo and match snapshot 1`] = `
       style
     >
       <svg viewbox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient
             x1="50%"
             x2="50%"
@@ -74,6 +74,7 @@ exports[`should render demo and match snapshot 1`] = `
             x1="64%"
             y1="100%"
             x2="64%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#FFF"
@@ -88,7 +89,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M36 131V53H16v20H2v58h34z"
             fill="url(#van-empty-a)"
@@ -108,6 +112,7 @@ exports[`should render demo and match snapshot 1`] = `
             y1="97%"
             x2="64%"
             y2="0%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#F2F3F5"
@@ -122,7 +127,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
             fill="url(#van-empty-b)"
@@ -154,6 +162,7 @@ exports[`should render demo and match snapshot 1`] = `
               width="64"
               height="66"
               rx="2"
+              data-allow-mismatch="attribute"
             >
             </rect>
             <rect
@@ -168,6 +177,7 @@ exports[`should render demo and match snapshot 1`] = `
             <g
               transform="translate(15 17)"
               fill="url(#van-empty-6)"
+              data-allow-mismatch="attribute"
             >
               <rect
                 width="34"
@@ -192,6 +202,7 @@ exports[`should render demo and match snapshot 1`] = `
             width="88"
             height="28"
             rx="1"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect
@@ -234,6 +245,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -243,6 +255,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -252,6 +265,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -266,7 +280,7 @@ exports[`should render demo and match snapshot 1`] = `
       style="width:100px;height:100px;"
     >
       <svg viewbox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient
             x1="50%"
             x2="50%"
@@ -330,6 +344,7 @@ exports[`should render demo and match snapshot 1`] = `
             x1="64%"
             y1="100%"
             x2="64%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#FFF"
@@ -344,7 +359,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M36 131V53H16v20H2v58h34z"
             fill="url(#van-empty-a)"
@@ -364,6 +382,7 @@ exports[`should render demo and match snapshot 1`] = `
             y1="97%"
             x2="64%"
             y2="0%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#F2F3F5"
@@ -378,7 +397,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
             fill="url(#van-empty-b)"
@@ -410,6 +432,7 @@ exports[`should render demo and match snapshot 1`] = `
               width="64"
               height="66"
               rx="2"
+              data-allow-mismatch="attribute"
             >
             </rect>
             <rect
@@ -424,6 +447,7 @@ exports[`should render demo and match snapshot 1`] = `
             <g
               transform="translate(15 17)"
               fill="url(#van-empty-6)"
+              data-allow-mismatch="attribute"
             >
               <rect
                 width="34"
@@ -448,6 +472,7 @@ exports[`should render demo and match snapshot 1`] = `
             width="88"
             height="28"
             rx="1"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect
@@ -489,7 +514,7 @@ exports[`should render demo and match snapshot 1`] = `
       style
     >
       <svg viewbox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient
             x1="50%"
             x2="50%"
@@ -553,6 +578,7 @@ exports[`should render demo and match snapshot 1`] = `
             x1="64%"
             y1="100%"
             x2="64%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#FFF"
@@ -567,7 +593,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M36 131V53H16v20H2v58h34z"
             fill="url(#van-empty-a)"
@@ -587,6 +616,7 @@ exports[`should render demo and match snapshot 1`] = `
             y1="97%"
             x2="64%"
             y2="0%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#F2F3F5"
@@ -601,7 +631,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
             fill="url(#van-empty-b)"
@@ -633,6 +666,7 @@ exports[`should render demo and match snapshot 1`] = `
               width="64"
               height="66"
               rx="2"
+              data-allow-mismatch="attribute"
             >
             </rect>
             <rect
@@ -647,6 +681,7 @@ exports[`should render demo and match snapshot 1`] = `
             <g
               transform="translate(15 17)"
               fill="url(#van-empty-6)"
+              data-allow-mismatch="attribute"
             >
               <rect
                 width="34"
@@ -671,6 +706,7 @@ exports[`should render demo and match snapshot 1`] = `
             width="88"
             height="28"
             rx="1"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect

--- a/packages/vant/src/empty/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/empty/test/__snapshots__/demo.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`should render demo and match snapshot 1`] = `
   <div class="van-empty">
     <div class="van-empty__image">
       <svg viewbox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient
             x1="50%"
             x2="50%"
@@ -65,6 +65,7 @@ exports[`should render demo and match snapshot 1`] = `
             x1="64%"
             y1="100%"
             x2="64%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#FFF"
@@ -79,7 +80,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M36 131V53H16v20H2v58h34z"
             fill="url(#van-empty-a)"
@@ -98,6 +102,7 @@ exports[`should render demo and match snapshot 1`] = `
             y1="97%"
             x2="64%"
             y2="0%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#F2F3F5"
@@ -112,7 +117,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
             fill="url(#van-empty-b)"
@@ -144,6 +152,7 @@ exports[`should render demo and match snapshot 1`] = `
               width="64"
               height="66"
               rx="2"
+              data-allow-mismatch="attribute"
             >
             </rect>
             <rect
@@ -158,6 +167,7 @@ exports[`should render demo and match snapshot 1`] = `
             <g
               transform="translate(15 17)"
               fill="url(#van-empty-6)"
+              data-allow-mismatch="attribute"
             >
               <rect
                 width="34"
@@ -182,6 +192,7 @@ exports[`should render demo and match snapshot 1`] = `
             width="88"
             height="28"
             rx="1"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect
@@ -216,6 +227,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Error
@@ -228,6 +240,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Network
@@ -240,6 +253,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Search
@@ -259,6 +273,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         <div class="van-empty">
@@ -270,6 +285,7 @@ exports[`should render demo and match snapshot 1`] = `
                   x2="50%"
                   y2="100%"
                   id="van-empty-8"
+                  data-allow-mismatch="attribute"
                 >
                   <stop
                     stop-color="#EAEDF1"
@@ -289,6 +305,7 @@ exports[`should render demo and match snapshot 1`] = `
                   x1="64%"
                   y1="100%"
                   x2="64%"
+                  data-allow-mismatch="attribute"
                 >
                   <stop
                     stop-color="#FFF"
@@ -303,7 +320,10 @@ exports[`should render demo and match snapshot 1`] = `
                   </stop>
                 </linearGradient>
               </defs>
-              <g opacity=".8">
+              <g
+                opacity=".8"
+                data-allow-mismatch="children"
+              >
                 <path
                   d="M36 131V53H16v20H2v58h34z"
                   fill="url(#van-empty-a)"
@@ -322,6 +342,7 @@ exports[`should render demo and match snapshot 1`] = `
                   y1="97%"
                   x2="64%"
                   y2="0%"
+                  data-allow-mismatch="attribute"
                 >
                   <stop
                     stop-color="#F2F3F5"
@@ -336,7 +357,10 @@ exports[`should render demo and match snapshot 1`] = `
                   </stop>
                 </linearGradient>
               </defs>
-              <g opacity=".8">
+              <g
+                opacity=".8"
+                data-allow-mismatch="children"
+              >
                 <path
                   d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
                   fill="url(#van-empty-b)"
@@ -357,6 +381,7 @@ exports[`should render demo and match snapshot 1`] = `
                   fy="54%"
                   r="297%"
                   gradienttransform="matrix(-.16 0 0 -.33 .58 .72)"
+                  data-allow-mismatch="attribute"
                 >
                   <stop
                     stop-color="#EBEDF0"
@@ -378,11 +403,13 @@ exports[`should render demo and match snapshot 1`] = `
                 cy="140"
                 rx="46"
                 ry="8"
+                data-allow-mismatch="attribute"
               >
               </ellipse>
               <path
                 d="m59 60 21 21 21-21h3l9 9v3L92 93l21 21v3l-9 9h-3l-21-21-21 21h-3l-9-9v-3l21-21-21-21v-3l9-9h3Z"
                 fill="url(#van-empty-8)"
+                data-allow-mismatch="attribute"
               >
               </path>
             </svg>
@@ -398,6 +425,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -407,6 +435,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -420,7 +449,7 @@ exports[`should render demo and match snapshot 1`] = `
       style="width: 100px; height: 100px;"
     >
       <svg viewbox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient
             x1="50%"
             x2="50%"
@@ -480,6 +509,7 @@ exports[`should render demo and match snapshot 1`] = `
             x1="64%"
             y1="100%"
             x2="64%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#FFF"
@@ -494,7 +524,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M36 131V53H16v20H2v58h34z"
             fill="url(#van-empty-a)"
@@ -513,6 +546,7 @@ exports[`should render demo and match snapshot 1`] = `
             y1="97%"
             x2="64%"
             y2="0%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#F2F3F5"
@@ -527,7 +561,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
             fill="url(#van-empty-b)"
@@ -559,6 +596,7 @@ exports[`should render demo and match snapshot 1`] = `
               width="64"
               height="66"
               rx="2"
+              data-allow-mismatch="attribute"
             >
             </rect>
             <rect
@@ -573,6 +611,7 @@ exports[`should render demo and match snapshot 1`] = `
             <g
               transform="translate(15 17)"
               fill="url(#van-empty-6)"
+              data-allow-mismatch="attribute"
             >
               <rect
                 width="34"
@@ -597,6 +636,7 @@ exports[`should render demo and match snapshot 1`] = `
             width="88"
             height="28"
             rx="1"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect
@@ -633,7 +673,7 @@ exports[`should render demo and match snapshot 1`] = `
   <div class="van-empty">
     <div class="van-empty__image">
       <svg viewbox="0 0 160 160">
-        <defs>
+        <defs data-allow-mismatch="children">
           <linearGradient
             x1="50%"
             x2="50%"
@@ -693,6 +733,7 @@ exports[`should render demo and match snapshot 1`] = `
             x1="64%"
             y1="100%"
             x2="64%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#FFF"
@@ -707,7 +748,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M36 131V53H16v20H2v58h34z"
             fill="url(#van-empty-a)"
@@ -726,6 +770,7 @@ exports[`should render demo and match snapshot 1`] = `
             y1="97%"
             x2="64%"
             y2="0%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#F2F3F5"
@@ -740,7 +785,10 @@ exports[`should render demo and match snapshot 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
             fill="url(#van-empty-b)"
@@ -772,6 +820,7 @@ exports[`should render demo and match snapshot 1`] = `
               width="64"
               height="66"
               rx="2"
+              data-allow-mismatch="attribute"
             >
             </rect>
             <rect
@@ -786,6 +835,7 @@ exports[`should render demo and match snapshot 1`] = `
             <g
               transform="translate(15 17)"
               fill="url(#van-empty-6)"
+              data-allow-mismatch="attribute"
             >
               <rect
                 width="34"
@@ -810,6 +860,7 @@ exports[`should render demo and match snapshot 1`] = `
             width="88"
             height="28"
             rx="1"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect

--- a/packages/vant/src/empty/test/__snapshots__/index.spec.ts.snap
+++ b/packages/vant/src/empty/test/__snapshots__/index.spec.ts.snap
@@ -4,7 +4,7 @@ exports[`should render bottom slot correctly 1`] = `
 <div class="van-empty">
   <div class="van-empty__image">
     <svg viewbox="0 0 160 160">
-      <defs>
+      <defs data-allow-mismatch="children">
         <linearGradient
           x1="50%"
           x2="50%"
@@ -64,6 +64,7 @@ exports[`should render bottom slot correctly 1`] = `
           x1="64%"
           y1="100%"
           x2="64%"
+          data-allow-mismatch="attribute"
         >
           <stop
             stop-color="#FFF"
@@ -78,7 +79,10 @@ exports[`should render bottom slot correctly 1`] = `
           </stop>
         </linearGradient>
       </defs>
-      <g opacity=".8">
+      <g
+        opacity=".8"
+        data-allow-mismatch="children"
+      >
         <path
           d="M36 131V53H16v20H2v58h34z"
           fill="url(#van-empty-a)"
@@ -97,6 +101,7 @@ exports[`should render bottom slot correctly 1`] = `
           y1="97%"
           x2="64%"
           y2="0%"
+          data-allow-mismatch="attribute"
         >
           <stop
             stop-color="#F2F3F5"
@@ -111,7 +116,10 @@ exports[`should render bottom slot correctly 1`] = `
           </stop>
         </linearGradient>
       </defs>
-      <g opacity=".8">
+      <g
+        opacity=".8"
+        data-allow-mismatch="children"
+      >
         <path
           d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
           fill="url(#van-empty-b)"
@@ -143,6 +151,7 @@ exports[`should render bottom slot correctly 1`] = `
             width="64"
             height="66"
             rx="2"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect
@@ -157,6 +166,7 @@ exports[`should render bottom slot correctly 1`] = `
           <g
             transform="translate(15 17)"
             fill="url(#van-empty-6)"
+            data-allow-mismatch="attribute"
           >
             <rect
               width="34"
@@ -181,6 +191,7 @@ exports[`should render bottom slot correctly 1`] = `
           width="88"
           height="28"
           rx="1"
+          data-allow-mismatch="attribute"
         >
         </rect>
         <rect
@@ -205,7 +216,7 @@ exports[`should render description slot correctly 1`] = `
 <div class="van-empty">
   <div class="van-empty__image">
     <svg viewbox="0 0 160 160">
-      <defs>
+      <defs data-allow-mismatch="children">
         <linearGradient
           x1="50%"
           x2="50%"
@@ -265,6 +276,7 @@ exports[`should render description slot correctly 1`] = `
           x1="64%"
           y1="100%"
           x2="64%"
+          data-allow-mismatch="attribute"
         >
           <stop
             stop-color="#FFF"
@@ -279,7 +291,10 @@ exports[`should render description slot correctly 1`] = `
           </stop>
         </linearGradient>
       </defs>
-      <g opacity=".8">
+      <g
+        opacity=".8"
+        data-allow-mismatch="children"
+      >
         <path
           d="M36 131V53H16v20H2v58h34z"
           fill="url(#van-empty-a)"
@@ -298,6 +313,7 @@ exports[`should render description slot correctly 1`] = `
           y1="97%"
           x2="64%"
           y2="0%"
+          data-allow-mismatch="attribute"
         >
           <stop
             stop-color="#F2F3F5"
@@ -312,7 +328,10 @@ exports[`should render description slot correctly 1`] = `
           </stop>
         </linearGradient>
       </defs>
-      <g opacity=".8">
+      <g
+        opacity=".8"
+        data-allow-mismatch="children"
+      >
         <path
           d="M87 6c3 0 7 3 8 6a8 8 0 1 1-1 16H80a7 7 0 0 1-8-6c0-4 3-7 6-7 0-5 4-9 9-9Z"
           fill="url(#van-empty-b)"
@@ -344,6 +363,7 @@ exports[`should render description slot correctly 1`] = `
             width="64"
             height="66"
             rx="2"
+            data-allow-mismatch="attribute"
           >
           </rect>
           <rect
@@ -358,6 +378,7 @@ exports[`should render description slot correctly 1`] = `
           <g
             transform="translate(15 17)"
             fill="url(#van-empty-6)"
+            data-allow-mismatch="attribute"
           >
             <rect
               width="34"
@@ -382,6 +403,7 @@ exports[`should render description slot correctly 1`] = `
           width="88"
           height="28"
           rx="1"
+          data-allow-mismatch="attribute"
         >
         </rect>
         <rect
@@ -414,7 +436,7 @@ exports[`should render svg when image is network 1`] = `
 <div class="van-empty">
   <div class="van-empty__image">
     <svg viewbox="0 0 160 160">
-      <defs>
+      <defs data-allow-mismatch="children">
         <linearGradient
           id="van-empty-1"
           x1="64%"
@@ -497,6 +519,7 @@ exports[`should render svg when image is network 1`] = `
             x1="64%"
             y1="100%"
             x2="64%"
+            data-allow-mismatch="attribute"
           >
             <stop
               stop-color="#FFF"
@@ -511,7 +534,10 @@ exports[`should render svg when image is network 1`] = `
             </stop>
           </linearGradient>
         </defs>
-        <g opacity=".8">
+        <g
+          opacity=".8"
+          data-allow-mismatch="children"
+        >
           <path
             d="M36 131V53H16v20H2v58h34z"
             fill="url(#van-empty-a)"
@@ -526,17 +552,20 @@ exports[`should render svg when image is network 1`] = `
         <path
           fill="url(#van-empty-4)"
           d="M0 139h160v21H0z"
+          data-allow-mismatch="attribute"
         >
         </path>
         <path
           d="M80 54a7 7 0 0 1 3 13v27l-2 2h-2a2 2 0 0 1-2-2V67a7 7 0 0 1 3-13z"
           fill="url(#van-empty-2)"
+          data-allow-mismatch="attribute"
         >
         </path>
         <g
           opacity=".6"
           stroke-linecap="round"
           stroke-width="7"
+          data-allow-mismatch="children"
         >
           <path
             d="M64 47a19 19 0 0 0-5 13c0 5 2 10 5 13"

--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -523,6 +523,7 @@ export default defineComponent({
         enterkeyhint: props.enterkeyhint,
         spellcheck: props.spellcheck,
         'aria-labelledby': props.label ? `${id}-label` : undefined,
+        'data-allow-mismatch': 'attribute',
         onBlur,
         onFocus,
         onInput,
@@ -614,6 +615,7 @@ export default defineComponent({
           <label
             id={`${id}-label`}
             for={slots.input ? undefined : getInputId()}
+            data-allow-mismatch="attribute"
             onClick={(event: MouseEvent) => {
               // https://github.com/youzan/vant/issues/11831
               preventDefault(event);

--- a/packages/vant/src/field/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/field/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Label
@@ -29,6 +30,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Text"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -50,6 +52,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Text
@@ -65,6 +68,7 @@ exports[`should render demo and match snapshot 1`] = `
               placeholder="Text"
               autocomplete="off"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -78,6 +82,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Phone
@@ -92,6 +97,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -105,6 +111,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Digit
@@ -120,6 +127,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Digit"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -133,6 +141,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Number
@@ -148,6 +157,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Number"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -161,6 +171,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Password
@@ -176,6 +187,7 @@ exports[`should render demo and match snapshot 1`] = `
               placeholder="Password"
               autocomplete="off"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -196,6 +208,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Text
@@ -210,6 +223,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             readonly
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -223,6 +237,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Text
@@ -237,6 +252,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             disabled
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -265,6 +281,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Text
@@ -279,6 +296,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Show Icon"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
           <div class="van-field__right-icon">
             <i
@@ -309,6 +327,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Text
@@ -323,6 +342,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Show Clear Icon"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -343,6 +363,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Username
@@ -357,6 +378,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Username"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -370,6 +392,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Phone
@@ -384,6 +407,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Phone"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -405,6 +429,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Username
@@ -419,6 +444,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Username"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -432,6 +458,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Phone
@@ -446,6 +473,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -466,6 +494,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Username
@@ -480,6 +509,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control van-field__control--error"
             placeholder="Username"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -493,6 +523,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Phone
@@ -507,6 +538,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Phone"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
         <div class="van-field__error-message">
@@ -529,6 +561,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           SMS
@@ -543,6 +576,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="SMS"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
           <div class="van-field__button">
             <!--[-->
@@ -577,6 +611,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Text
@@ -591,6 +626,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Format On Change"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -604,6 +640,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Text
@@ -618,6 +655,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Format On Blur"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -637,6 +675,7 @@ exports[`should render demo and match snapshot 1`] = `
             rows="1"
             class="van-field__control"
             placeholder="Message"
+            data-allow-mismatch="attribute"
           >
           </textarea>
         </div>
@@ -657,6 +696,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Message
@@ -671,6 +711,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Message"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
           </textarea>
         </div>
@@ -697,6 +738,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Text
@@ -711,6 +753,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control van-field__control--right"
             placeholder="Input Align Right"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -730,6 +773,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Label
@@ -744,6 +788,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Top"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -757,6 +802,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Label
@@ -771,6 +817,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Left"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -784,6 +831,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Label
@@ -798,6 +846,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Center"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -811,6 +860,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
           style
         >
           Label
@@ -825,6 +875,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Right"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>

--- a/packages/vant/src/field/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/field/test/__snapshots__/demo.spec.ts.snap
@@ -8,6 +8,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Label
         </label>
@@ -20,6 +21,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Text"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -34,6 +36,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Text
           </label>
@@ -47,6 +50,7 @@ exports[`should render demo and match snapshot 1`] = `
               placeholder="Text"
               autocomplete="off"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -56,6 +60,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Phone
           </label>
@@ -68,6 +73,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -77,6 +83,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Digit
           </label>
@@ -90,6 +97,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Digit"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -99,6 +107,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Number
           </label>
@@ -112,6 +121,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Number"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -121,6 +131,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Password
           </label>
@@ -134,6 +145,7 @@ exports[`should render demo and match snapshot 1`] = `
               placeholder="Password"
               autocomplete="off"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -148,6 +160,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Text
         </label>
@@ -160,6 +173,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             readonly
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -169,6 +183,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Text
         </label>
@@ -181,6 +196,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             disabled
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -198,6 +214,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Text
         </label>
@@ -210,6 +227,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Show Icon"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
           <div class="van-field__right-icon">
             <i class="van-badge__wrapper van-icon van-icon-warning-o">
@@ -227,6 +245,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Text
         </label>
@@ -239,6 +258,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Show Clear Icon"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -252,6 +272,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Username
         </label>
@@ -264,6 +285,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Username"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -273,6 +295,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Phone
         </label>
@@ -285,6 +308,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Phone"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -299,6 +323,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Username
           </label>
@@ -311,6 +336,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Username"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -320,6 +346,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Phone
           </label>
@@ -332,6 +359,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Phone"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -346,6 +374,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Username
         </label>
@@ -358,6 +387,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control van-field__control--error"
             placeholder="Username"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -367,6 +397,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Phone
         </label>
@@ -379,6 +410,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Phone"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
         <div class="van-field__error-message">
@@ -395,6 +427,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           SMS
         </label>
@@ -407,6 +440,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="SMS"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
           <div class="van-field__button">
             <button
@@ -432,6 +466,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Text
         </label>
@@ -444,6 +479,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Format On Change"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -453,6 +489,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Text
         </label>
@@ -465,6 +502,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Format On Blur"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -481,6 +519,7 @@ exports[`should render demo and match snapshot 1`] = `
             rows="1"
             class="van-field__control"
             placeholder="Message"
+            data-allow-mismatch="attribute"
             style="height: auto;"
           >
           </textarea>
@@ -496,6 +535,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Message
         </label>
@@ -508,6 +548,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Message"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
             style="height: auto;"
           >
           </textarea>
@@ -529,6 +570,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Text
         </label>
@@ -541,6 +583,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control van-field__control--right"
             placeholder="Input Align Right"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -554,6 +597,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Label
         </label>
@@ -566,6 +610,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Top"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -575,6 +620,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Label
         </label>
@@ -587,6 +633,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Left"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -596,6 +643,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Label
         </label>
@@ -608,6 +656,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Center"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>
@@ -617,6 +666,7 @@ exports[`should render demo and match snapshot 1`] = `
         <label
           id="van-field-label"
           for="van-field-input"
+          data-allow-mismatch="attribute"
         >
           Label
         </label>
@@ -629,6 +679,7 @@ exports[`should render demo and match snapshot 1`] = `
             class="van-field__control"
             placeholder="Align Right"
             aria-labelledby="van-field-label"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>

--- a/packages/vant/src/field/test/__snapshots__/index.spec.js.snap
+++ b/packages/vant/src/field/test/__snapshots__/index.spec.js.snap
@@ -13,6 +13,7 @@ exports[`should render colon when using colon prop 1`] = `
   <label
     id="van-field-label"
     for="van-field-input"
+    data-allow-mismatch="attribute"
   >
     foo:
   </label>
@@ -33,6 +34,7 @@ exports[`should render extra slot correctly 1`] = `
         type="text"
         id="van-field-input"
         class="van-field__control"
+        data-allow-mismatch="attribute"
       >
     </div>
   </div>
@@ -51,6 +53,7 @@ exports[`should render label correctly when dynamically set empty label 1`] = `
   <label
     id="van-field-label"
     for="van-field-input"
+    data-allow-mismatch="attribute"
   >
     abc
   </label>
@@ -73,6 +76,7 @@ exports[`should render left icon inside label when label-align is top 1`] = `
     <label
       id="van-field-label"
       for="van-field-input"
+      data-allow-mismatch="attribute"
     >
       Label
     </label>
@@ -84,6 +88,7 @@ exports[`should render left icon inside label when label-align is top 1`] = `
         id="van-field-input"
         class="van-field__control"
         aria-labelledby="van-field-label"
+        data-allow-mismatch="attribute"
       >
     </div>
   </div>
@@ -97,6 +102,7 @@ exports[`should render textarea when type is textarea 1`] = `
       <textarea
         id="van-field-input"
         class="van-field__control"
+        data-allow-mismatch="attribute"
         style="height: auto;"
       >
       </textarea>
@@ -122,6 +128,7 @@ exports[`should render word limit correctly when modelValue is null 1`] = `
         type="text"
         id="van-field-input"
         class="van-field__control"
+        data-allow-mismatch="attribute"
       >
     </div>
     <div class="van-field__word-limit">
@@ -142,6 +149,7 @@ exports[`should render word limit correctly when modelValue is undefined 1`] = `
         type="text"
         id="van-field-input"
         class="van-field__control"
+        data-allow-mismatch="attribute"
       >
     </div>
     <div class="van-field__word-limit">

--- a/packages/vant/src/floating-bubble/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/floating-bubble/test/__snapshots__/demo.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Basic Usage
@@ -27,6 +28,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Free Magnetic
@@ -39,6 +41,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           vModel
@@ -58,6 +61,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       <p class="text">
@@ -70,6 +74,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -79,6 +84,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>

--- a/packages/vant/src/floating-panel/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/floating-panel/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -22,6 +22,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -31,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -40,6 +42,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>

--- a/packages/vant/src/floating-panel/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/floating-panel/test/__snapshots__/demo.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Basic Usage
@@ -27,6 +28,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Custom Anchors
@@ -39,6 +41,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Head Drag Only
@@ -58,6 +61,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       <div
@@ -262,6 +266,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -271,6 +276,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>

--- a/packages/vant/src/form/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/form/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -17,6 +17,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Username
@@ -32,6 +33,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Username"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -45,6 +47,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Password
@@ -60,6 +63,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Password"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -96,6 +100,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Label
@@ -111,6 +116,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use pattern"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -124,6 +130,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Label
@@ -139,6 +146,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use validator"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -152,6 +160,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Label
@@ -167,6 +176,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use validator to return message"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -180,6 +190,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Label
@@ -195,6 +206,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use async validator"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -230,6 +242,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Switch
@@ -262,6 +275,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Checkbox
@@ -303,6 +317,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Checkbox Group
@@ -374,6 +389,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Radio
@@ -448,6 +464,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Stepper
@@ -500,6 +517,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Rate
@@ -611,6 +629,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Slider
@@ -658,6 +677,7 @@ exports[`should render demo and match snapshot 1`] = `
           <!--[-->
           <label
             id="van-field-label"
+            data-allow-mismatch="attribute"
             style
           >
             Uploader
@@ -741,6 +761,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Picker
@@ -757,6 +778,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select city"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -781,6 +803,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Datetime Picker
@@ -797,6 +820,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select time"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -821,6 +845,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Area Picker
@@ -837,6 +862,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select area"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -861,6 +887,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
             style
           >
             Calendar
@@ -877,6 +904,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select date"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>

--- a/packages/vant/src/form/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/form/test/__snapshots__/demo.spec.ts.snap
@@ -9,6 +9,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Username
           </label>
@@ -22,6 +23,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Username"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -31,6 +33,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Password
           </label>
@@ -44,6 +47,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Password"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -71,6 +75,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Label
           </label>
@@ -84,6 +89,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use pattern"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -93,6 +99,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Label
           </label>
@@ -106,6 +113,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use validator"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -115,6 +123,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Label
           </label>
@@ -128,6 +137,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use validator to return message"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -137,6 +147,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Label
           </label>
@@ -150,6 +161,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               placeholder="Use async validator"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -174,7 +186,10 @@ exports[`should render demo and match snapshot 1`] = `
     <div class="van-cell-group van-cell-group--inset">
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Switch
           </label>
         </div>
@@ -196,7 +211,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Checkbox
           </label>
         </div>
@@ -220,7 +238,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Checkbox Group
           </label>
         </div>
@@ -263,7 +284,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Radio
           </label>
         </div>
@@ -309,7 +333,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Stepper
           </label>
         </div>
@@ -349,7 +376,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Rate
           </label>
         </div>
@@ -425,7 +455,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Slider
           </label>
         </div>
@@ -457,7 +490,10 @@ exports[`should render demo and match snapshot 1`] = `
       </div>
       <div class="van-cell van-field">
         <div class="van-cell__title van-field__label">
-          <label id="van-field-label">
+          <label
+            id="van-field-label"
+            data-allow-mismatch="attribute"
+          >
             Uploader
           </label>
         </div>
@@ -512,6 +548,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Picker
           </label>
@@ -526,6 +563,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select city"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -541,6 +579,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Datetime Picker
           </label>
@@ -555,6 +594,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select time"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -570,6 +610,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Area Picker
           </label>
@@ -584,6 +625,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select area"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -599,6 +641,7 @@ exports[`should render demo and match snapshot 1`] = `
           <label
             id="van-field-label"
             for="van-field-input"
+            data-allow-mismatch="attribute"
           >
             Calendar
           </label>
@@ -613,6 +656,7 @@ exports[`should render demo and match snapshot 1`] = `
               readonly
               placeholder="Select date"
               aria-labelledby="van-field-label"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>

--- a/packages/vant/src/form/test/__snapshots__/events.spec.tsx.snap
+++ b/packages/vant/src/form/test/__snapshots__/events.spec.tsx.snap
@@ -10,6 +10,7 @@ exports[`should emit failed event when validating failed 1`] = `
           id="van-field-input"
           name="A"
           class="van-field__control"
+          data-allow-mismatch="attribute"
         >
       </div>
       <div class="van-field__error-message">
@@ -25,6 +26,7 @@ exports[`should emit failed event when validating failed 1`] = `
           id="van-field-input"
           name="B"
           class="van-field__control"
+          data-allow-mismatch="attribute"
         >
       </div>
       <div class="van-field__error-message">

--- a/packages/vant/src/form/test/__snapshots__/props.spec.tsx.snap
+++ b/packages/vant/src/form/test/__snapshots__/props.spec.tsx.snap
@@ -7,6 +7,7 @@ exports[`should render colon when using colon prop 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Label:
       </label>
@@ -18,6 +19,7 @@ exports[`should render colon when using colon prop 1`] = `
           id="van-field-input"
           class="van-field__control"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -32,6 +34,7 @@ exports[`should render colon when using colon prop 1`] = `
           type="text"
           id="van-field-input"
           class="van-field__control"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -48,6 +51,7 @@ exports[`should render error-message-align prop correctly 1`] = `
           type="text"
           id="van-field-input"
           class="van-field__control"
+          data-allow-mismatch="attribute"
         >
       </div>
       <div class="van-field__error-message van-field__error-message--right">
@@ -67,6 +71,7 @@ exports[`should render input-align prop correctly 1`] = `
           type="text"
           id="van-field-input"
           class="van-field__control van-field__control--right"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -91,6 +96,7 @@ exports[`should render label-align prop correctly 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Label
       </label>
@@ -102,6 +108,7 @@ exports[`should render label-align prop correctly 1`] = `
           id="van-field-input"
           class="van-field__control"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -111,6 +118,7 @@ exports[`should render label-align prop correctly 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Label
       </label>
@@ -122,6 +130,7 @@ exports[`should render label-align prop correctly 1`] = `
           id="van-field-input"
           class="van-field__control"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -139,6 +148,7 @@ exports[`should render label-width prop correctly 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Label
       </label>
@@ -150,6 +160,7 @@ exports[`should render label-width prop correctly 1`] = `
           id="van-field-input"
           class="van-field__control"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -162,6 +173,7 @@ exports[`should render label-width prop correctly 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Label
       </label>
@@ -173,6 +185,7 @@ exports[`should render label-width prop correctly 1`] = `
           id="van-field-input"
           class="van-field__control"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -182,6 +195,7 @@ exports[`should render label-width prop correctly 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style="width: 10vw;"
       >
         Label
@@ -194,6 +208,7 @@ exports[`should render label-width prop correctly 1`] = `
           id="van-field-input"
           class="van-field__control"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>
@@ -211,6 +226,7 @@ exports[`should validate first field when using validate-first prop 1`] = `
           id="van-field-input"
           name="A"
           class="van-field__control"
+          data-allow-mismatch="attribute"
         >
       </div>
       <div class="van-field__error-message">
@@ -226,6 +242,7 @@ exports[`should validate first field when using validate-first prop 1`] = `
           id="van-field-input"
           name="B"
           class="van-field__control"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/icon/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/icon/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -32,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -41,6 +42,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -50,6 +52,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -59,6 +62,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="-1"
       aria-labelledby="van-tabs-3"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>

--- a/packages/vant/src/icon/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/icon/test/__snapshots__/demo.spec.ts.snap
@@ -18,6 +18,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="0"
               aria-selected="true"
               aria-controls="van-tab"
+              data-allow-mismatch="attribute"
             >
               <span class="van-tab__text van-tab__text--ellipsis">
                 Demo
@@ -30,6 +31,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-selected="false"
               aria-controls="van-tab"
+              data-allow-mismatch="attribute"
             >
               <span class="van-tab__text van-tab__text--ellipsis">
                 Basic
@@ -42,6 +44,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-selected="false"
               aria-controls="van-tab"
+              data-allow-mismatch="attribute"
             >
               <span class="van-tab__text van-tab__text--ellipsis">
                 Outline
@@ -54,6 +57,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-selected="false"
               aria-controls="van-tab"
+              data-allow-mismatch="attribute"
             >
               <span class="van-tab__text van-tab__text--ellipsis">
                 Filled
@@ -76,6 +80,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       <div>
@@ -165,6 +170,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -174,6 +180,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -183,6 +190,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel demo-icon-tab-panel"
       tabindex="-1"
       aria-labelledby="van-tabs-3"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>

--- a/packages/vant/src/index-bar/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/index-bar/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -22,6 +22,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -31,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>

--- a/packages/vant/src/index-bar/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/index-bar/test/__snapshots__/demo.spec.ts.snap
@@ -204,7 +204,7 @@ exports[`should render demo and match snapshot 1`] = `
             Y
           </span>
           <span
-            class="van-index-bar__index"
+            class="van-index-bar__index van-index-bar__index--active"
             data-index="Z"
           >
             Z
@@ -911,8 +911,8 @@ exports[`should render demo and match snapshot 1`] = `
           </div>
         </div>
         <div>
-          <div>
-            <div class="van-index-anchor">
+          <div style="height: 0px;">
+            <div class="van-index-anchor van-index-anchor--sticky van-hairline--bottom">
               Z
             </div>
           </div>

--- a/packages/vant/src/index-bar/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/index-bar/test/__snapshots__/demo.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Basic Usage
@@ -27,6 +28,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Custom Index List
@@ -46,6 +48,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       <div class="van-index-bar">
@@ -201,7 +204,7 @@ exports[`should render demo and match snapshot 1`] = `
             Y
           </span>
           <span
-            class="van-index-bar__index van-index-bar__index--active"
+            class="van-index-bar__index"
             data-index="Z"
           >
             Z
@@ -908,8 +911,8 @@ exports[`should render demo and match snapshot 1`] = `
           </div>
         </div>
         <div>
-          <div style="height: 0px;">
-            <div class="van-index-anchor van-index-anchor--sticky van-hairline--bottom">
+          <div>
+            <div class="van-index-anchor">
               Z
             </div>
           </div>
@@ -943,6 +946,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>

--- a/packages/vant/src/list/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/list/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -22,6 +22,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -31,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -40,6 +42,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>

--- a/packages/vant/src/list/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/list/test/__snapshots__/demo.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Basic Usage
@@ -27,6 +28,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Error Info
@@ -39,6 +41,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           PullRefresh
@@ -58,6 +61,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       <div
@@ -100,6 +104,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -109,6 +114,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>

--- a/packages/vant/src/number-keyboard/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/number-keyboard/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -137,6 +137,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         Bind Value
@@ -152,6 +153,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Click To Input"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/number-keyboard/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/number-keyboard/test/__snapshots__/demo.spec.ts.snap
@@ -89,6 +89,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Bind Value
       </label>
@@ -102,6 +103,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Click To Input"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/picker-group/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/picker-group/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -53,6 +53,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -590,6 +591,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -1528,6 +1530,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -2065,6 +2068,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -3003,6 +3007,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -3540,6 +3545,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -4106,6 +4112,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -4995,6 +5002,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -5946,6 +5954,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">
@@ -6483,6 +6492,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
             >
               <!--[-->
               <div class="van-tab__panel">

--- a/packages/vant/src/picker-group/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/picker-group/test/__snapshots__/demo.spec.ts.snap
@@ -34,6 +34,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="0"
             aria-selected="true"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Date
@@ -46,6 +47,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-selected="false"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Time
@@ -71,6 +73,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="0"
               aria-hidden="false"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -601,6 +604,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -1516,6 +1520,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="0"
             aria-selected="true"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Date
@@ -1528,6 +1533,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-selected="false"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Time
@@ -1553,6 +1559,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="0"
               aria-hidden="false"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -2083,6 +2090,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -2998,6 +3006,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="0"
             aria-selected="true"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Start Date
@@ -3010,6 +3019,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-selected="false"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               End Date
@@ -3035,6 +3045,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="0"
               aria-hidden="false"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -3565,6 +3576,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -4107,6 +4119,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="0"
             aria-selected="true"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Start Time
@@ -4119,6 +4132,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-selected="false"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               End Time
@@ -4144,6 +4158,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="0"
               aria-hidden="false"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -5027,6 +5042,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -5953,6 +5969,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="0"
             aria-selected="true"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Date
@@ -5965,6 +5982,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-selected="false"
             aria-controls="van-tab"
+            data-allow-mismatch="attribute"
           >
             <span class="van-tab__text">
               Time
@@ -5990,6 +6008,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="0"
               aria-hidden="false"
               aria-labelledby="van-tabs-0"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">
@@ -6520,6 +6539,7 @@ exports[`should render demo and match snapshot 1`] = `
               tabindex="-1"
               aria-hidden="true"
               aria-labelledby="van-tabs-1"
+              data-allow-mismatch="attribute"
               style="width: 100px;"
             >
               <div class="van-tab__panel">

--- a/packages/vant/src/picker/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/picker/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -115,6 +115,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         City
@@ -130,6 +131,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Choose City"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/picker/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/picker/test/__snapshots__/demo.spec.ts.snap
@@ -104,6 +104,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         City
       </label>
@@ -117,6 +118,7 @@ exports[`should render demo and match snapshot 1`] = `
           readonly
           placeholder="Choose City"
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/popover/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/popover/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -52,6 +52,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
         style
       >
         Placement
@@ -67,6 +68,7 @@ exports[`should render demo and match snapshot 1`] = `
           class="van-field__control"
           readonly
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/popover/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/popover/test/__snapshots__/demo.spec.ts.snap
@@ -37,6 +37,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         id="van-field-label"
         for="van-field-input"
+        data-allow-mismatch="attribute"
       >
         Placement
       </label>
@@ -50,6 +51,7 @@ exports[`should render demo and match snapshot 1`] = `
           class="van-field__control"
           readonly
           aria-labelledby="van-field-label"
+          data-allow-mismatch="attribute"
         >
       </div>
     </div>

--- a/packages/vant/src/pull-refresh/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/pull-refresh/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -22,6 +22,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -31,6 +32,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>
@@ -40,6 +42,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display:none;"
     >
     </div>

--- a/packages/vant/src/pull-refresh/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/pull-refresh/test/__snapshots__/demo.spec.ts.snap
@@ -15,6 +15,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Basic Usage
@@ -27,6 +28,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Success Tip
@@ -39,6 +41,7 @@ exports[`should render demo and match snapshot 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           Custom Tips
@@ -58,6 +61,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       <div class="van-pull-refresh">
@@ -79,6 +83,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -88,6 +93,7 @@ exports[`should render demo and match snapshot 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>

--- a/packages/vant/src/search/Search.tsx
+++ b/packages/vant/src/search/Search.tsx
@@ -76,7 +76,11 @@ export default defineComponent({
     const renderLabel = () => {
       if (slots.label || props.label) {
         return (
-          <label class={bem('label')} for={getInputId()}>
+          <label
+            class={bem('label')}
+            for={getInputId()}
+            data-allow-mismatch="attribute"
+          >
             {slots.label ? slots.label() : props.label}
           </label>
         );

--- a/packages/vant/src/search/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/search/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -27,6 +27,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -60,6 +61,7 @@ exports[`should render demo and match snapshot 1`] = `
                 id="van-search-input"
                 class="van-field__control"
                 placeholder="Placeholder"
+                data-allow-mismatch="attribute"
               >
             </div>
           </div>
@@ -100,6 +102,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control van-field__control--center"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -133,6 +136,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               disabled
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -165,6 +169,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -182,6 +187,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         class="van-search__label"
         for="van-search-input"
+        data-allow-mismatch="attribute"
       >
         Address
       </label>
@@ -203,6 +209,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>

--- a/packages/vant/src/search/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/search/test/__snapshots__/demo.spec.ts.snap
@@ -16,6 +16,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -39,6 +40,7 @@ exports[`should render demo and match snapshot 1`] = `
                 id="van-search-input"
                 class="van-field__control"
                 placeholder="Placeholder"
+                data-allow-mismatch="attribute"
               >
             </div>
           </div>
@@ -69,6 +71,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control van-field__control--center"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -92,6 +95,7 @@ exports[`should render demo and match snapshot 1`] = `
               class="van-field__control"
               disabled
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -117,6 +121,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>
@@ -130,6 +135,7 @@ exports[`should render demo and match snapshot 1`] = `
       <label
         class="van-search__label"
         for="van-search-input"
+        data-allow-mismatch="attribute"
       >
         Address
       </label>
@@ -145,6 +151,7 @@ exports[`should render demo and match snapshot 1`] = `
               id="van-search-input"
               class="van-field__control"
               placeholder="Placeholder"
+              data-allow-mismatch="attribute"
             >
           </div>
         </div>

--- a/packages/vant/src/search/test/__snapshots__/index.spec.ts.snap
+++ b/packages/vant/src/search/test/__snapshots__/index.spec.ts.snap
@@ -10,7 +10,7 @@ exports[`should render action text when using action-text prop 1`] = `
 </div>
 `;
 
-exports[`should render label slot correctly 1`] = `"<label class="van-search__label" for="van-search-input">Custom Label</label>"`;
+exports[`should render label slot correctly 1`] = `"<label class="van-search__label" for="van-search-input" data-allow-mismatch="attribute">Custom Label</label>"`;
 
 exports[`should render left icon when using left-icon prop 1`] = `
 <div class="van-field__left-icon">
@@ -34,6 +34,7 @@ exports[`should render left slot correctly 1`] = `
             type="search"
             id="van-search-input"
             class="van-field__control"
+            data-allow-mismatch="attribute"
           >
         </div>
       </div>

--- a/packages/vant/src/tab/Tab.tsx
+++ b/packages/vant/src/tab/Tab.tsx
@@ -180,6 +180,7 @@ export default defineComponent({
             tabindex={active.value ? 0 : -1}
             aria-hidden={!active.value}
             aria-labelledby={label}
+            data-allow-mismatch="attribute"
           >
             <div class={bem('panel')}>{slots.default?.()}</div>
           </SwipeItem>
@@ -197,6 +198,7 @@ export default defineComponent({
           class={bem('panel')}
           tabindex={show ? 0 : -1}
           aria-labelledby={label}
+          data-allow-mismatch="attribute"
         >
           {Content}
         </div>

--- a/packages/vant/src/tab/TabTitle.tsx
+++ b/packages/vant/src/tab/TabTitle.tsx
@@ -95,6 +95,7 @@ export const TabTitle = defineComponent({
         aria-selected={props.isActive}
         aria-disabled={props.disabled || undefined}
         aria-controls={props.controls}
+        data-allow-mismatch="attribute"
       >
         {renderText()}
       </div>

--- a/packages/vant/src/tab/test/__snapshots__/demo-ssr.spec.ts.snap
+++ b/packages/vant/src/tab/test/__snapshots__/demo-ssr.spec.ts.snap
@@ -26,6 +26,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -35,6 +36,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -44,6 +46,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -53,6 +56,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -82,6 +86,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -91,6 +96,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -100,6 +106,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -130,6 +137,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -139,6 +147,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -148,6 +157,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -157,6 +167,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -166,6 +177,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-4"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -175,6 +187,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-5"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -184,6 +197,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-6"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -193,6 +207,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-7"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -223,6 +238,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -232,6 +248,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -241,6 +258,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -271,6 +289,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -280,6 +299,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -289,6 +309,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -319,6 +340,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -328,6 +350,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -368,6 +391,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -377,6 +401,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -386,6 +411,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -395,6 +421,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -425,6 +452,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -434,6 +462,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -443,6 +472,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -452,6 +482,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -482,6 +513,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -491,6 +523,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -500,6 +533,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -509,6 +543,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -539,6 +574,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -548,6 +584,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -586,6 +623,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-0"
+            data-allow-mismatch="attribute"
           >
           </div>
           <div
@@ -596,6 +634,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-1"
+            data-allow-mismatch="attribute"
           >
           </div>
           <div
@@ -606,6 +645,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-2"
+            data-allow-mismatch="attribute"
           >
           </div>
           <div
@@ -616,6 +656,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-3"
+            data-allow-mismatch="attribute"
           >
           </div>
         </div>
@@ -655,6 +696,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-0"
+            data-allow-mismatch="attribute"
           >
           </div>
           <div
@@ -665,6 +707,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-1"
+            data-allow-mismatch="attribute"
           >
           </div>
           <div
@@ -675,6 +718,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-2"
+            data-allow-mismatch="attribute"
           >
           </div>
           <div
@@ -685,6 +729,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-3"
+            data-allow-mismatch="attribute"
           >
           </div>
         </div>
@@ -726,6 +771,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 1
@@ -736,6 +782,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 2
@@ -746,6 +793,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 3
@@ -756,6 +804,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 4
@@ -766,6 +815,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-4"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 5
@@ -776,6 +826,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-5"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 6
@@ -786,6 +837,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-6"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 7
@@ -796,6 +848,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-7"
+        data-allow-mismatch="attribute"
       >
         <!--[-->
         content of tab 8
@@ -827,6 +880,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -836,6 +890,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -845,6 +900,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>
@@ -854,6 +910,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display:none;"
       >
       </div>

--- a/packages/vant/src/tab/test/__snapshots__/demo.spec.ts.snap
+++ b/packages/vant/src/tab/test/__snapshots__/demo.spec.ts.snap
@@ -16,6 +16,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -28,6 +29,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -40,6 +42,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 3
@@ -52,6 +55,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 4
@@ -71,6 +75,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -81,6 +86,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -90,6 +96,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -99,6 +106,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -120,6 +128,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -132,6 +141,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -144,6 +154,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 3
@@ -163,6 +174,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -172,6 +184,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 2
@@ -182,6 +195,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -203,6 +217,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 1
@@ -215,6 +230,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 2
@@ -227,6 +243,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 3
@@ -239,6 +256,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 4
@@ -251,6 +269,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 5
@@ -263,6 +282,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 6
@@ -275,6 +295,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 7
@@ -287,6 +308,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 8
@@ -306,6 +328,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -316,6 +339,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -325,6 +349,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -334,6 +359,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -343,6 +369,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-4"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -352,6 +379,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-5"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -361,6 +389,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-6"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -370,6 +399,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-7"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -391,6 +421,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -403,6 +434,7 @@ exports[`should render demo and match snapshot 1`] = `
           aria-selected="false"
           aria-disabled="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -415,6 +447,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 3
@@ -434,6 +467,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -444,6 +478,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -453,6 +488,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -474,6 +510,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -486,6 +523,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -498,6 +536,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 3
@@ -512,6 +551,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -522,6 +562,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -531,6 +572,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -552,6 +594,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -564,6 +607,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -583,6 +627,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -593,6 +638,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -617,6 +663,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="0"
                 aria-selected="true"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text van-tab__text--ellipsis">
                   Tab 1
@@ -629,6 +676,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text van-tab__text--ellipsis">
                   Tab 2
@@ -641,6 +689,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text van-tab__text--ellipsis">
                   Tab 3
@@ -653,6 +702,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text van-tab__text--ellipsis">
                   Tab 4
@@ -675,6 +725,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -685,6 +736,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -694,6 +746,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -703,6 +756,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -724,6 +778,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 1
@@ -736,6 +791,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 2
@@ -748,6 +804,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 3
@@ -760,6 +817,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 4
@@ -779,6 +837,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -789,6 +848,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -798,6 +858,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -807,6 +868,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -826,6 +888,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 1
@@ -838,6 +901,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 2
@@ -850,6 +914,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 3
@@ -862,6 +927,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text">
             Tab 4
@@ -876,6 +942,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -886,6 +953,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -895,6 +963,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -904,6 +973,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -925,6 +995,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             <i class="van-badge__wrapper van-icon van-icon-more-o">
@@ -939,6 +1010,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             <i class="van-badge__wrapper van-icon van-icon-more-o">
@@ -960,6 +1032,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -970,6 +1043,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -991,6 +1065,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -1003,6 +1078,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -1015,6 +1091,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 3
@@ -1027,6 +1104,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 4
@@ -1052,6 +1130,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="0"
             aria-hidden="false"
             aria-labelledby="van-tabs-0"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
             <div class="van-tab__panel">
@@ -1065,6 +1144,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-1"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
             <div class="van-tab__panel">
@@ -1078,6 +1158,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-2"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
           </div>
@@ -1088,6 +1169,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-3"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
           </div>
@@ -1111,6 +1193,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -1123,6 +1206,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -1135,6 +1219,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 3
@@ -1147,6 +1232,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 4
@@ -1172,6 +1258,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="0"
             aria-hidden="false"
             aria-labelledby="van-tabs-0"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
             <div class="van-tab__panel">
@@ -1185,6 +1272,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-1"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
             <div class="van-tab__panel">
@@ -1198,6 +1286,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-2"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
           </div>
@@ -1208,6 +1297,7 @@ exports[`should render demo and match snapshot 1`] = `
             tabindex="-1"
             aria-hidden="true"
             aria-labelledby="van-tabs-3"
+            data-allow-mismatch="attribute"
             style="width: 100px;"
           >
           </div>
@@ -1234,6 +1324,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="0"
                 aria-selected="true"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 1
@@ -1246,6 +1337,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 2
@@ -1258,6 +1350,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 3
@@ -1270,6 +1363,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 4
@@ -1282,6 +1376,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 5
@@ -1294,6 +1389,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 6
@@ -1306,6 +1402,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 7
@@ -1318,6 +1415,7 @@ exports[`should render demo and match snapshot 1`] = `
                 tabindex="-1"
                 aria-selected="false"
                 aria-controls="van-tab"
+                data-allow-mismatch="attribute"
               >
                 <span class="van-tab__text">
                   Tab 8
@@ -1340,6 +1438,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
       >
         content of tab 1
       </div>
@@ -1349,6 +1448,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
       >
         content of tab 2
       </div>
@@ -1358,6 +1458,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
       >
         content of tab 3
       </div>
@@ -1367,6 +1468,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
       >
         content of tab 4
       </div>
@@ -1376,6 +1478,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-4"
+        data-allow-mismatch="attribute"
       >
         content of tab 5
       </div>
@@ -1385,6 +1488,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-5"
+        data-allow-mismatch="attribute"
       >
         content of tab 6
       </div>
@@ -1394,6 +1498,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-6"
+        data-allow-mismatch="attribute"
       >
         content of tab 7
       </div>
@@ -1403,6 +1508,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-7"
+        data-allow-mismatch="attribute"
       >
         content of tab 8
       </div>
@@ -1424,6 +1530,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="0"
           aria-selected="true"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 1
@@ -1436,6 +1543,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 2
@@ -1448,6 +1556,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 3
@@ -1460,6 +1569,7 @@ exports[`should render demo and match snapshot 1`] = `
           tabindex="-1"
           aria-selected="false"
           aria-controls="van-tab"
+          data-allow-mismatch="attribute"
         >
           <span class="van-tab__text van-tab__text--ellipsis">
             Tab 4
@@ -1479,6 +1589,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-0"
+        data-allow-mismatch="attribute"
         style
       >
         content of tab 1
@@ -1489,6 +1600,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -1498,6 +1610,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-2"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>
@@ -1507,6 +1620,7 @@ exports[`should render demo and match snapshot 1`] = `
         class="van-tab__panel"
         tabindex="-1"
         aria-labelledby="van-tabs-3"
+        data-allow-mismatch="attribute"
         style="display: none;"
       >
       </div>

--- a/packages/vant/src/tab/test/__snapshots__/index.spec.tsx.snap
+++ b/packages/vant/src/tab/test/__snapshots__/index.spec.tsx.snap
@@ -8,6 +8,7 @@ exports[`should allow to disable lazy-render prop 1`] = `
     class="van-tab__panel"
     tabindex="-1"
     aria-labelledby="van-tabs-0"
+    data-allow-mismatch="attribute"
     style="display: none;"
   >
   </div>
@@ -17,6 +18,7 @@ exports[`should allow to disable lazy-render prop 1`] = `
     class="van-tab__panel"
     tabindex="-1"
     aria-labelledby="van-tabs-1"
+    data-allow-mismatch="attribute"
     style="display: none;"
   >
   </div>
@@ -31,6 +33,7 @@ exports[`should allow to disable lazy-render prop 2`] = `
     class="van-tab__panel"
     tabindex="0"
     aria-labelledby="van-tabs-0"
+    data-allow-mismatch="attribute"
     style
   >
     Text
@@ -41,6 +44,7 @@ exports[`should allow to disable lazy-render prop 2`] = `
     class="van-tab__panel"
     tabindex="-1"
     aria-labelledby="van-tabs-1"
+    data-allow-mismatch="attribute"
     style="display: none;"
   >
     Text
@@ -63,6 +67,7 @@ exports[`should allow to set name prop 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title1
@@ -75,6 +80,7 @@ exports[`should allow to set name prop 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title2
@@ -87,6 +93,7 @@ exports[`should allow to set name prop 1`] = `
         aria-selected="false"
         aria-disabled="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title3
@@ -106,6 +113,7 @@ exports[`should allow to set name prop 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       Text
@@ -116,6 +124,7 @@ exports[`should allow to set name prop 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -125,6 +134,7 @@ exports[`should allow to set name prop 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -139,6 +149,7 @@ exports[`should emit rendered event after tab is rendered 1`] = `
   class="van-tab__panel"
   tabindex="0"
   aria-labelledby="van-tabs-0"
+  data-allow-mismatch="attribute"
   style
 >
   Text
@@ -158,6 +169,7 @@ exports[`should render badge prop correctly 1`] = `
   tabindex="0"
   aria-selected="true"
   aria-controls="van-tab"
+  data-allow-mismatch="attribute"
 >
   <div class="van-badge__wrapper">
     <span class="van-tab__text van-tab__text--ellipsis">
@@ -184,6 +196,7 @@ exports[`should render nav-left、nav-right slot correctly 1`] = `
       tabindex="0"
       aria-selected="true"
       aria-controls="van-tab"
+      data-allow-mismatch="attribute"
     >
       <span class="van-tab__text van-tab__text--ellipsis">
         Title
@@ -214,6 +227,7 @@ exports[`should switch tab after click the tab title 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title1
@@ -226,6 +240,7 @@ exports[`should switch tab after click the tab title 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title2
@@ -238,6 +253,7 @@ exports[`should switch tab after click the tab title 1`] = `
         aria-selected="false"
         aria-disabled="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title3
@@ -257,6 +273,7 @@ exports[`should switch tab after click the tab title 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style
     >
       Text
@@ -267,6 +284,7 @@ exports[`should switch tab after click the tab title 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -276,6 +294,7 @@ exports[`should switch tab after click the tab title 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -298,6 +317,7 @@ exports[`should switch tab after click the tab title 2`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title1
@@ -310,6 +330,7 @@ exports[`should switch tab after click the tab title 2`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title2
@@ -322,6 +343,7 @@ exports[`should switch tab after click the tab title 2`] = `
         aria-selected="false"
         aria-disabled="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title3
@@ -341,6 +363,7 @@ exports[`should switch tab after click the tab title 2`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
       Text
@@ -351,6 +374,7 @@ exports[`should switch tab after click the tab title 2`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style
     >
       Text
@@ -361,6 +385,7 @@ exports[`should switch tab after click the tab title 2`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -383,6 +408,7 @@ exports[`swipe switch tab after swiping tab content 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title1
@@ -395,6 +421,7 @@ exports[`swipe switch tab after swiping tab content 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title2
@@ -407,6 +434,7 @@ exports[`swipe switch tab after swiping tab content 1`] = `
         aria-selected="false"
         aria-disabled="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title3
@@ -432,6 +460,7 @@ exports[`swipe switch tab after swiping tab content 1`] = `
           tabindex="0"
           aria-hidden="false"
           aria-labelledby="van-tabs-0"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">
@@ -445,6 +474,7 @@ exports[`swipe switch tab after swiping tab content 1`] = `
           tabindex="-1"
           aria-hidden="true"
           aria-labelledby="van-tabs-1"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">
@@ -458,6 +488,7 @@ exports[`swipe switch tab after swiping tab content 1`] = `
           tabindex="-1"
           aria-hidden="true"
           aria-labelledby="van-tabs-2"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
         </div>
@@ -482,6 +513,7 @@ exports[`swipe switch tab after swiping tab content 2`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title1
@@ -494,6 +526,7 @@ exports[`swipe switch tab after swiping tab content 2`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title2
@@ -506,6 +539,7 @@ exports[`swipe switch tab after swiping tab content 2`] = `
         aria-selected="false"
         aria-disabled="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title3
@@ -531,6 +565,7 @@ exports[`swipe switch tab after swiping tab content 2`] = `
           tabindex="-1"
           aria-hidden="true"
           aria-labelledby="van-tabs-0"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">
@@ -544,6 +579,7 @@ exports[`swipe switch tab after swiping tab content 2`] = `
           tabindex="0"
           aria-hidden="false"
           aria-labelledby="van-tabs-1"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">
@@ -557,6 +593,7 @@ exports[`swipe switch tab after swiping tab content 2`] = `
           tabindex="-1"
           aria-hidden="true"
           aria-labelledby="van-tabs-2"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">
@@ -584,6 +621,7 @@ exports[`swipe switch tab after swiping tab content 3`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title1
@@ -596,6 +634,7 @@ exports[`swipe switch tab after swiping tab content 3`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title2
@@ -608,6 +647,7 @@ exports[`swipe switch tab after swiping tab content 3`] = `
         aria-selected="false"
         aria-disabled="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           title3
@@ -633,6 +673,7 @@ exports[`swipe switch tab after swiping tab content 3`] = `
           tabindex="-1"
           aria-hidden="true"
           aria-labelledby="van-tabs-0"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">
@@ -646,6 +687,7 @@ exports[`swipe switch tab after swiping tab content 3`] = `
           tabindex="0"
           aria-hidden="false"
           aria-labelledby="van-tabs-1"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">
@@ -659,6 +701,7 @@ exports[`swipe switch tab after swiping tab content 3`] = `
           tabindex="-1"
           aria-hidden="true"
           aria-labelledby="van-tabs-2"
+          data-allow-mismatch="attribute"
           style="width: 100px;"
         >
           <div class="van-tab__panel">

--- a/packages/vant/src/tab/test/__snapshots__/insert.spec.tsx.snap
+++ b/packages/vant/src/tab/test/__snapshots__/insert.spec.tsx.snap
@@ -15,6 +15,7 @@ exports[`should render Tab inside a component correctly 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           1
@@ -27,6 +28,7 @@ exports[`should render Tab inside a component correctly 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           2
@@ -39,6 +41,7 @@ exports[`should render Tab inside a component correctly 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           3
@@ -58,6 +61,7 @@ exports[`should render Tab inside a component correctly 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -67,6 +71,7 @@ exports[`should render Tab inside a component correctly 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style
     >
       2
@@ -77,6 +82,7 @@ exports[`should render Tab inside a component correctly 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -99,6 +105,7 @@ exports[`should render correctly after inserting a tab 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           1
@@ -111,6 +118,7 @@ exports[`should render correctly after inserting a tab 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           2
@@ -123,6 +131,7 @@ exports[`should render correctly after inserting a tab 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           3
@@ -142,6 +151,7 @@ exports[`should render correctly after inserting a tab 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
     </div>
@@ -152,6 +162,7 @@ exports[`should render correctly after inserting a tab 1`] = `
         class="van-tab__panel"
         tabindex="0"
         aria-labelledby="van-tabs-1"
+        data-allow-mismatch="attribute"
       >
         2
       </div>
@@ -162,6 +173,7 @@ exports[`should render correctly after inserting a tab 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-2"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
       3
@@ -185,6 +197,7 @@ exports[`should render correctly after inserting a tab from an array 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           1
@@ -197,6 +210,7 @@ exports[`should render correctly after inserting a tab from an array 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           2
@@ -209,6 +223,7 @@ exports[`should render correctly after inserting a tab from an array 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           3
@@ -241,6 +256,7 @@ exports[`should render correctly after inserting a tab with name 1`] = `
         tabindex="-1"
         aria-selected="false"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           bar
@@ -253,6 +269,7 @@ exports[`should render correctly after inserting a tab with name 1`] = `
         tabindex="0"
         aria-selected="true"
         aria-controls="van-tab"
+        data-allow-mismatch="attribute"
       >
         <span class="van-tab__text van-tab__text--ellipsis">
           foo
@@ -272,6 +289,7 @@ exports[`should render correctly after inserting a tab with name 1`] = `
       class="van-tab__panel"
       tabindex="-1"
       aria-labelledby="van-tabs-0"
+      data-allow-mismatch="attribute"
       style="display: none;"
     >
       bar
@@ -282,6 +300,7 @@ exports[`should render correctly after inserting a tab with name 1`] = `
       class="van-tab__panel"
       tabindex="0"
       aria-labelledby="van-tabs-1"
+      data-allow-mismatch="attribute"
       style
     >
       foo


### PR DESCRIPTION
https://github.com/youzan/vant/pull/12719#issuecomment-2351408940

Note that this PR only ignores the warnings. we will thoroughly fix the issue when the time is right.