### PR TITLE
fix(Popup): add PopupEmitsProps to Popup

### DIFF
--- a/packages/vant/src/action-sheet/ActionSheet.tsx
+++ b/packages/vant/src/action-sheet/ActionSheet.tsx
@@ -1,21 +1,21 @@
-import { nextTick, defineComponent, type ExtractPropTypes } from 'vue';
+import { defineComponent, nextTick, type ExtractPropTypes } from 'vue';
 
 // Utils
 import {
-  pick,
+  createNamespace,
   extend,
-  truthProp,
+  HAPTICS_FEEDBACK,
   makeArrayProp,
   makeStringProp,
-  createNamespace,
-  HAPTICS_FEEDBACK,
+  pick,
+  truthProp,
 } from '../utils';
 
 // Components
 import { Icon } from '../icon';
-import { Popup } from '../popup';
 import { Loading } from '../loading';
-import { popupSharedProps, popupSharedPropKeys } from '../popup/shared';
+import { Popup, PopupEmitsProps } from '../popup';
+import { popupSharedPropKeys, popupSharedProps } from '../popup/shared';
 
 const [name, bem] = createNamespace('action-sheet');
 
@@ -59,7 +59,7 @@ export default defineComponent({
 
   emits: ['select', 'cancel', 'update:show'],
 
-  setup(props, { slots, emit }) {
+  setup(props: ActionSheetProps & PopupEmitsProps, { emit, slots }) {
     const updateShow = (show: boolean) => emit('update:show', show);
 
     const onCancel = () => {

--- a/packages/vant/src/dialog/Dialog.tsx
+++ b/packages/vant/src/dialog/Dialog.tsx
@@ -27,7 +27,7 @@ import {
 import { popupSharedProps, popupSharedPropKeys } from '../popup/shared';
 
 // Components
-import { Popup } from '../popup';
+import { Popup, PopupEmitsProps } from '../popup';
 import { Button } from '../button';
 import { ActionBar } from '../action-bar';
 import { ActionBarButton } from '../action-bar-button';
@@ -82,7 +82,7 @@ export default defineComponent({
 
   emits: ['confirm', 'cancel', 'keydown', 'update:show'],
 
-  setup(props, { emit, slots }) {
+  setup(props: DialogProps & PopupEmitsProps, { emit, slots }) {
     const root = ref<ComponentInstance>();
     const loading = reactive({
       confirm: false,

--- a/packages/vant/src/popup/index.ts
+++ b/packages/vant/src/popup/index.ts
@@ -1,3 +1,4 @@
+import { EmitsToProps } from 'vue';
 import { withInstall } from '../utils';
 import _Popup from './Popup';
 
@@ -5,6 +6,11 @@ export const Popup = withInstall(_Popup);
 export default Popup;
 export { popupProps } from './Popup';
 export type { PopupProps } from './Popup';
+
+export type PopupEmitsProps = EmitsToProps<
+  NonNullable<(typeof Popup)['emits']>
+>;
+
 export type {
   PopupPosition,
   PopupInstance,


### PR DESCRIPTION
Before submitting a pull request, please read the [contributing guide](https://vant-ui.github.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。

issues(#13754)
1 Popup保留Emits的事件类型 PopupEmitsProps
2 actionSheet ,Dialog继承PopupEmitsProps ,不修改现有代码逻辑,只改动类型