### PR TITLE
docs(button): add android compatibility tip

### DIFF
--- a/packages/vant/src/button/README.md
+++ b/packages/vant/src/button/README.md
@@ -111,6 +111,20 @@ By default, the button is an inline-block element. Use the `block` prop to chang
 <van-button type="primary" block>Block Element</van-button>
 ```
 
+> **Compatibility Tip (for Android devices):** On certain Android devices (especially running version 10.0 and below), using `style="position: fixed; width: 100%"` directly on `<van-button>` may cause layout issues or unexpected rendering behavior due to differences in WebView rendering engines.
+>
+> **Recommended solution:** Instead of applying positioning styles directly to the button, wrap the `<van-button>` inside a container `<div>` to control layout more reliably:
+>
+> ```html
+> <div
+>   style="position: fixed; bottom: 0; left: 0; right: 0; padding: 12px; background: #fff; z-index: 999;"
+> >
+>   <van-button type="primary" block @click="onAdd">Add</van-button>
+> </div>
+> ```
+>
+> This approach ensures better layout compatibility across Android devices, especially in embedded WebViews used by hybrid apps or mini programs.
+
 ### Route
 
 You can use the `url` prop for URL redirection or the `to` prop for route navigation.

--- a/packages/vant/src/button/README.zh-CN.md
+++ b/packages/vant/src/button/README.zh-CN.md
@@ -111,6 +111,20 @@ app.use(Button);
 <van-button type="primary" block>块级元素</van-button>
 ```
 
+> **兼容性提示：** 在某些 Android 设备（尤其是系统版本 10.0 及以下）中，`van-button` 组件在设置 `style="position: fixed; width: 100%"` 后，可能会出现布局错位或样式不生效的问题。这通常与 WebView 内核渲染差异有关。
+>
+> **建议：** 为确保兼容性，建议使用以下方式进行布局控制：
+>
+> ```html
+> <div
+>   style="position: fixed; bottom: 0; left: 0; right: 0; padding: 12px; background: #fff; z-index: 999;"
+> >
+>   <van-button type="primary" block @click="onAdd">新增</van-button>
+> </div>
+> ```
+>
+> 同时建议避免直接在 `van-button` 组件上使用 `position: fixed`，而应将其包裹在 `div` 容器中实现定位，以获得更好的跨设备兼容性。
+
 ### 页面导航
 
 可以通过 `url` 属性进行 URL 跳转，或通过 `to` 属性进行路由跳转。


### PR DESCRIPTION
> ### ✨ What’s this PR about?
>
> This PR adds a **compatibility tip** to the Button documentation for better handling of layout issues on specific Android devices.
>
> ### 🔧 Context
>
> In some cases, when applying `position: fixed` and `width: 100%` directly to `<van-button>`, the button layout breaks or gets cropped in hybrid mobile environments (especially on Android 10.0 or below). This is often due to WebView rendering inconsistencies.
>
> ### ✅ Suggested Solution
>
> A `div` container with layout styles is recommended for consistent rendering. This is already used in many production mobile web projects.
>
> ### 💡 Why this matters
>
> Developers often face device-specific layout issues and having this tip in the documentation can help them resolve such issues faster without diving deep into debugging.