### PR TITLE
fix(Field): set the value of the input field when the slot change causes an update

### DIFF
--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -5,6 +5,7 @@ import {
   computed,
   nextTick,
   reactive,
+  onUpdated,
   onMounted,
   defineComponent,
   type PropType,
@@ -685,6 +686,10 @@ export default defineComponent({
         nextTick(adjustTextareaSize);
       },
     );
+
+    onUpdated(() => {
+      updateValue(getModelValue());
+    });
 
     onMounted(() => {
       updateValue(getModelValue(), props.formatTrigger);


### PR DESCRIPTION
This PR is to fix #13492 

The bug is caused by the slot change leading to an update, but the input field value is not set.

I listen to the update caused by the slot change through **onUpdated** and call **updateValue** to set the input field value.

I’m sorry, I’m not sure how to write a unit test for this scenario.