### PR TITLE
fix(locale): correct Japanese (ja-JP) translations

### DIFF
--- a/packages/vant/src/locale/lang/ja-JP.ts
+++ b/packages/vant/src/locale/lang/ja-JP.ts
@@ -44,8 +44,8 @@ export default {
     count: (count: number) => `${count}枚が利用可能`,
   },
   vanCouponList: {
-    exchange: '両替',
-    close: '使用禁止',
+    exchange: '交換',
+    close: '使用しない',
     enable: '利用可能',
     disabled: '利用できません',
     placeholder: '割引コードを入力してください',


### PR DESCRIPTION
Corrects two inaccurate strings in the Japanese (`ja-JP`) locale, both in `vanCouponList`:

- `exchange`: "両替" → "交換". This key is the redeem button for entering a coupon code (`exchange-button-text`, default `Exchange`). "両替" specifically means exchanging money/currency, not redeeming a code. The other locales use a general exchange/redeem word here (zh-CN `兑换`, ko-KR `교환`).
- `close`: "使用禁止" → "使用しない". This is the close button text for proceeding without selecting a coupon. "使用禁止" reads as "use is forbidden", which sounds like the system is blocking the coupon rather than the user opting out. zh-CN uses `不使用` ("do not use"), so "使用しない" matches the intended meaning.

No keys added or removed. Same kind of fix as the recent locale corrections in #13853.

Disclosure: prepared with AI assistance and reviewed by me as a native Japanese speaker.