### PR TITLE
ci: pin actions to commit SHAs and declare workflow permissions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -36,11 +36,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -51,7 +51,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -65,4 +65,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6

--- a/.github/workflows/deploy-v4-site.yml
+++ b/.github/workflows/deploy-v4-site.yml
@@ -8,6 +8,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-and-deploy:
     if: github.repository == 'youzan/vant'

--- a/.github/workflows/deploy-v4-site.yml
+++ b/.github/workflows/deploy-v4-site.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-26
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           ref: 'main'
           persist-credentials: false
@@ -24,7 +24,7 @@ jobs:
           npm install -g corepack@latest --force 
           corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -36,7 +36,7 @@ jobs:
         run: npm run build:site
 
       - name: Deploy for GitHub 🚀
-        uses: JamesIves/github-pages-deploy-action@v4.8.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           branch: gh-pages
           folder: packages/vant/site-dist

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -6,6 +6,11 @@ on:
       - opened
       - edited
 
+permissions:
+  # Read .github/pr-labeler.yml and apply labels to the pull request.
+  contents: read
+  pull-requests: write
+
 jobs:
   change-labeling:
     name: Labeling for changes

--- a/.github/workflows/pr-label.yaml
+++ b/.github/workflows/pr-label.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Labeling for changes
     runs-on: ubuntu-latest
     steps:
-      - uses: github/issue-labeler@v3.4
+      - uses: github/issue-labeler@c1b0f9f52a63158c4adc09425e858e87b32e9685 # v3.4
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           configuration-path: .github/pr-labeler.yml

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -5,10 +5,16 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Create Release
     runs-on: ubuntu-latest
+    permissions:
+      # Create the GitHub release and generate its notes.
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Create Release for Tag
         id: release_tag
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           generateReleaseNotes: "true"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,9 @@ on:
 
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,14 +15,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install pnpm
         run: |
           npm install -g corepack@latest --force 
           corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -36,14 +36,14 @@ jobs:
   test:
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install pnpm
         run: |
           npm install -g corepack@latest --force 
           corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'pnpm'
@@ -55,7 +55,7 @@ jobs:
         run: pnpm run test:coverage
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v6.0.2
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./packages/vant/test/coverage
@@ -63,14 +63,14 @@ jobs:
   build:
     runs-on: macos-26
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
 
       - name: Install pnpm
         run: |
           npm install -g corepack@latest --force 
           corepack enable
 
-      - uses: actions/setup-node@v6
+      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
         with:
           node-version: '24'
           cache: 'pnpm'


### PR DESCRIPTION
Hi, drive-by CI hardening in two commits, one logical change each.

**Commit 1 pins every action to its commit sha**, versions kept as comments. A tag like `@v1` or `@v4.8.0` is a movable pointer: whoever controls the action, or anyone who compromises it, can re-point it and your next run executes their code with the job's credentials. The two spots that matter here: `deploy-v4-site.yml` runs with `VANT_UI_TOKEN`, which can push to the public documentation site repo, and `release-tag.yml` creates the GitHub releases. Same pattern as the tj-actions/changed-files incident (CVE-2025-30066). You already pin `actions/stale` by sha in `issue-close-require.yml`, this just finishes the job: every sha was resolved from the upstream repo and cross checked against its release tag. The pins stay maintainable: Renovate understands digest pins and your config already automerges digest updates, so they keep themselves fresh.

**Commit 2 scopes the GITHUB_TOKEN per workflow**, derived from what each job actually uses: `test.yml` and `deploy-v4-site.yml` drop to `contents: read` (the site deploy pushes with its own token, and the checkout already sets `persist-credentials: false`, nicely done); `release-tag.yml` gets `contents: write` on the job that creates the release; `pr-label.yaml` runs on `pull_request_target` so an exact scope matters most there, it gets `contents: read` plus `pull-requests: write`. CodeQL and both issue workflows already declare scoped permissions and are untouched.

One heads up: if the org uses an Actions allowlist in settings, patterns written against tags (like `owner/action@v1`) stop matching once refs are shas and workflows refuse to start. Entries need to be `owner/action@*` in that case.

Found with the Plumber CLI (https://github.com/getplumber/plumber), verified on main. I also open a PR which adds it to CI so this does not quietly drift back, that one is a bonus, this PR stands on its own.