### PR TITLE
docs: correct window.innerWidth to window.innerHeight in FloatingPanel

### DIFF
--- a/packages/vant/src/floating-panel/README.md
+++ b/packages/vant/src/floating-panel/README.md
@@ -85,7 +85,7 @@ By default, both the header and content areas of FloatingPanel can be dragged, b
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
 | v-model:height | The current display height of the panel | _number \| string_ | `0` |
-| anchors | Setting custom anchors, unit `px` | _number[]_ | `[100, window.innerWidth * 0.6]` |
+| anchors | Setting custom anchors, unit `px` | _number[]_ | `[100, window.innerHeight * 0.6]` |
 | duration | Transition duration, unit second | _number \| string_ | `0.3` |
 | content-draggable | Allow dragging content | _boolean_ | `true` |
 | lock-scroll `v4.6.4` | When not dragging, Whether to lock background scroll | _boolean_ | `false` |

--- a/packages/vant/src/floating-panel/README.zh-CN.md
+++ b/packages/vant/src/floating-panel/README.zh-CN.md
@@ -85,7 +85,7 @@ export default {
 | 参数 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | --- |
 | v-model:height | 当前面板的显示高度 | _number \| string_ | `0` |
-| anchors | 设置自定义锚点, 单位 `px` | _number[]_ | `[100, window.innerWidth * 0.6]` |
+| anchors | 设置自定义锚点, 单位 `px` | _number[]_ | `[100, window.innerHeight * 0.6]` |
 | duration | 动画时长，单位秒，设置为 0 可以禁用动画 | _number \| string_ | `0.3` |
 | content-draggable | 允许拖拽内容容器 | _boolean_ | `true` |
 | lock-scroll `v4.6.4` | 当不拖拽时，是否锁定背景滚动 | _boolean_ | `false` |


### PR DESCRIPTION
## 问题描述
修复了 FloatingPanel 组件文档中的错误，将 `window.innerWidth * 0.6` 错误地用于计算面板高度改为正确的 `window.innerHeight * 0.6`。

## 修改内容
修改了以下文件中的默认值描述：
- `packages/vant/src/floating-panel/README.md`（英文文档）
- `packages/vant/src/floating-panel/README.zh-CN.md`（中文文档）

## 影响范围
- 仅修改了文档中的描述，不影响组件的实际功能
- 不影响已有的代码实现，因为实际代码中已经正确使用了 `window.innerHeight`