### PR TITLE
fix(Button): fix button active style

### DIFF
--- a/packages/vant/src/button/index.less
+++ b/packages/vant/src/button/index.less
@@ -69,6 +69,7 @@
     transform: translate(-50%, -50%);
     opacity: 0;
     content: ' ';
+    box-sizing: content-box;
   }
 
   &:active::before {


### PR DESCRIPTION
在进行业务开始时，通常会事先配置一些全局的 CSS 样式，比如：

```css
*,
*::before,
*::after {
  box-sizing: border-box;
}
```

而当上面这段 CSS 作用于 Vant Button 按钮的 ::before 伪元素时将导致该伪元素的宽高比 Button 按钮的宽高小 `border * 2`。Vant Button 的 border 宽度默认是 1px，那么默认就会小 1 * 2 = 2px。

这在一些特殊的样式下，比如业务上将 border 修改为 2px 时，两者差距就 2 * 2 = 4px，肉眼就非常明显了。

如下为 Vant 官网对比图：

![image](https://github.com/user-attachments/assets/5567f139-e37f-48fe-982c-44c0de3c8df8)
![image](https://github.com/user-attachments/assets/89e838f5-b76f-40dc-9993-d201d3f7a7dc)

该 PR 的解决办法就是强制对该伪元素使用 `box-sizing: content-box;`
