### PR TITLE
docs(ConfigProvider): fix incorrect theme classnames

### DIFF
--- a/packages/vant/src/config-provider/demo/index.vue
+++ b/packages/vant/src/config-provider/demo/index.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref } from 'vue';
+import { ref, onActivated } from 'vue';
 import VanCell from '../../cell';
 import VanForm from '../../form';
 import VanField from '../../field';
@@ -44,6 +44,17 @@ const themeVars = {
   buttonPrimaryBackground: '#07c160',
   buttonPrimaryBorderColor: '#07c160',
 };
+// fix https://github.com/youzan/vant/issues/13179
+const removeUselessStyle = () => {
+  const element = document.documentElement;
+  if (
+    element.classList.contains('van-theme-dark') &&
+    element.classList.contains('van-theme-light')
+  ) {
+    element.classList.remove('van-theme-light');
+  }
+};
+onActivated(removeUselessStyle);
 </script>
 
 <template>


### PR DESCRIPTION
… switching causes the theme styles to stack up in the document.

Before submitting a pull request, please read the [contributing guide](https://vant-ui.github.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。

解决https://github.com/youzan/vant/issues/13179 

这个bug存在于文档ConfigProvider全局配置的demo中，并且只有暗色主题存在这个问题，看了下源码，发现应该是在顶部切换主题的时候会默认执行增删van-theme-dark 和van-theme-light逻辑，而ConfigProvider全局配置内部引入了ConfigProvider在加载时会默认添加van-theme-light，应该算是文档的一个小bug，修复逻辑是暂时在ConfigProvider全局配置的示例文件中，如果同时存在这两种主题的话将van-theme-light属性删除，不会影响其他