### PR TITLE
fix(checkbox): apply 'checked-color' when 'checkbox' is indeterminate

### DIFF
--- a/packages/vant/src/checkbox/Checker.tsx
+++ b/packages/vant/src/checkbox/Checker.tsx
@@ -86,7 +86,11 @@ export default defineComponent({
     const iconStyle = computed(() => {
       const checkedColor = props.checkedColor || getParentProp('checkedColor');
 
-      if (checkedColor && props.checked && !disabled.value) {
+      if (
+        checkedColor &&
+        (props.checked || props.indeterminate) &&
+        !disabled.value
+      ) {
         return {
           borderColor: checkedColor,
           backgroundColor: checkedColor,


### PR DESCRIPTION
This PR is to fix #13552 

The selected state color and indeterminate state color of a group of checkboxes could be better if kept consistent, as this would create a more unified style

Set 'checked-color' to 'red',comparison of effects:

Before modification
<img width="144" height="85" alt="{9A76EC29-8476-4C7E-B6B3-5B916C320F62}" src="https://github.com/user-attachments/assets/ad540798-6198-477d-8350-22c0267d8121" />

After modification
<img width="145" height="89" alt="{B688C328-D739-47D7-B5D1-0FF7A86E8ABF}" src="https://github.com/user-attachments/assets/e9b5cd61-2752-43c2-9684-ff9dbd8cd10c" />

I didn't see any unit tests related to the color, so I didn't add the corresponding unit tests