### PR TITLE
fix(Picker): update selected values when modelValue is cleared

### DIFF
--- a/packages/vant/src/picker/Picker.tsx
+++ b/packages/vant/src/picker/Picker.tsx
@@ -147,9 +147,7 @@ export default defineComponent({
     };
 
     const getEventParams = () => ({
-      selectedValues: selectedValues.value.length
-        ? selectedValues.value.slice(0)
-        : resetSelectedValues(currentColumns.value),
+      selectedValues: selectedValues.value.slice(0),
       selectedOptions: selectedOptions.value,
       selectedIndexes: selectedIndexes.value,
     });
@@ -299,9 +297,14 @@ export default defineComponent({
           selectedValues.value = newValues.slice(0);
           lastEmittedModelValue = newValues.slice(0);
         }
+
+        if (props.modelValue.length === 0) {
+          resetSelectedValues(currentColumns.value);
+        }
       },
       { deep: true },
     );
+
     watch(
       selectedValues,
       (newValues) => {

--- a/packages/vant/src/picker/test/index.spec.tsx
+++ b/packages/vant/src/picker/test/index.spec.tsx
@@ -490,6 +490,7 @@ test('should emit correct values when clicking confirm button during column scro
   ]);
 });
 
+// https://github.com/youzan/vant/issues/13423
 test('should emit default values when clear modelValue', async () => {
   const columns = [
     { text: '1', value: '1' },


### PR DESCRIPTION
This is an improvement on https://github.com/youzan/vant/pull/13425, which automatically resets `selectedValues` ​​when Picker's `modelValue` prop is set to an empty array, which is more appropriate than waiting for an event to trigger.

