### PR TITLE
fix(Field): should not modify the value if it's within the min/max

### DIFF
--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -346,7 +346,9 @@ export default defineComponent({
             props.min ?? -Infinity,
             props.max ?? Infinity,
           );
-          value = adjustedValue.toString();
+          if (+value !== adjustedValue) {
+            value = adjustedValue.toString();
+          }
         }
       }
 


### PR DESCRIPTION
在 type 为 number 或 digit 时，如果没有设置 min 或 max，onblur 时值 1.00 不会有变化，但当设置了 min 或 max 时，onblur  会触发非必要的格式化，导致值 1.00 变成 1。