### PR TITLE
fix(Slider): precision problem

### DIFF
--- a/packages/vant/src/slider/Slider.tsx
+++ b/packages/vant/src/slider/Slider.tsx
@@ -130,7 +130,10 @@ export default defineComponent({
 
       value = clamp(value, min, max);
       const diff = Math.round((value - min) / step) * step;
-      return addNumber(min, diff);
+      const result = addNumber(min, diff);
+      // fix precision problem
+      const decimal = (step.toString().split('.')[1] || '').length;
+      return parseFloat(result.toFixed(decimal));
     };
 
     const updateStartValue = () => {


### PR DESCRIPTION
修复 issue: https://github.com/youzan/vant/issues/13718 提到的问题

---

该 PR 没有提供单测，因为不知为何原因，以下想新增的单测始终过不了

```
test('should have precision', async () => {
  const wrapper = mount(Slider, {
    props: {
      max: 1000000,
      step: 0.01,
      modelValue: 300000.03,
    },
  });

  await later();
  expect(wrapper.emitted('update:modelValue')![0]).toEqual([300000.03]);
});
```

显示 wrapper.emitted('update:modelValue') 始终为 undefined