### PR TITLE
docs: remove broken contributors section

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -162,14 +162,6 @@ Vant および Vant Weapp のコアコントリビューター：
 | :-: | :-: | :-: | :-: | :-: | :-: |
 | [Lindysen](https://github.com/Lindysen/) | [JakeLaoyu](https://github.com/JakeLaoyu/) | [landluck](https://github.com/landluck/) | [wjw-gavin](https://github.com/wjw-gavin/) | [inottn](https://github.com/inottn/) | [zhousg](https://github.com/zhousg/) |
 
-## 全コントリビューター
-
-Vant への貢献に感謝します：
-
-<a href="https://github.com/vant-ui/vant/graphs/contributors">
-  <img src="https://opencollective.com/vant/contributors.svg?width=890&button=false" alt="contributors">
-</a>
-
 ## コントリビューションガイド
 
 プルリクエストを作成する前に必ず [コントリビューティングガイド](./.github/CONTRIBUTING.md) をお読みください。

--- a/README.md
+++ b/README.md
@@ -162,14 +162,6 @@ Core contributors of Vant and Vant Weapp:
 | :-: | :-: | :-: | :-: | :-: | :-: |
 | [Lindysen](https://github.com/Lindysen/) | [JakeLaoyu](https://github.com/JakeLaoyu/) | [landluck](https://github.com/landluck/) | [wjw-gavin](https://github.com/wjw-gavin/) | [inottn](https://github.com/inottn/) | [zhousg](https://github.com/zhousg/) |
 
-## All Contributors
-
-Thanks to the following friends for their contributions to Vant:
-
-<a href="https://github.com/vant-ui/vant/graphs/contributors">
-  <img src="https://opencollective.com/vant/contributors.svg?width=890&button=false" alt="contributors">
-</a>
-
 ## Contribution Guide
 
 Please make sure to read the [Contributing Guide](./.github/CONTRIBUTING.md) before making a pull request.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -163,14 +163,6 @@ Vant 3/4 支持现代浏览器以及 Chrome >= 51、iOS >= 10.0（与 Vue 3 一�
 | :-: | :-: | :-: | :-: | :-: | :-: |
 | [Lindysen](https://github.com/Lindysen/) | [JakeLaoyu](https://github.com/JakeLaoyu/) | [landluck](https://github.com/landluck/) | [wjw-gavin](https://github.com/wjw-gavin/) | [inottn](https://github.com/inottn/) | [zhousg](https://github.com/zhousg/) |
 
-## 贡献者们
-
-感谢以下小伙伴们为 Vant 发展做出的贡献：
-
-<a href="https://github.com/vant-ui/vant/graphs/contributors">
-  <img src="https://opencollective.com/vant/contributors.svg?width=890&button=false" alt="contributors">
-</a>
-
 ## 贡献指南
 
 修改代码请阅读我们的 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。


### PR DESCRIPTION
The Open Collective contributors image embedded in the READMEs no longer loads because the upstream resource is unavailable. This removes the broken contributors section from the English, Chinese, and Japanese READMEs.