### PR TITLE
feat(image-preview): expose prev/next methods

### DIFF
--- a/packages/vant/src/image-preview/ImagePreview.tsx
+++ b/packages/vant/src/image-preview/ImagePreview.tsx
@@ -217,6 +217,10 @@ export default defineComponent({
 
     const onClosed = () => emit('closed');
 
+    const prev = () => swipeRef.value?.prev();
+
+    const next = () => swipeRef.value?.next();
+
     const swipeTo = (index: number, options?: SwipeToOptions) =>
       swipeRef.value?.swipeTo(index, options);
 
@@ -225,6 +229,8 @@ export default defineComponent({
         activedPreviewItemRef.value?.resetScale();
       },
       swipeTo,
+      prev,
+      next,
     });
 
     onMounted(resize);

--- a/packages/vant/src/image-preview/README.zh-CN.md
+++ b/packages/vant/src/image-preview/README.zh-CN.md
@@ -290,6 +290,8 @@ Vant 中导出了以下 ImagePreview 相关的辅助函数：
 
 | 方法名 | 说明 | 参数 | 返回值 |
 | --- | --- | --- | --- |
+| prev | 切换到上一轮播 | - | - |
+| next | 切换到下一轮播 | - | - |
 | resetScale `4.7.4` | 重置当前图片的缩放比 | - | - |
 | swipeTo | 切换到指定位置 | _index: number, options?: SwipeToOptions_ | - |
 

--- a/packages/vant/src/image-preview/README.zh-CN.md
+++ b/packages/vant/src/image-preview/README.zh-CN.md
@@ -290,8 +290,8 @@ Vant 中导出了以下 ImagePreview 相关的辅助函数：
 
 | 方法名 | 说明 | 参数 | 返回值 |
 | --- | --- | --- | --- |
-| prev | 切换到上一轮播 | - | - |
-| next | 切换到下一轮播 | - | - |
+| prev | 切换到上一张图片 | - | - |
+| next | 切换到下一张图片 | - | - |
 | resetScale `4.7.4` | 重置当前图片的缩放比 | - | - |
 | swipeTo | 切换到指定位置 | _index: number, options?: SwipeToOptions_ | - |
 

--- a/packages/vant/src/image-preview/types.ts
+++ b/packages/vant/src/image-preview/types.ts
@@ -54,6 +54,8 @@ export type ImagePreviewItemInstance = ComponentPublicInstance<
 export type ImagePreviewExpose = {
   resetScale: () => void;
   swipeTo: (index: number, options?: SwipeToOptions) => void;
+  prev: () => void;
+  next: () => void;
 };
 
 export type ImagePreviewInstance = ComponentPublicInstance<


### PR DESCRIPTION
feat(image-preview): expose prev() and next() methods

## 📝 Description
This PR exposes the internal `prev()` and `next()` methods of the `ImagePreview` component, which implement the same logic as gesture-based swiping. These methods allow developers to programmatically navigate between images with native seamless looping behavior.

## 🎯 Problem solved
Currently, the `ImagePreview` component only exposes the `swipeTo(index)` method. When using `swipeTo()` in infinite loop mode, there is a critical limitation:
- When calling `swipeTo(0)` from the last image, or `swipeTo(length-1)` from the first image, the transition cannot use the "virtual slide" mechanism, resulting in a jump instead of a smooth, seamless loop animation.
- Developers have no way to programmatically trigger the same smooth looping behavior that exists in gesture swipes.

This severely limits custom navigation scenarios that require seamless transitions, such as:
- Custom left/right arrow buttons like in car galleries
- Keyboard navigation support
- Timed auto-play with infinite loop
- Custom indicator-driven image switching

## ✨ Changes made
- Exposed `prev()` and `next()` methods on the component instance
- Both methods use the internal gesture swipe logic, supporting native seamless looping
- No breaking changes to existing props, events, or behaviors

## 🧪 Testing
- Verified that `prev()` and `next()` trigger the same smooth loop animation as swiping
- Confirmed that infinite loop works correctly at both the first and last image
- All existing tests pass

This is a backward-compatible, high-demand enhancement that unlocks seamless custom navigation for infinite loop scenarios.