### PR TITLE
feat(image): add native `decoding` prop to Image component

### DIFF
--- a/packages/vant/src/image/Image.tsx
+++ b/packages/vant/src/image/Image.tsx
@@ -52,6 +52,7 @@ export const imageProps = {
   loadingIcon: makeStringProp('photo'),
   crossorigin: String as PropType<ImgHTMLAttributes['crossorigin']>,
   referrerpolicy: String as PropType<ImgHTMLAttributes['referrerpolicy']>,
+  decoding: makeStringProp<'auto' | 'sync' | 'async'>('sync') as PropType<ImgHTMLAttributes['decoding']>,
 };
 
 export type ImageProps = ExtractPropTypes<typeof imageProps>;
@@ -153,6 +154,7 @@ export default defineComponent({
       const attrs = {
         alt: props.alt,
         class: bem('img'),
+        decoding: props.decoding,
         style: {
           objectFit: props.fit,
           objectPosition: props.position,

--- a/packages/vant/src/image/Image.tsx
+++ b/packages/vant/src/image/Image.tsx
@@ -52,7 +52,7 @@ export const imageProps = {
   loadingIcon: makeStringProp('photo'),
   crossorigin: String as PropType<ImgHTMLAttributes['crossorigin']>,
   referrerpolicy: String as PropType<ImgHTMLAttributes['referrerpolicy']>,
-  decoding: makeStringProp<'auto' | 'sync' | 'async'>('sync') as PropType<ImgHTMLAttributes['decoding']>,
+  decoding: String as PropType<ImgHTMLAttributes['decoding']>,
 };
 
 export type ImageProps = ExtractPropTypes<typeof imageProps>;


### PR DESCRIPTION
**Pull Request: Add Native `decoding` Support to `<Image>` Component**

https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decoding

---

### 📦 What’s New

* Introduce a new `decoding` prop on the `Image` component, allowing consumers to specify browser-native image decoding mode (`"auto" | "sync" | "async"`).
* Default value remains `"auto"`, preserving existing behavior.

### 🛠️ Changes

* **Props Definition**

  * Added `decoding: makeStringProp<'auto' | 'sync' | 'async'>('auto') as PropType<ImgHTMLAttributes['decoding']>` to `imageProps`.

