### PR TITLE
fix(Cell): restore clickable behavior when to or url prop is set

### DIFF
--- a/packages/vant/src/cell/Cell.tsx
+++ b/packages/vant/src/cell/Cell.tsx
@@ -146,7 +146,11 @@ export default defineComponent({
 
     return () => {
       const { tag, size, center, border, isLink, required } = props;
-      const clickable = props.clickable ?? isLink;
+      // `to` / `url` props imply clickable behavior (same as before v4.10.0),
+      // so Cells with a route target keep working without an explicit `clickable` prop.
+      const clickable = Boolean(
+        props.clickable ?? props.to ?? props.url ?? isLink,
+      );
 
       const classes: Record<string, boolean | undefined> = {
         center,

--- a/packages/vant/src/cell/test/index.spec.ts
+++ b/packages/vant/src/cell/test/index.spec.ts
@@ -107,6 +107,27 @@ test('should not render as button when clickable is false with is-link prop', ()
   expect(root.attributes('tabindex')).toBeFalsy();
 });
 
+test('should be clickable when only to prop is set (regression #13868)', () => {
+  const wrapper = mount(Cell, {
+    props: {
+      to: '/foo',
+    },
+  });
+  expect(wrapper.classes()).toContain('van-cell--clickable');
+  const root = wrapper.find('.van-cell');
+  expect(root.attributes('role')).toEqual('button');
+  expect(root.attributes('tabindex')).toEqual('0');
+});
+
+test('should be clickable when only url prop is set (regression #13868)', () => {
+  const wrapper = mount(Cell, {
+    props: {
+      url: 'https://example.com',
+    },
+  });
+  expect(wrapper.classes()).toContain('van-cell--clickable');
+});
+
 test('should render tag prop correctly', () => {
   const wrapper = mount(Cell, {
     props: {


### PR DESCRIPTION
## Description

Fixes #13868: since v4.10.0, Cells that only set the `to` or `url` prop (without an explicit `clickable`) no longer route on click.

## Root Cause

v4.10.0 (#13846, `fix(Field): prevent click event when disabled with is-link`) changed `onClick` to only bind when `clickable` is true, but the `clickable` computation only considered the `clickable` and `isLink` props. The implicit clickable behavior of `to` / `url` (working since before v4.10.0) was silently dropped.

## Changes

- `Cell.tsx`: include `to` / `url` in the clickable computation:
  ```ts
  const clickable = Boolean(props.clickable ?? props.to ?? props.url ?? isLink)
  ```
- The `??` chain keeps the explicit opt-out: `clickable={false}` still disables interaction (existing test still passes).
- Added two regression tests for `to`-only and `url`-only cells.

## Verification

- `rstest run src/cell/test`: 15/15 passed (2 new)
- `rstest run src/field/test`: 52/52 passed — confirms #13846's disabled+is-link fix is not regressed