### PR TITLE
docs: fix placement typo

### DIFF
--- a/packages/vant/src/popover/README.md
+++ b/packages/vant/src/popover/README.md
@@ -248,7 +248,7 @@ You can use Popover as a controlled or uncontrolled component:
 - When `v-model:show` is not used, Popover is an uncontrolled component. You can pass in a default value through the `show` prop, and the display is controlled by the component itself.
 
 ```html
-<van-popover :actions="actions" position="top-start" @select="onSelect">
+<van-popover :actions="actions" placement="top-start" @select="onSelect">
   <template #reference>
     <van-button type="primary">Uncontrolled</van-button>
   </template>

--- a/packages/vant/src/popover/README.zh-CN.md
+++ b/packages/vant/src/popover/README.zh-CN.md
@@ -258,7 +258,7 @@ export default {
 - 当未绑定 `v-model:show` 时，Popover 为非受控组件，此时你可以通过 `show` 属性传入一个默认值，组件值的显示由组件自身控制。
 
 ```html
-<van-popover :actions="actions" position="top-start" @select="onSelect">
+<van-popover :actions="actions" placement="top-start" @select="onSelect">
   <template #reference>
     <van-button type="primary">非受控模式</van-button>
   </template>


### PR DESCRIPTION
fix the typo:
popover support placement not position