### PR TITLE
docs(Popup): align document and demo

### DIFF
--- a/packages/vant/src/popup/demo/index.vue
+++ b/packages/vant/src/popup/demo/index.vue
@@ -161,9 +161,7 @@ const showDisplayEvents = ref(false);
       round
       position="center"
       :style="{ padding: '64px' }"
-    >
-      {{ t('content') }}
-    </van-popup>
+    />
 
     <van-cell
       :title="t('roundCornerBottom')"

--- a/packages/vant/src/popup/demo/index.vue
+++ b/packages/vant/src/popup/demo/index.vue
@@ -159,7 +159,6 @@ const showDisplayEvents = ref(false);
     <van-popup
       v-model:show="showRoundCornerCenter"
       round
-      position="center"
       :style="{ padding: '64px' }"
     />
 


### PR DESCRIPTION
<img width="1467" height="831" alt="image" src="https://github.com/user-attachments/assets/d2d1d669-55d0-4938-a039-7536b591de97" />

将 demo 中多余的文字删除，与文档示例代码保持一致