### PR TITLE
fix(locale): correct German weekdays translation

### DIFF
--- a/packages/vant/src/locale/lang/de-DE.ts
+++ b/packages/vant/src/locale/lang/de-DE.ts
@@ -16,7 +16,7 @@ export default {
     end: 'Ende',
     start: 'Start',
     title: 'Kalender',
-    weekdays: ['So', 'Mo', 'Di', 'Mo', 'Do', 'Fr', 'Sa'],
+    weekdays: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa'],
     monthTitle: (year: number, month: number) => `${year}/${month}`,
     rangePrompt: (maxRange: number) => `Wähle nicht mehr als ${maxRange} Tage`,
   },


### PR DESCRIPTION
The German locale file contains a typo in the `weekdays` array. "Mittwoch" (Wednesday) was incorrectly listed as "Mo" (Monday) for a second time.

### Changes
- Fixed `vanCalendar.weekdays` in `de-DE.ts`.

**Before:**
`weekdays: ['So', 'Mo', 'Di', 'Mo', 'Do', 'Fr', 'Sa']`

**After:**
`weekdays: ['So', 'Mo', 'Di', 'Mi', 'Do', 'Fr', 'Sa']`
