### PR TITLE
fix(FloatingPanel): add `-webkit-overflow-scrolling` to prevent iOS render glitch

### DIFF
--- a/packages/vant/src/floating-panel/index.less
+++ b/packages/vant/src/floating-panel/index.less
@@ -53,5 +53,6 @@
     flex: 1;
     overflow-y: auto;
     background-color: var(--van-floating-panel-background);
+    -webkit-overflow-scrolling: touch;
   }
 }


### PR DESCRIPTION
issue: #13746 