### PR TITLE
fix(web-types): v-model:x can't generate correct web-types

### DIFF
--- a/packages/vant-cli/src/compiler/web-types/formatter.ts
+++ b/packages/vant-cli/src/compiler/web-types/formatter.ts
@@ -123,8 +123,9 @@ export function formatter(
           },
         };
 
-        if (name === 'v-model') {
-          const modelValue = 'modelValue';
+        const vModelMatch = name.match(/^v-model:([\w-]+)$/);
+        if (name === 'v-model' || vModelMatch) {
+          const modelValue = vModelMatch ? vModelMatch[1] : 'modelValue';
           // add `modelValue`
           tag.attributes.push({ ...attribute, name: modelValue });
 


### PR DESCRIPTION
修复vant-cli生成的web-types错误 - 无法正确处理v-model:show这类具名双向绑定