### PR TITLE
feat(dialog): add new `keyboardEnabled` prop

### DIFF
--- a/packages/vant/src/dialog/Dialog.tsx
+++ b/packages/vant/src/dialog/Dialog.tsx
@@ -62,6 +62,7 @@ export const dialogProps = extend({}, popupSharedProps, {
   confirmButtonDisabled: Boolean,
   showConfirmButton: truthProp,
   closeOnClickOverlay: Boolean,
+  keyboardEnabled: truthProp,
 });
 
 export type DialogProps = ExtractPropTypes<typeof dialogProps>;
@@ -122,6 +123,10 @@ export default defineComponent({
     const onConfirm = getActionHandler('confirm');
     const onKeydown = withKeys(
       (event: KeyboardEvent) => {
+        // disable keyboard events when loading
+        if (!props.keyboardEnabled) {
+          return;
+        }
         // skip keyboard events of child elements
         if (event.target !== root.value?.popupRef?.value) {
           return;

--- a/packages/vant/src/dialog/Dialog.tsx
+++ b/packages/vant/src/dialog/Dialog.tsx
@@ -123,7 +123,6 @@ export default defineComponent({
     const onConfirm = getActionHandler('confirm');
     const onKeydown = withKeys(
       (event: KeyboardEvent) => {
-        // disable keyboard events when loading
         if (!props.keyboardEnabled) {
           return;
         }

--- a/packages/vant/src/dialog/README.md
+++ b/packages/vant/src/dialog/README.md
@@ -182,6 +182,7 @@ Vant exports following Dialog utility functions:
 | beforeClose | Callback function before close | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | Transition, equivalent to `name` prop of [transition](https://vuejs.org/api/built-in-components.html#transition) | _string_ | - |
 | teleport | Specifies a target element where Dialog will be mounted | _string \| Element_ | `body` |
+| keyboardEnabled | Whether or not the keyboard capability is used, the `Enter` and `Esc` keys by default execute the confirm and cancel functions when the `confirm` and `cancel` buttons are displayed | _boolean_ | `true` |
 
 ### Props
 
@@ -213,6 +214,7 @@ Vant exports following Dialog utility functions:
 | before-close | Callback function before close | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | Transition, equivalent to `name` prop of [transition](https://vuejs.org/api/built-in-components.html#transition) | _string_ | - |
 | teleport | Specifies a target element where Dialog will be mounted | _string \| Element_ | - |
+| keyboard-enabled | Whether or not the keyboard capability is used, the `Enter` and `Esc` keys by default execute the confirm and cancel functions when the `confirm` and `cancel` buttons are displayed | _boolean_ | `true` |
 
 ### Events
 

--- a/packages/vant/src/dialog/README.md
+++ b/packages/vant/src/dialog/README.md
@@ -182,7 +182,7 @@ Vant exports following Dialog utility functions:
 | beforeClose | Callback function before close | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | Transition, equivalent to `name` prop of [transition](https://vuejs.org/api/built-in-components.html#transition) | _string_ | - |
 | teleport | Specifies a target element where Dialog will be mounted | _string \| Element_ | `body` |
-| keyboardEnabled | Whether or not the keyboard capability is used, the `Enter` and `Esc` keys by default execute the confirm and cancel functions when the `confirm` and `cancel` buttons are displayed | _boolean_ | `true` |
+| keyboardEnabled | Whether to enable keyboard capabilities. When displaying the confirm and cancel buttons, the keyboard's `Enter` and `Esc` will call the `confirm` and `cancel` functions by default | _boolean_ | `true` |
 
 ### Props
 
@@ -214,7 +214,7 @@ Vant exports following Dialog utility functions:
 | before-close | Callback function before close | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | Transition, equivalent to `name` prop of [transition](https://vuejs.org/api/built-in-components.html#transition) | _string_ | - |
 | teleport | Specifies a target element where Dialog will be mounted | _string \| Element_ | - |
-| keyboard-enabled | Whether or not the keyboard capability is used, the `Enter` and `Esc` keys by default execute the confirm and cancel functions when the `confirm` and `cancel` buttons are displayed | _boolean_ | `true` |
+| keyboard-enabled | Whether to enable keyboard capabilities. When displaying the confirm and cancel buttons, the keyboard's `Enter` and `Esc` will call the `confirm` and `cancel` functions by default | _boolean_ | `true` |
 
 ### Events
 

--- a/packages/vant/src/dialog/README.zh-CN.md
+++ b/packages/vant/src/dialog/README.zh-CN.md
@@ -182,7 +182,7 @@ Vant 中导出了以下 Dialog 相关的辅助函数：
 | beforeClose | 关闭前的回调函数，返回 `false` 可阻止关闭，支持返回 Promise | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | 动画类名，等价于 [transition](https://cn.vuejs.org/api/built-in-components.html#transition) 的 `name` 属性 | _string_ | - |
 | teleport | 指定挂载的节点，等同于 Teleport 组件的 [to 属性](https://cn.vuejs.org/api/built-in-components.html#teleport) | _string \| Element_ | `body` |
-| keyboardEnabled | 是否使用键盘能力，在展示确认按钮和取消按钮的时候默认情况下键盘的 `Enter` 和 `Esc` 会执行 `confirm` 和 `cancel` 函数 | _boolean_ | `true` |
+| keyboardEnabled | 是否启用键盘能力，在展示确认和取消按钮的时候，默认情况下键盘的 `Enter` 和 `Esc` 会执行 `confirm` 和 `cancel` 函数 | _boolean_ | `true` |
 
 ### Props
 

--- a/packages/vant/src/dialog/README.zh-CN.md
+++ b/packages/vant/src/dialog/README.zh-CN.md
@@ -216,7 +216,7 @@ Vant 中导出了以下 Dialog 相关的辅助函数：
 | before-close | 关闭前的回调函数，返回 `false` 可阻止关闭，支持返回 Promise | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | 动画类名，等价于 [transition](https://cn.vuejs.org/api/built-in-components.html#transition) 的 `name` 属性 | _string_ | - |
 | teleport | 指定挂载的节点，等同于 Teleport 组件的 [to 属性](https://cn.vuejs.org/api/built-in-components.html#teleport) | _string \| Element_ | - |
-| keyboard-enabled | 是否使用键盘能力，在展示确认按钮和取消按钮的时候默认情况下键盘的`Enter`和`Esc`会执行confirm和cancel函数 | _boolean_ | `true` |
+| keyboard-enabled | 是否启用键盘能力，在展示确认和取消按钮的时候，默认情况下键盘的 `Enter` 和 `Esc` 会执行 `confirm` 和 `cancel` 函数 | _boolean_ | `true` |
 
 ### Events
 

--- a/packages/vant/src/dialog/README.zh-CN.md
+++ b/packages/vant/src/dialog/README.zh-CN.md
@@ -182,6 +182,7 @@ Vant 中导出了以下 Dialog 相关的辅助函数：
 | beforeClose | 关闭前的回调函数，返回 `false` 可阻止关闭，支持返回 Promise | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | 动画类名，等价于 [transition](https://cn.vuejs.org/api/built-in-components.html#transition) 的 `name` 属性 | _string_ | - |
 | teleport | 指定挂载的节点，等同于 Teleport 组件的 [to 属性](https://cn.vuejs.org/api/built-in-components.html#teleport) | _string \| Element_ | `body` |
+| keyboardEnabled | 是否使用键盘能力，在展示确认按钮和取消按钮的时候默认情况下键盘的`Enter`和`Esc`会执行`confirm`和`cancel`函数 | _boolean_ | `true` |
 
 ### Props
 
@@ -215,6 +216,7 @@ Vant 中导出了以下 Dialog 相关的辅助函数：
 | before-close | 关闭前的回调函数，返回 `false` 可阻止关闭，支持返回 Promise | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | 动画类名，等价于 [transition](https://cn.vuejs.org/api/built-in-components.html#transition) 的 `name` 属性 | _string_ | - |
 | teleport | 指定挂载的节点，等同于 Teleport 组件的 [to 属性](https://cn.vuejs.org/api/built-in-components.html#teleport) | _string \| Element_ | - |
+| keyboard-enabled | 是否使用键盘能力，在展示确认按钮和取消按钮的时候默认情况下键盘的`Enter`和`Esc`会执行confirm和cancel函数 | _boolean_ | `true` |
 
 ### Events
 

--- a/packages/vant/src/dialog/README.zh-CN.md
+++ b/packages/vant/src/dialog/README.zh-CN.md
@@ -182,7 +182,7 @@ Vant 中导出了以下 Dialog 相关的辅助函数：
 | beforeClose | 关闭前的回调函数，返回 `false` 可阻止关闭，支持返回 Promise | _(action: string) => boolean \| Promise\<boolean\>_ | - |
 | transition | 动画类名，等价于 [transition](https://cn.vuejs.org/api/built-in-components.html#transition) 的 `name` 属性 | _string_ | - |
 | teleport | 指定挂载的节点，等同于 Teleport 组件的 [to 属性](https://cn.vuejs.org/api/built-in-components.html#teleport) | _string \| Element_ | `body` |
-| keyboardEnabled | 是否使用键盘能力，在展示确认按钮和取消按钮的时候默认情况下键盘的`Enter`和`Esc`会执行`confirm`和`cancel`函数 | _boolean_ | `true` |
+| keyboardEnabled | 是否使用键盘能力，在展示确认按钮和取消按钮的时候默认情况下键盘的 `Enter` 和 `Esc` 会执行 `confirm` 和 `cancel` 函数 | _boolean_ | `true` |
 
 ### Props
 


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-ui.github.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。

https://github.com/youzan/vant/issues/13164

针对issue #13164 提到的部分手机场景的某些操作会自动执行enter的键盘事件，新增keyboardEnabled属性来控制是否选择使用键盘能力选项
