### PR TITLE
fix(Field): prevent click event when disabled with is-link

### DIFF
--- a/packages/vant/src/cell/Cell.tsx
+++ b/packages/vant/src/cell/Cell.tsx
@@ -163,7 +163,7 @@ export default defineComponent({
           class={bem(classes)}
           role={clickable ? 'button' : undefined}
           tabindex={clickable ? 0 : undefined}
-          onClick={route}
+          onClick={clickable ? route : undefined}
         >
           {renderLeftIcon()}
           {renderTitle()}

--- a/packages/vant/src/cell/test/index.spec.ts
+++ b/packages/vant/src/cell/test/index.spec.ts
@@ -95,6 +95,18 @@ test('should allow to disable clickable when using is-link prop', () => {
   expect(wrapper.classes()).not.toContain('van-cell--clickable');
 });
 
+test('should not render as button when clickable is false with is-link prop', () => {
+  const wrapper = mount(Cell, {
+    props: {
+      isLink: true,
+      clickable: false,
+    },
+  });
+  const root = wrapper.find('.van-cell');
+  expect(root.attributes('role')).toBeFalsy();
+  expect(root.attributes('tabindex')).toBeFalsy();
+});
+
 test('should render tag prop correctly', () => {
   const wrapper = mount(Cell, {
     props: {

--- a/packages/vant/src/field/Field.tsx
+++ b/packages/vant/src/field/Field.tsx
@@ -726,8 +726,13 @@ export default defineComponent({
           })}
           center={props.center}
           border={props.border}
-          isLink={props.isLink}
-          clickable={props.clickable}
+          isLink={disabled ? false : props.isLink}
+          clickable={disabled ? false : props.clickable}
+          onClick={
+            disabled
+              ? (e: MouseEvent) => e.stopImmediatePropagation()
+              : undefined
+          }
           titleStyle={labelStyle.value}
           valueClass={bem('value')}
           titleClass={[

--- a/packages/vant/src/field/test/index.spec.ts
+++ b/packages/vant/src/field/test/index.spec.ts
@@ -357,6 +357,32 @@ test('should change arrow direction when using arrow-direction prop', () => {
   expect(wrapper.find('.van-icon-arrow-up').exists()).toBeTruthy();
 });
 
+test('should not trigger click event when disabled with is-link', () => {
+  const onClick = rs.fn();
+  const wrapper = mount(Field, {
+    props: {
+      disabled: true,
+      isLink: true,
+      onClick,
+    },
+  });
+
+  wrapper.trigger('click');
+  expect(onClick).not.toHaveBeenCalled();
+});
+
+test('should not show arrow icon when disabled with is-link', () => {
+  const wrapper = mount(Field, {
+    props: {
+      disabled: true,
+      isLink: true,
+    },
+  });
+
+  expect(wrapper.find('.van-icon-arrow').exists()).toBeFalsy();
+  expect(wrapper.find('.van-cell--clickable').exists()).toBeFalsy();
+});
+
 test('should allow to format value with formatter prop', () => {
   const wrapper = mount(Field, {
     props: {


### PR DESCRIPTION

**Problem**

When `van-field` has `disabled=true` and `is-link=true`, clicking the arrow icon area still triggers the `@click` event. This happens because:

1. `Cell` always attaches `onClick={route}` regardless of the `clickable` state
2. `Field` does not override `isLink`/`clickable` when `disabled`
Fixes #13843

**Solution**

- `Cell.tsx`: only attach `onClick` when `clickable` is `true`
- `Field.tsx`: suppress `isLink` and `clickable` when `disabled`, and use `stopImmediatePropagation` to prevent fallthrough `@click` handlers from firing

**Changes**

| File | Change |
|------|--------|
| `packages/vant/src/cell/Cell.tsx` | Conditionally attach `onClick` based on `clickable` state |
| `packages/vant/src/field/Field.tsx` | Suppress `isLink`/`clickable` and block clicks when disabled |
| `packages/vant/src/cell/test/index.spec.ts` | Add test: disabled clickable with is-link |
| `packages/vant/src/field/test/index.spec.ts` | Add tests: disabled + isLink click + arrow visibility |

**Before**: Clicking arrow on disabled Field triggers `@click`  
**After**: Disabled Field shows no arrow and blocks all click events

## Change Description
Fix `van-field` disabled + is-link still responding to `@click`

## Change Type
- [x] Bug fix (fix)

## Testing Method
1. Set `van-field` with `disabled=true` `is-link=true` `@click=handler`
2. Click the right-side area (where arrow would be)
3. `handler` should not be called


## Checklist
- [x] Code has been self-tested
- [x] Unit tests added and passing
- [x] Lint checks passing