### PR TITLE
fix(Watermark): ensure watermark updates on imageBase64 change

### DIFF
--- a/packages/vant/src/watermark/Watermark.tsx
+++ b/packages/vant/src/watermark/Watermark.tsx
@@ -1,5 +1,6 @@
 import {
   defineComponent,
+  nextTick,
   onMounted,
   onUnmounted,
   ref,
@@ -158,7 +159,6 @@ export default defineComponent({
 
     watch(
       () => [
-        imageBase64.value,
         props.content,
         props.textColor,
         props.height,
@@ -169,6 +169,10 @@ export default defineComponent({
       ],
       generateWatermarkUrl,
     );
+
+    watch(imageBase64, () => {
+      nextTick(generateWatermarkUrl);
+    });
 
     onMounted(generateWatermarkUrl);
 


### PR DESCRIPTION
fix #13468
When using watermark with image, need to wait for image to mount before generating the watermark URL.