### PR TITLE
docs: fix typo in contributors link target attribute

### DIFF
--- a/packages/vant/docs/markdown/home.en-US.md
+++ b/packages/vant/docs/markdown/home.en-US.md
@@ -113,7 +113,7 @@ Core contributors of Vant and Vant Weapp:
 
 Thanks to the following friends for their contributions to Vant:
 
-<a href="https://github.com/vant-ui/vant/graphs/contributors" target="_black">
+<a href="https://github.com/vant-ui/vant/graphs/contributors" target="_blank">
   <img src="https://opencollective.com/vant/contributors.svg?width=890&button=false" alt="contributors" style="width: 100%; margin: 16px 0">
 </a>
 

--- a/packages/vant/docs/markdown/home.zh-CN.md
+++ b/packages/vant/docs/markdown/home.zh-CN.md
@@ -127,7 +127,7 @@ Vant 3/4 支持现代浏览器以及 Chrome >= 51、iOS >= 10.0（与 Vue 3 一�
 
 感谢以下小伙伴们为 Vant 发展做出的贡献：
 
-<a href="https://github.com/vant-ui/vant/graphs/contributors" target="_black">
+<a href="https://github.com/vant-ui/vant/graphs/contributors" target="_blank">
   <img src="https://opencollective.com/vant/contributors.svg?width=890&button=false" alt="contributors" style="width: 100%; margin: 16px 0">
 </a>
 


### PR DESCRIPTION
**Fixes**
Changed `target="_black"` to `target="_blank"`.

**Comments**
I initially thought `_black` was definitely a typo. After searching, I learned that it actually works by reusing the opened tab (as a named window), which is quite interesting!

However, given that `black` and `blank` are so similar, and `_blank` is the standard, I suspect this was likely a typo. I submitted this fix to follow the standard behavior.

**中文说明**
将 `target="_black"` 修改为了 `_blank`。

起初我以为这仅仅是个笔误，后来特意查了一下，发现 `_black` 这种写法竟然能复用标签页（被识别为窗口命名），这让我学到了新知识。

不过考虑到 `_black` 极易引起混淆，且通常标准写法是 `_blank`，我推测大概率还是手误，因此提交了此修复。如果原本就是为了利用“窗口复用”的特性，请忽略这条 PR，非常感谢！