### PR TITLE
feat(@vant/auto-import-resolver): Support exclude in components or apis

### DIFF
--- a/packages/vant-auto-import-resolver/README.md
+++ b/packages/vant-auto-import-resolver/README.md
@@ -196,3 +196,31 @@ Components({
 - **Default:** `undefined`
 
 This option is deprecated. Please use the `module` option to set the module type.
+
+### exclude
+
+Set the components or APIs that do not require automatic import.
+
+- **Type:** `string[]`
+- **Default:** `[]`
+- **Example:**
+
+```ts
+Components({
+  resolvers: [
+    VantResolver({
+      exclude: ['Button'],
+    }),
+  ],
+});
+```
+
+```ts
+AutoImport({
+  resolvers: [
+    VantResolver({
+      exclude: ['showToast'],
+    }),
+  ],
+});
+```

--- a/packages/vant-auto-import-resolver/README.zh-CN.md
+++ b/packages/vant-auto-import-resolver/README.zh-CN.md
@@ -196,3 +196,31 @@ Components({
 - **Default：** `undefined`
 
 此选项已废弃，请使用 `module` 选项来设置模块类型。
+
+### exclude
+
+设置不自动引入的组件或 API。
+
+- **Type：** `string[]`
+- **Default：** `[]`
+- **Example：**
+
+```ts
+Components({
+  resolvers: [
+    VantResolver({
+      exclude: ['Button'],
+    }),
+  ],
+});
+```
+
+```ts
+AutoImport({
+  resolvers: [
+    VantResolver({
+      exclude: ['showToast'],
+    }),
+  ],
+});
+```

--- a/packages/vant-auto-import-resolver/src/index.ts
+++ b/packages/vant-auto-import-resolver/src/index.ts
@@ -21,6 +21,13 @@ export interface VantResolverOptions {
    * @deprecated Please use `module` option instead.
    */
   ssr?: boolean;
+
+  /**
+   * exclude components or API that do not require automatic import
+   *
+   * @default []
+   */
+  exclude?: string[];
 }
 
 export type VantImportsOptions = Pick<VantResolverOptions, 'module' | 'ssr'>;
@@ -107,21 +114,23 @@ export function VantResolver(options: VantResolverOptions = {}) {
     resolve: (name: string) => {
       if (name.startsWith('Van')) {
         const partialName = name.slice(3);
-        return {
-          name: partialName,
-          from: `vant/${moduleType}`,
-          sideEffects: getSideEffects(kebabCase(partialName), options),
-        };
+        if (!options.exclude?.includes(partialName)) {
+          return {
+            name: partialName,
+            from: `vant/${moduleType}`,
+            sideEffects: getSideEffects(kebabCase(partialName), options)
+          };
+        }
       }
 
       // import API
-      if (apiMap.has(name)) {
+      if (apiMap.has(name) && !options.exclude?.includes(name)) {
         const partialName = apiMap.get(name)!;
-        return {
-          name,
-          from: `vant/${moduleType}`,
-          sideEffects: getSideEffects(kebabCase(partialName), options),
-        };
+          return {
+            name,
+            from: `vant/${moduleType}`,
+            sideEffects: getSideEffects(kebabCase(partialName), options),
+          };
       }
     },
   };


### PR DESCRIPTION
添加 @vant/auto-import-resolver 支持 exclude，主要用于二次封装组件或者 api 的场景，不对其原组件或 api 自动引入，而是使用二次封装好的同名组件或者同名 api