### PR TITLE
fix(tabs): support controlled mode

### DIFF
--- a/packages/vant/src/tabs/Tabs.tsx
+++ b/packages/vant/src/tabs/Tabs.tsx
@@ -237,15 +237,6 @@ export default defineComponent({
       const newName = getTabName(newTab, newIndex);
       const shouldEmitChange = state.currentIndex !== null;
 
-      if (state.currentIndex !== newIndex) {
-        state.currentIndex = newIndex;
-
-        if (!skipScrollIntoView) {
-          scrollIntoView();
-        }
-        setLine();
-      }
-
       if (newName !== props.active) {
         emit('update:active', newName);
 
@@ -254,11 +245,21 @@ export default defineComponent({
         }
       }
 
-      // scroll to correct position
-      if (stickyFixed && !props.scrollspy) {
-        setRootScrollTop(
-          Math.ceil(getElementTop(root.value!) - offsetTopPx.value),
-        );
+      // only update current index when active prop is changed
+      if (newName === props.active && state.currentIndex !== newIndex) {
+        state.currentIndex = newIndex;
+
+        if (!skipScrollIntoView) {
+          scrollIntoView();
+        }
+        setLine();
+
+        // scroll to correct position
+        if (stickyFixed && !props.scrollspy) {
+          setRootScrollTop(
+            Math.ceil(getElementTop(root.value!) - offsetTopPx.value),
+          );
+        }
       }
     };
 


### PR DESCRIPTION
## Summary

The Tabs component was not behaving as a controlled component. Clicking a tab would change its internal state directly, ignoring the `active` prop. This change makes the internal state update conditional on the `active` prop's value, ensuring the component's state is always driven by its props when used in controlled mode.

## Changes

- **packages/vant/src/tabs/Tabs.tsx**: The `setCurrentIndex` function was modified to make the component fully controlled. Previously, it updated the internal state (`state.currentIndex`) immediately on click, causing a disconnect with the `active` prop. The fix makes the state update conditional, only allowing it when the new tab's name matches the `active` prop. This ensures the component's state is always driven by its props, fixing the controlled mode behavior.

## Related Issue

Closes #12005

