### PR TITLE
ci: add Plumber workflow security check

### DIFF
--- a/.github/workflows/plumber.yml
+++ b/.github/workflows/plumber.yml
@@ -1,0 +1,37 @@
+name: Plumber
+
+on:
+  push:
+    branches: [main]
+
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  plumber:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      security-events: write
+      # Needed by score-push to publish the score for the README badge.
+      id-token: write
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+
+      - uses: getplumber/plumber@24de99968c08ffe230545f413695ad933208b0d2 # v0.4.29
+        with:
+          # Code scanning upload needs security-events write, which PRs
+          # from forks do not get. The report stays available as a
+          # workflow artifact there.
+          upload-sarif: ${{ github.event.pull_request.head.repo.fork != true }}
+          # Publishes the score to score.getplumber.io, which feeds the
+          # badge in the README. A failed push never fails the run.
+          score-push: true
+          # Gate at 85 points instead of the all-or-nothing default,
+          # leaves room for a small finding without blocking PRs.
+          min-points: 85

--- a/.plumber.yaml
+++ b/.plumber.yaml
@@ -1,0 +1,15 @@
+# Plumber overlay: inherits every control from the CLI's built-in
+# baseline, only the differences for this repo are written here.
+# Run 'plumber config resolve' to see the full effective config.
+extends: plumber:default
+version: '2.0'
+
+github:
+  controls:
+    githubActionMustComeFromAuthorizedSources:
+      # Keep the curated default list and trust the release and site
+      # deploy actions this repo already uses on top of it.
+      includePlumberDefaults: true
+      trustedGithubActions:
+        - JamesIves/github-pages-deploy-action
+        - ncipollo/release-action

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
     <img src="https://img.shields.io/npm/v/vant?style=flat-square" alt="npm version" />
     <img src="https://img.shields.io/codecov/c/github/youzan/vant/main.svg?style=flat-square&color=#4fc08d" alt="Coverage Status" />
     <img src="https://img.shields.io/npm/dm/vant.svg?style=flat-square&color=#4fc08d" alt="downloads" />
+    <a href="https://score.getplumber.io/github.com/youzan/vant"><img src="https://score.getplumber.io/github.com/youzan/vant.svg" alt="plumber score" /></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
Companion to https://github.com/youzan/vant/pull/13889, merge that one first: the check added here flags the unpinned actions and the missing permission scopes until the hardening lands, then it goes green.

This adds [Plumber](https://github.com/getplumber/plumber) to CI, the tool I used to find those issues in the first place. It scans the workflows on each push to main and on each PR, and fails when something regresses: an unpinned action, a job without a permissions block, a known vulnerable action version, that kind of thing. The gate passes at 85 of 100 points, so one small finding does not block your PRs.

- `plumber.yml`: pinned by sha, minimal permissions, findings go to the Security tab as SARIF (skipped on PRs from forks, the report stays as a workflow artifact there).
- `.plumber.yaml`: a small overlay that inherits the tool's built-in baseline; the only thing written is what differs for this repo, the release and site deploy actions already in use are trusted on top of the curated default source list. Everything else, including new controls in future releases, follows the defaults automatically.
- `README.md`: one line, the score badge next to the npm ones.

## Score badge

I enabled `score-push` on the action. It works like OpenSSF Scorecard's published results: every run, on any branch, publishes the score to score.getplumber.io, and that feeds the badge in the README. Scores are public and the badge always shows the state of main. A failed publish never fails your CI. Until the first run the badge reads UNKNOWN in gray, then it flips to the grade. If you would rather not have it, drop the README line and the `score-push` input, the rest works the same.

With the hardening in, this runs green with a score of A. Set `soft-fail: true` if you prefer report only, without gating PRs.

To be fully transparent: I work on Plumber. If you do not want the tool in your CI, no hard feelings, say so and I close this PR, the hardening PR stands on its own.