### PR TITLE
docs: fix typo in uploader document

### DIFF
--- a/packages/vant/src/uploader/README.md
+++ b/packages/vant/src/uploader/README.md
@@ -341,7 +341,7 @@ export default {
 | capture | Capture, can be set to `camera` | _string_ | - |
 | after-read | Hook after reading the file | _Function_ | - |
 | before-read | Hook before reading the file, return false to stop reading the file, can return Promise | _Function_ | - |
-| before-delete | Hook before delete the file, return false to stop reading the file, can return Promise | _Function_ | - |
+| before-delete | Hook before delete the file, return false to stop deleting the file, can return Promise | _Function_ | - |
 | max-size | Max size of file | _number \| string \| (file: File) => boolean_ | `Infinity` |
 | max-count | Max count of image | _number \| string_ | `Infinity` |
 | result-type | Type of file read result, can be set to `file` `text` | _string_ | `dataUrl` |

--- a/packages/vant/src/uploader/README.zh-CN.md
+++ b/packages/vant/src/uploader/README.zh-CN.md
@@ -360,7 +360,7 @@ export default {
 | capture | 图片选取模式，可选值为 `camera` (直接调起摄像头) | _string_ | - |
 | after-read | 文件读取完成后的回调函数 | _Function_ | - |
 | before-read | 文件读取前的回调函数，返回 `false` 可终止文件读取，<br>支持返回 `Promise` | _Function_ | - |
-| before-delete | 文件删除前的回调函数，返回 `false` 可终止文件删除，<br>支持返回 `Promise` | _Function_ | - |
+| before-delete | 文件删除前的回调函数，返回 `false` 可终止文件删除，支持返回 `Promise` | _Function_ | - |
 | max-size | 文件大小限制，单位为 `byte` | _number \| string \| (file: File) => boolean_ | `Infinity` |
 | max-count | 文件上传数量限制 | _number \| string_ | `Infinity` |
 | result-type | 文件读取结果类型，可选值为 `file` `text` | _string_ | `dataUrl` |

--- a/packages/vant/src/uploader/README.zh-CN.md
+++ b/packages/vant/src/uploader/README.zh-CN.md
@@ -360,7 +360,7 @@ export default {
 | capture | 图片选取模式，可选值为 `camera` (直接调起摄像头) | _string_ | - |
 | after-read | 文件读取完成后的回调函数 | _Function_ | - |
 | before-read | 文件读取前的回调函数，返回 `false` 可终止文件读取，<br>支持返回 `Promise` | _Function_ | - |
-| before-delete | 文件删除前的回调函数，返回 `false` 可终止文件读取，<br>支持返回 `Promise` | _Function_ | - |
+| before-delete | 文件删除前的回调函数，返回 `false` 可终止文件删除，<br>支持返回 `Promise` | _Function_ | - |
 | max-size | 文件大小限制，单位为 `byte` | _number \| string \| (file: File) => boolean_ | `Infinity` |
 | max-count | 文件上传数量限制 | _number \| string_ | `Infinity` |
 | result-type | 文件读取结果类型，可选值为 `file` `text` | _string_ | `dataUrl` |


### PR DESCRIPTION
This pull request includes a minor correction to the documentation for the `before-delete` hook in the `Uploader` component. The change clarifies that returning `false` stops the deletion of the file, rather than stopping the reading of the file.

Documentation updates:

* [`packages/vant/src/uploader/README.md`](diffhunk://#diff-f098d46c8075bbddb55679f2bfd61809501a8e0d7f9cb8934e2bbb3cb15c7949L344-R344): Corrected the description for the `before-delete` hook to specify that returning `false` stops file deletion.
* [`packages/vant/src/uploader/README.zh-CN.md`](diffhunk://#diff-b5381e9de9033005b887586dad66816e1dfc1bfda1f08617960918dee506f2f2L363-R363): Updated the Chinese documentation for the `before-delete` hook to clarify that returning `false` stops file deletion.