### PR TITLE
fix(Image): inline ImageFit and ImagePosition types to avoid csstype leak (TS2742)

### DIFF
--- a/packages/vant/src/image/test/index.spec.ts
+++ b/packages/vant/src/image/test/index.spec.ts
@@ -2,6 +2,7 @@ import 'rstest-canvas-mock';
 import { mount } from '../../../test';
 import { Lazyload } from '../../lazyload';
 import VanImage from '..';
+import type { ImageFit, ImagePosition } from '../types';
 
 const IMAGE_URL = 'https://img.com';
 
@@ -244,3 +245,25 @@ test('should render default slot correctly', () => {
 //     },
 //   });
 // });
+
+// Regression test for https://github.com/youzan/vant/issues/13818
+// ImageFit and ImagePosition must be self-contained types that do not
+// reference csstype, so that consumers generating d.ts files do not
+// encounter TS2742 ("cannot be named without a reference to …csstype").
+test('ImageFit only allows valid CSS object-fit keywords', () => {
+  const validFits: ImageFit[] = ['contain', 'cover', 'fill', 'none', 'scale-down'];
+  validFits.forEach((fit) => {
+    const wrapper = mount(VanImage, {
+      props: { src: 'https://img.com', fit },
+    });
+    expect(wrapper.find('img').attributes('style')).toContain(`object-fit: ${fit}`);
+  });
+});
+
+test('ImagePosition accepts a string value', () => {
+  const position: ImagePosition = 'center top';
+  const wrapper = mount(VanImage, {
+    props: { src: 'https://img.com', position },
+  });
+  expect(wrapper.find('img').attributes('style')).toContain('object-position: center top');
+});

--- a/packages/vant/src/image/types.ts
+++ b/packages/vant/src/image/types.ts
@@ -1,8 +1,13 @@
-import type { CSSProperties } from 'vue';
+// Use explicit union types instead of CSSProperties lookups to avoid
+// csstype leaking into consumers' generated d.ts files (TS2742).
+export type ImageFit =
+  | 'contain'
+  | 'cover'
+  | 'fill'
+  | 'none'
+  | 'scale-down';
 
-export type ImageFit = CSSProperties['objectFit'];
-
-export type ImagePosition = CSSProperties['objectPosition'];
+export type ImagePosition = string;
 
 export type ImageThemeVars = {
   imagePlaceholderTextColor?: string;


### PR DESCRIPTION
**Problem**

When consumers wrap `Image` in their own components and run `vue-tsc` or `vite-plugin-dts` to generate `.d.ts` files, the output contains a reference to `csstype.Property.ObjectFit` — a type from a transitive dependency not in the consumer's `node_modules`. This triggers **TS2742**: *"The inferred type cannot be named without a reference to '…/csstype'."*

Root cause: `ImageFit` and `ImagePosition` were defined as `CSSProperties['objectFit']` and `CSSProperties['objectPosition']`, which resolve through `csstype`.

Fixes #13818

**Solution**

- `ImageFit` → explicit union `'contain' | 'cover' | 'fill' | 'none' | 'scale-down'`
- `ImagePosition` → `string` (covers all valid CSS `object-position` values)
- Removed the now-unused `import type { CSSProperties } from 'vue'`

**Tests**

Added regression tests in `packages/vant/src/image/test/index.spec.ts` verifying all `ImageFit` keywords render with the correct `object-fit` style, and that `ImagePosition` accepts a string value.
