### PR TITLE
fix(Picker): should reset subsequent columns when a column is changed

### DIFF
--- a/packages/vant/src/picker/Picker.tsx
+++ b/packages/vant/src/picker/Picker.tsx
@@ -159,7 +159,10 @@ export default defineComponent({
         // reset values after cascading
         selectedValues.value.forEach((value, index) => {
           const options = currentColumns.value[index];
-          if (!isOptionExist(options, value, fields.value)) {
+          if (
+            index > columnIndex ||
+            !isOptionExist(options, value, fields.value)
+          ) {
             setValue(
               index,
               options.length ? options[0][fields.value.value] : undefined,

--- a/packages/vant/src/picker/test/cascade.spec.ts
+++ b/packages/vant/src/picker/test/cascade.spec.ts
@@ -130,3 +130,58 @@ test('should move to first option when all options are disabled', () => {
 
   expect(wrapper.html()).toMatchSnapshot();
 });
+
+// https://github.com/youzan/vant/issues/13365
+test('should reset subsequent columns when a column is changed', async () => {
+  const wrapper = mount(Picker, {
+    props: {
+      columns: [
+        {
+          text: 'A1',
+          value: 'A1',
+          children: [
+            {
+              text: 'B1',
+              value: 'B1',
+            },
+            {
+              text: 'B2',
+              value: 'B2',
+            },
+          ],
+        },
+        {
+          text: 'A2',
+          value: 'A2',
+          children: [
+            {
+              text: 'B2',
+              value: 'B2',
+            },
+            {
+              text: 'B1',
+              value: 'B1',
+            },
+          ],
+        },
+      ],
+    },
+  });
+
+  await wrapper.find('.van-picker__confirm').trigger('click');
+  expect(
+    wrapper.emitted<[PickerConfirmEventParams]>('confirm')![0][0]
+      .selectedValues,
+  ).toEqual(['A1', 'B1']);
+
+  await wrapper
+    .findAll('.van-picker-column')[0]
+    .findAll('.van-picker-column__item')[1]
+    .trigger('click');
+
+  await wrapper.find('.van-picker__confirm').trigger('click');
+  expect(
+    wrapper.emitted<[PickerConfirmEventParams]>('confirm')![1][0]
+      .selectedValues,
+  ).toEqual(['A2', 'B2']);
+});


### PR DESCRIPTION
… is changed somehow

fixes: #13365

add a new property for resetChildren 
```js

```


Before submitting a pull request, please read the [contributing guide](https://vant-ui.github.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。
