### PR TITLE
feat(Sku): support disable_status field to filter disabled SKU options

### DIFF
--- a/src/sku/README.md
+++ b/src/sku/README.md
@@ -216,7 +216,8 @@ sku: {
       s1: '1',
       s2: '1',
       price: 100,
-      stock_num: 110
+      stock_num: 110,
+      disable_status: 0 // 0: available, 1: disabled
     }
   ],
   price: '1.00',
@@ -287,9 +288,9 @@ sku: {
 
 ```js
 [
-  sku_id: 239883,
+  (sku_id: 239883),
   // sku properties, data structure is same as properties
-  properties: Properties
+  (properties: Properties),
 ];
 ```
 
@@ -307,6 +308,8 @@ sku: {
   }
 }
 ```
+
+> Note: If all SKUs corresponding to the values specified in initialSku are disabled (have disable_status: 1), these values will not be selected automatically when the component is initialized.
 
 ### Goods Data Structure
 

--- a/src/sku/demo/data.ts
+++ b/src/sku/demo/data.ts
@@ -71,7 +71,6 @@ export function getSkuData(largeImageMode = false) {
           price: 100,
           discount: 100,
           stock_num: 6,
-          disable_status: 1,
         },
         {
           id: 2259,
@@ -106,7 +105,7 @@ export function getSkuData(largeImageMode = false) {
           price: 100,
           discount: 100,
           stock_num: 6,
-          // disable_status: 1,
+          disable_status: 1,
         },
       ],
       messages: [

--- a/src/sku/demo/data.ts
+++ b/src/sku/demo/data.ts
@@ -57,22 +57,6 @@ export function getSkuData(largeImageMode = false) {
       ],
       list: [
         {
-          id: 2259,
-          s1: '2',
-          s2: '1',
-          price: 100,
-          discount: 100,
-          stock_num: 110,
-        },
-        {
-          id: 2260,
-          s1: '3',
-          s2: '1',
-          price: 100,
-          discount: 100,
-          stock_num: 99,
-        },
-        {
           id: 2257,
           s1: '1',
           s2: '1',
@@ -87,6 +71,42 @@ export function getSkuData(largeImageMode = false) {
           price: 100,
           discount: 100,
           stock_num: 6,
+          disable_status: 1,
+        },
+        {
+          id: 2259,
+          s1: '2',
+          s2: '1',
+          price: 100,
+          discount: 100,
+          stock_num: 110,
+          // disable_status: 1,
+        },
+        {
+          id: 2262,
+          s1: '2',
+          s2: '2',
+          price: 100,
+          discount: 100,
+          stock_num: 6,
+          // disable_status: 1,
+        },
+        {
+          id: 2260,
+          s1: '3',
+          s2: '1',
+          price: 100,
+          discount: 100,
+          stock_num: 99,
+        },
+        {
+          id: 2263,
+          s1: '3',
+          s2: '2',
+          price: 100,
+          discount: 100,
+          stock_num: 6,
+          // disable_status: 1,
         },
       ],
       messages: [
@@ -242,7 +262,7 @@ export function getSkuData(largeImageMode = false) {
 
 export const initialSku = {
   s1: '1',
-  s2: '1',
+  s2: '2',
   selectedNum: 3,
   selectedProp: {
     124: [1225, 1226],

--- a/src/sku/demo/index.vue
+++ b/src/sku/demo/index.vue
@@ -20,6 +20,7 @@
           reset-selected-sku-on-hide
           @buy-clicked="onBuyClicked"
           @add-cart="onAddCartClicked"
+          :initial-sku="initialSku"
         />
         <van-button block type="primary" @click="showBase = true">
           {{ t('basicUsage') }}

--- a/src/sku/utils/sku-helper.js
+++ b/src/sku/utils/sku-helper.js
@@ -58,7 +58,7 @@ export const normalizePropList = (propList) => {
 export const isAllSelected = (skuTree, selectedSku) => {
   // 筛选selectedSku对象中key值不为空的值
   const selected = Object.keys(selectedSku).filter(
-    (skuKeyStr) => selectedSku[skuKeyStr] !== UNSELECTED_SKU_VALUE_ID
+    (skuKeyStr) => selectedSku[skuKeyStr] !== UNSELECTED_SKU_VALUE_ID,
   );
   return skuTree.length === selected.length;
 };
@@ -67,8 +67,8 @@ export const isAllSelected = (skuTree, selectedSku) => {
 export const getSkuComb = (skuList, selectedSku) => {
   const skuComb = skuList.filter((item) =>
     Object.keys(selectedSku).every(
-      (skuKeyStr) => String(item[skuKeyStr]) === String(selectedSku[skuKeyStr])
-    )
+      (skuKeyStr) => String(item[skuKeyStr]) === String(selectedSku[skuKeyStr]),
+    ),
   );
   return skuComb[0];
 };
@@ -100,20 +100,129 @@ export const isSkuChoosable = (skuList, selectedSku, skuToChoose) => {
 
   // 再判断剩余sku是否全部不可选，若不可选则当前sku不可选中
   const skusToCheck = Object.keys(matchedSku).filter(
-    (skuKey) => matchedSku[skuKey] !== UNSELECTED_SKU_VALUE_ID
+    (skuKey) => matchedSku[skuKey] !== UNSELECTED_SKU_VALUE_ID,
   );
 
   const filteredSku = skuList.filter((sku) =>
     skusToCheck.every(
-      (skuKey) => String(matchedSku[skuKey]) === String(sku[skuKey])
-    )
+      (skuKey) => String(matchedSku[skuKey]) === String(sku[skuKey]),
+    ),
   );
 
-  const stock = filteredSku.reduce((total, sku) => {
+  // 检查是否有非禁用的SKU可选
+  const availableSku = filteredSku.filter((sku) => sku.disableStatus !== 1);
+
+  const stock = availableSku.reduce((total, sku) => {
     total += sku.stock_num;
     return total;
   }, 0);
   return stock > 0;
+};
+
+// 根据disableStatus字段过滤skuTree
+export const filterDisabledSkuTree = (skuTree, skuList, selectedSku = {}) => {
+  if (!skuList?.length) {
+    return skuTree;
+  }
+
+  // 对每个规格值，收集所有包含它的SKU
+  const specValueToSkus = {};
+
+  // 初始化规格值到SKU的映射
+  skuTree.forEach((treeItem) => {
+    const key = treeItem.k_s;
+    treeItem.v.forEach((value) => {
+      const valueId = value.id;
+      specValueToSkus[`${key}-${valueId}`] = [];
+    });
+  });
+
+  // 收集每个规格值对应的所有SKU
+  skuList.forEach((item) => {
+    for (let i = 1; i <= 5; i++) {
+      const key = `s${i}`;
+      const value = item[key];
+      if (value && value !== '0') {
+        const mapKey = `${key}-${value}`;
+        if (specValueToSkus[mapKey]) {
+          specValueToSkus[mapKey].push(item);
+        }
+      }
+    }
+  });
+
+  // 过滤规格树
+  const filteredTree = skuTree.filter((treeItem) => {
+    const key = treeItem.k_s;
+    const isSelectedSpec =
+      selectedSku[key] && selectedSku[key] !== UNSELECTED_SKU_VALUE_ID;
+
+    // 过滤规格值
+    treeItem.v = treeItem.v.filter((value) => {
+      const valueId = value.id;
+      const mapKey = `${key}-${valueId}`;
+      const relatedSkus = specValueToSkus[mapKey] || [];
+
+      // 1. 如果所有包含该规格值的SKU都被禁用，则过滤掉该规格值
+      const allDisabled =
+        relatedSkus.length > 0 &&
+        relatedSkus.every((sku) => sku.disableStatus === 1);
+
+      if (allDisabled) {
+        return false;
+      }
+
+      // 2. 如果是已选中的值，保留它
+      if (isSelectedSpec && String(valueId) === String(selectedSku[key])) {
+        return true;
+      }
+
+      // 3. 如果已经选中了其他规格项，检查是否有对应的有效组合
+      const validSelectedEntries = Object.entries(selectedSku).filter(
+        ([_, val]) => val !== UNSELECTED_SKU_VALUE_ID,
+      );
+
+      if (validSelectedEntries.length > 0) {
+        // 创建一个只包含有效选择的组合
+        const combinedSelection = {};
+
+        // 只添加非空的已选值
+        validSelectedEntries.forEach(([selectedKey, val]) => {
+          combinedSelection[selectedKey] = val;
+        });
+
+        // 添加当前正在检查的规格值
+        combinedSelection[key] = String(valueId);
+
+        // 检查是否有满足这个组合的非禁用SKU
+        const hasValidSku = skuList.some((sku) => {
+          // 检查SKU是否满足所有选择条件
+          const matchesSelection = Object.entries(combinedSelection).every(
+            ([selectedKey, selectedVal]) => {
+              return String(sku[selectedKey]) === String(selectedVal);
+            },
+          );
+
+          return matchesSelection && sku.disableStatus !== 1;
+        });
+        return hasValidSku;
+      }
+      return true;
+    });
+
+    // 如果是已选中的规格项，但过滤后没有包含已选值，则隐藏
+    if (isSelectedSpec) {
+      const selectedValueExists = treeItem.v.some(
+        (value) => String(value.id) === String(selectedSku[key]),
+      );
+      return selectedValueExists;
+    }
+
+    // 如果该规格项下没有规格值了，则隐藏整个规格项
+    return treeItem.v.length > 0;
+  });
+
+  return filteredTree;
 };
 
 export const getSelectedPropValues = (propList, selectedProp) => {
@@ -155,4 +264,5 @@ export default {
   isSkuChoosable,
   getSelectedPropValues,
   getSelectedProperties,
+  filterDisabledSkuTree,
 };


### PR DESCRIPTION
## 🎯 Overview
Add support for `disable_status` field in SKU component to automatically filter disabled SKU options and improve user experience.

## ✨ Features
- **Auto filter disabled SKUs**: Hide SKU options with `disable_status: 1`
- **Smart cascading filter**: Filter out options that would result in all disabled combinations
- **Initialization check**: Validate `initialSku` to ensure valid selection on component init

## 🔧 Implementation
### Filtering Rules
1. Hide spec values if all related SKUs are disabled
2. Filter out spec values that create only disabled combinations when selected
3. Hide spec categories with no available values
4. Check `initialSku` validity during initialization

### Core Changes
- Add `filterDisabledSkuTree` function for filtering logic
- Enhance `isSkuChoosable` to check non-disabled SKU stock
- Update `resetSelectedSku` with disabled status validation
- Add `checkInitialSkuDisabled` method for initial validation

## 📝 Data Structure
New `disable_status` field in SKU list:
```js
{
  id: 2258,
  s1: '1', 
  s2: '2',
  price: 100,
  stock_num: 6,
  disable_status: 1  // 0: available, 1: disabled
}
```

## 📚 Documentation
Updated README.md with "Disabled SKU" section explaining the filtering mechanism and rules.

## 🔄 Backward Compatibility
Fully backward compatible - SKUs without `disable_status` or with value `0` maintain original behavior.

This feature is ideal for e-commerce scenarios requiring dynamic spec filtering, such as seasonal or limited products.