### PR TITLE
docs(Overlay): fix the misleading overlay example

### DIFF
--- a/packages/vant/src/overlay/README.md
+++ b/packages/vant/src/overlay/README.md
@@ -38,6 +38,8 @@ export default {
 
 ### Embedded Content
 
+Any content can be embedded on the overlay through the default slot.
+
 ```html
 <van-overlay :show="show" @click="show = false">
   <div class="wrapper">

--- a/packages/vant/src/overlay/README.md
+++ b/packages/vant/src/overlay/README.md
@@ -40,8 +40,8 @@ export default {
 
 ```html
 <van-overlay :show="show" @click="show = false">
-  <div class="wrapper" @click.stop>
-    <div class="block" />
+  <div class="wrapper">
+    <div class="block" @click.stop />
   </div>
 </van-overlay>
 

--- a/packages/vant/src/overlay/README.zh-CN.md
+++ b/packages/vant/src/overlay/README.zh-CN.md
@@ -42,8 +42,8 @@ export default {
 
 ```html
 <van-overlay :show="show" @click="show = false">
-  <div class="wrapper" @click.stop>
-    <div class="block" />
+  <div class="wrapper">
+    <div class="block" @click.stop />
   </div>
 </van-overlay>
 

--- a/packages/vant/src/overlay/demo/index.vue
+++ b/packages/vant/src/overlay/demo/index.vue
@@ -42,7 +42,7 @@ const showZIndex = ref(false);
     />
     <van-overlay :show="showEmbedded" @click="showEmbedded = false">
       <div class="wrapper">
-        <div class="block" />
+        <div class="block" @click.stop />
       </div>
     </van-overlay>
   </demo-block>


### PR DESCRIPTION
使该示例正确表达：**点击嵌入内容不会关闭遮罩层，点击空白区域可以**