### PR TITLE
fix(web-types): v-model:x can't generate correct web-types

### DIFF
--- a/packages/vant-cli/src/compiler/web-types/formatter.ts
+++ b/packages/vant-cli/src/compiler/web-types/formatter.ts
@@ -123,8 +123,9 @@ export function formatter(
           },
         };
 
-        if (name === 'v-model') {
-          const modelValue = 'modelValue';
+        const vModelMatch = name.match(/^v-model:([\w-]+)$/);
+        if (name === 'v-model' || vModelMatch) {
+          const modelValue = vModelMatch ? vModelMatch[1] : 'modelValue';
           // add `modelValue`
           tag.attributes.push({ ...attribute, name: modelValue });
 

--- a/packages/vant-cli/src/compiler/web-types/formatter.ts
+++ b/packages/vant-cli/src/compiler/web-types/formatter.ts
@@ -149,9 +149,9 @@ export function formatter(
               },
             ],
           });
+        } else {
+          tag.attributes.push(attribute);
         }
-
-        tag.attributes.push(attribute);
       });
       return;
     }


### PR DESCRIPTION
vant-cli生成的web-types错误，将v-model:show等当成了普通变量处理
从而导致IDE提示异常