### PR TITLE
docs(Uploader): optimize parameter description

### DIFF
--- a/packages/vant/src/uploader/README.md
+++ b/packages/vant/src/uploader/README.md
@@ -370,7 +370,14 @@ export default {
 | preview-delete | Custom delete icon | - |
 | preview-cover | Custom content that covers the image preview | _item: FileListItem_ |
 
-### Parameters of before-read、after-read、before-delete
+### Parameters of before-read、before-delete
+
+| Attribute | Description                          | Type     |
+| --------- | ------------------------------------ | -------- |
+| file      | File object                          | _object_ |
+| detail    | Detail info, contains name and index | _object_ |
+
+### Parameters of after-read
 
 | Attribute | Description | Type |
 | --- | --- | --- |

--- a/packages/vant/src/uploader/README.md
+++ b/packages/vant/src/uploader/README.md
@@ -372,10 +372,10 @@ export default {
 
 ### Parameters of before-read、after-read、before-delete
 
-| Attribute | Description                          | Type     |
-| --------- | ------------------------------------ | -------- |
-| file      | File object                          | _object_ |
-| detail    | Detail info, contains name and index | _object_ |
+| Attribute | Description | Type |
+| --- | --- | --- |
+| file | Contains File object | _UploaderFileListItem \| UploaderFileListItem[]_ |
+| detail | Detail info, contains name and index | _object_ |
 
 ### ResultType
 

--- a/packages/vant/src/uploader/README.zh-CN.md
+++ b/packages/vant/src/uploader/README.zh-CN.md
@@ -398,7 +398,7 @@ before-read、before-delete 执行时会传递以下回调参数：
 | file   | file 对象                         | _object_ |
 | detail | 额外信息，包含 name 和 index 字段 | _object_ |
 
-### 回调参数
+### after-read 回调参数
 
 after-read 执行时会传递以下回调参数：
 

--- a/packages/vant/src/uploader/README.zh-CN.md
+++ b/packages/vant/src/uploader/README.zh-CN.md
@@ -391,7 +391,16 @@ export default {
 
 ### 回调参数
 
-before-read、after-read、before-delete 执行时会传递以下回调参数：
+before-read、before-delete 执行时会传递以下回调参数：
+
+| 参数名 | 说明                              | 类型     |
+| ------ | --------------------------------- | -------- |
+| file   | file 对象                         | _object_ |
+| detail | 额外信息，包含 name 和 index 字段 | _object_ |
+
+### 回调参数
+
+after-read 执行时会传递以下回调参数：
 
 | 参数名 | 说明 | 类型 |
 | --- | --- | --- |

--- a/packages/vant/src/uploader/README.zh-CN.md
+++ b/packages/vant/src/uploader/README.zh-CN.md
@@ -393,9 +393,9 @@ export default {
 
 before-read、after-read、before-delete 执行时会传递以下回调参数：
 
-| 参数名 | 说明                              | 类型     |
-| ------ | --------------------------------- | -------- |
-| file   | file 对象                         | _object_ |
+| 参数名 | 说明 | 类型 |
+| --- | --- | --- |
+| file | 包含 file 对象 | _UploaderFileListItem \| UploaderFileListItem[]_ |
 | detail | 额外信息，包含 name 和 index 字段 | _object_ |
 
 ### ResultType 可选值


### PR DESCRIPTION
根据源码中类型文件得知以下回调参数：

```ts
export type UploaderAfterRead = (
  items: UploaderFileListItem | UploaderFileListItem[],
  detail: {
    name: Numeric;
    index: number;
  },
) => void;
```

所以将文档中相关的描述更改为：`UploaderFileListItem | UploaderFileListItem[]`