### PR TITLE
chore(ci): align workflow Node.js version with package engines

### DIFF
--- a/.github/workflows/deploy-v4-site.yml
+++ b/.github/workflows/deploy-v4-site.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.22.3'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.22.3'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -45,7 +45,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.22.3'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies
@@ -72,7 +72,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.22.3'
+          node-version: '24'
           cache: 'pnpm'
 
       - name: Install dependencies


### PR DESCRIPTION
## Why
Package metadata declares `engines.node` / `volta.node` / `.nvmrc` as `24`, but CI workflows still pin `node-version` to a mismatched value.

That can make CI run on a runtime the project no longer supports (or skip the version the package actually targets).

## What changed
Update the affected workflow `node-version` pins so they satisfy `24` (using `24` where a concrete pin is needed).

- `.github/workflows/deploy-v4-site.yml`
  - `node-version: '22.22.3'` → `node-version: '24'`
- `.github/workflows/test.yml`
  - `node-version: '22.22.3'` → `node-version: '24'`
  - `node-version: '22.22.3'` → `node-version: '24'`
  - `node-version: '22.22.3'` → `node-version: '24'`

## Test plan
- [ ] Package `engines.node` / `volta.node` / `.nvmrc` is still `24`
- [ ] Updated workflows now use versions consistent with that constraint
- [ ] Relevant CI jobs on this branch look healthy

Found while auditing CI/package version consistency across popular repos.
