### PR TITLE
docs(components):  add FAQ for showToast on-demand loading

### DIFF
--- a/packages/vant/src/toast/README.md
+++ b/packages/vant/src/toast/README.md
@@ -339,7 +339,7 @@ The component provides the following CSS variables, which can be used to customi
 
 ## FAQ
 
-### Compilation Error When Referencing showToast?
+### Compilation error when referencing showToast?
 
 If you encounter the following error when referencing the `showToast` method, it indicates that the project is using the `babel-plugin-import` plugin, which causes incorrect compilation.
 
@@ -354,9 +354,9 @@ Starting from version 4.0, Vant no longer supports the `babel-plugin-import` plu
 
 ### Style Issues When Using showToast with On-Demand Component Import?
 
-When integrating `vant` using the [on-demand component import](https://vant.pro/vant/#/en-US/quickstart#import-on-demand) method, using functions like `showToast` does not require explicit import. Doing so can cause style issues.
+When integrating Vant using the [on-demand component import](#/en-US/quickstart#import-on-demand) method, using functions like `showToast` does not require explicit import. Doing so can cause style issues.
 
-```
+```js
 // The following import is not needed
 import { showToast } from 'vant'
 ```
@@ -364,10 +364,11 @@ import { showToast } from 'vant'
 This is because when you explicitly import functions like `showToast`, `@vant/auto-import-resolver` will not automatically import the style resources for Toast, leading to missing styles and resulting in style issues.
 
 There are two solutions:
+
 - Do not explicitly import `showToast` when using it.
 - If you must explicitly import `showToast`, you also need to manually import the related styles for the `Toast` component.
 
-```
+```js
 import { showToast } from 'vant'
 import 'vant/lib/toast/style'
 ```

--- a/packages/vant/src/toast/README.zh-CN.md
+++ b/packages/vant/src/toast/README.zh-CN.md
@@ -371,21 +371,21 @@ Vant 从 4.0 版本开始不再支持 `babel-plugin-import` 插件，请参考 [
 
 ### 按需引入组件时，使用 showToast 时出现样式异常问题？
 
-在使用[按需引入组件](https://vant.pro/vant/#/zh-CN/quickstart#fang-fa-er.-an-xu-yin-ru-zu-jian-yang-shi)方案集成 `vant` 时，使用 showToast 等函数无需进行显式导入，否则会造成样式异常。
+在使用[按需引入组件](#/zh-CN/quickstart#fang-fa-er.-an-xu-yin-ru-zu-jian-yang-shi)方案集成 Vant 时，使用 showToast 等函数无需进行显式导入，否则会造成样式异常。
 
-```
+```js
 // 以下方式是不需要的
 import { showToast } from 'vant'
 ```
 
-这是因为在显式导入 showToast 等函数时，` @vant/auto-import-resolver` 将不会自动导入 Toast 的样式资源，这将导致 Toast 组件
-的样式缺失，从而导致样式异常问题。
+这是因为在显式导入 showToast 等函数时，` @vant/auto-import-resolver` 将不会自动导入 Toast 的样式资源，这将导致 Toast 组件的样式缺失，从而导致样式异常问题。
 
-解决方案有2种：
+解决方案有 2 种：
+
 - 使用 `showToast` 时不进行显式导入；
 - 如果必须显示导入 `showToast` ，则同时需要手动导入 `Toast` 组件的相关样式。
 
-```
+```js
 import { showToast } from 'vant'
 import 'vant/lib/toast/style'
 ```


### PR DESCRIPTION
#13109 

### 按需引入组件时，使用 showToast 时出现样式异常问题？

在使用[按需引入组件](https://vant.pro/vant/#/zh-CN/quickstart#fang-fa-er.-an-xu-yin-ru-zu-jian-yang-shi)方案集成 `vant` 时，使用 showToast 等函数无需进行显式导入，否则会造成样式异常。

```
// 以下方式是不需要的
import { showToast } from 'vant'
```

这是因为在显式导入 showToast 等函数时，` @vant/auto-import-resolver` 将不会自动导入 Toast 的样式资源，这将导致 Toast 组件
的样式缺失，从而导致样式异常问题。

解决方案有2种：
- 使用 `showToast` 时不进行显式导入；
- 如果必须显示导入 `showToast` ，则同时需要手动导入 `Toast` 组件的相关样式。

```
import { showToast } from 'vant'
import 'vant/lib/toast/style'
```