### PR TITLE
chore: fix missing `@types/node` dependency

### DIFF
--- a/packages/create-vant-cli-app/package.json
+++ b/packages/create-vant-cli-app/package.json
@@ -2,44 +2,45 @@
   "name": "create-vant-cli-app",
   "version": "3.0.0",
   "description": "Create Vant CLI App",
-  "main": "lib/index.js",
-  "bin": {
-    "create-vant-cli-app": "./lib/index.js"
-  },
-  "scripts": {
-    "dev": "tsc --watch",
-    "build": "rimraf ./lib && tsc",
-    "release": "vant-cli release",
-    "prepare": "pnpm build"
-  },
-  "files": [
-    "lib",
-    "generators"
-  ],
   "keywords": [
     "vant"
   ],
-  "publishConfig": {
-    "registry": "https://registry.npmjs.org/"
-  },
+  "bugs": "https://github.com/vant-ui/vant/issues",
   "repository": {
     "type": "git",
     "url": "https://github.com/vant-ui/vant.git",
     "directory": "packages/create-vant-cli-app"
   },
-  "bugs": "https://github.com/vant-ui/vant/issues",
-  "author": "chenjiahan",
   "license": "MIT",
+  "author": "chenjiahan",
+  "main": "lib/index.js",
+  "bin": {
+    "create-vant-cli-app": "./lib/index.js"
+  },
+  "files": [
+    "lib",
+    "generators"
+  ],
+  "scripts": {
+    "build": "rimraf ./lib && tsc",
+    "dev": "tsc --watch",
+    "prepare": "pnpm build",
+    "release": "vant-cli release"
+  },
+  "dependencies": {
+    "enquirer": "2.4.1",
+    "fast-glob": "^3.3.3",
+    "fs-extra": "^11.2.0",
+    "picocolors": "^1.1.1",
+    "rslog": "^1.2.3"
+  },
   "devDependencies": {
     "@types/fs-extra": "^11.0.4",
+    "@types/node": "^22.10.5",
     "rimraf": "^6.0.1",
     "typescript": "^5.7.3"
   },
-  "dependencies": {
-    "rslog": "^1.2.3",
-    "fast-glob": "^3.3.3",
-    "fs-extra": "^11.2.0",
-    "enquirer": "2.4.1",
-    "picocolors": "^1.1.1"
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/packages/vant-cli/package.json
+++ b/packages/vant-cli/package.json
@@ -1,20 +1,22 @@
 {
   "name": "@vant/cli",
   "version": "7.1.0",
+  "keywords": [
+    "vant"
+  ],
+  "bugs": "https://github.com/vant-ui/vant/issues",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/vant-ui/vant.git",
+    "directory": "packages/vant-cli"
+  },
+  "license": "MIT",
+  "author": "chenjiahan",
   "type": "module",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "bin": {
     "vant-cli": "./bin.js"
-  },
-  "engines": {
-    "node": ">=16.0.0"
-  },
-  "scripts": {
-    "dev": "tsc --watch",
-    "build": "rimraf ./lib && tsc",
-    "release": "rm -rf ./site/node_modules && vant-cli release",
-    "prepare": "pnpm build"
   },
   "files": [
     "lib",
@@ -22,28 +24,11 @@
     "site",
     "bin.js"
   ],
-  "keywords": [
-    "vant"
-  ],
-  "publishConfig": {
-    "access": "public",
-    "registry": "https://registry.npmjs.org/"
-  },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/vant-ui/vant.git",
-    "directory": "packages/vant-cli"
-  },
-  "bugs": "https://github.com/vant-ui/vant/issues",
-  "author": "chenjiahan",
-  "license": "MIT",
-  "devDependencies": {
-    "@types/fs-extra": "^11.0.4",
-    "@types/less": "^3.0.7",
-    "@types/lodash": "^4.17.14",
-    "@types/markdown-it": "^14.1.2",
-    "rimraf": "^6.0.1",
-    "vue": "^3.5.13"
+  "scripts": {
+    "build": "rimraf ./lib && tsc",
+    "dev": "tsc --watch",
+    "prepare": "pnpm build",
+    "release": "rm -rf ./site/node_modules && vant-cli release"
   },
   "dependencies": {
     "@babel/core": "^7.26.0",
@@ -61,10 +46,9 @@
     "@vue/babel-plugin-jsx": "^1.2.5",
     "autoprefixer": "^10.4.20",
     "commander": "^13.0.0",
-    "rslog": "^1.2.3",
+    "enquirer": "2.4.1",
     "esbuild": "^0.24.2",
     "eslint": "^8.57.1",
-    "enquirer": "2.4.1",
     "fast-glob": "^3.3.3",
     "fs-extra": "^11.2.0",
     "hash-sum": "^2.0.0",
@@ -79,11 +63,28 @@
     "postcss": "^8.4.49",
     "postcss-load-config": "^6.0.1",
     "prettier": "^3.4.2",
+    "rslog": "^1.2.3",
     "rspack-plugin-virtual-module": "^0.1.13",
     "terser": "^5.37.0",
     "transliteration": "^2.3.5",
     "typescript": "^5.7.3",
     "vite": "^5.4.11",
     "vue-router": "^4.5.0"
+  },
+  "devDependencies": {
+    "@types/fs-extra": "^11.0.4",
+    "@types/less": "^3.0.7",
+    "@types/lodash": "^4.17.14",
+    "@types/markdown-it": "^14.1.2",
+    "@types/node": "^22.10.5",
+    "rimraf": "^6.0.1",
+    "vue": "^3.5.13"
+  },
+  "engines": {
+    "node": ">=16.0.0"
+  },
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@types/fs-extra':
         specifier: ^11.0.4
         version: 11.0.4
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.10.5
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -275,6 +278,9 @@ importers:
       '@types/markdown-it':
         specifier: ^14.1.2
         version: 14.1.2
+      '@types/node':
+        specifier: ^22.10.5
+        version: 22.10.5
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -1240,9 +1246,6 @@ packages:
 
   '@types/mdurl@2.0.0':
     resolution: {integrity: sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==}
-
-  '@types/node@18.19.34':
-    resolution: {integrity: sha512-eXF4pfBNV5DAMKGbI02NnDtWrQ40hAN558/2vvS4gMpMIxaf6JmD7YjnZbq0Q9TDSSkKBamime8ewRoomHdt4g==}
 
   '@types/node@22.10.5':
     resolution: {integrity: sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==}
@@ -2935,9 +2938,6 @@ packages:
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
-  undici-types@5.26.5:
-    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
-
   undici-types@6.20.0:
     resolution: {integrity: sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==}
 
@@ -3966,7 +3966,7 @@ snapshots:
   '@types/fs-extra@11.0.4':
     dependencies:
       '@types/jsonfile': 6.1.4
-      '@types/node': 18.19.34
+      '@types/node': 22.10.5
 
   '@types/json-schema@7.0.15': {}
 
@@ -3986,10 +3986,6 @@ snapshots:
       '@types/mdurl': 2.0.0
 
   '@types/mdurl@2.0.0': {}
-
-  '@types/node@18.19.34':
-    dependencies:
-      undici-types: 5.26.5
 
   '@types/node@22.10.5':
     dependencies:
@@ -5776,8 +5772,6 @@ snapshots:
   typescript@5.7.3: {}
 
   uc.micro@2.1.0: {}
-
-  undici-types@5.26.5: {}
 
   undici-types@6.20.0: {}
 


### PR DESCRIPTION
Fix missing `@types/node` dependency:

<img width="1129" alt="Screenshot 2025-01-18 at 17 58 00" src="https://github.com/user-attachments/assets/b8c44d11-9459-4830-9366-6a0a5d9c617d" />
