### PR TITLE
docs: update the Viewport layout adaptation example

### DIFF
--- a/packages/vant/docs/markdown/advanced-usage.en-US.md
+++ b/packages/vant/docs/markdown/advanced-usage.en-US.md
@@ -89,7 +89,15 @@ export default {
 
 ### Viewport Units
 
-Vant uses `px` unit by default，you can use tools such as [postcss--px-to-viewport](https://github.com/evrone/postcss-px-to-viewport) to transform `px` unit to viewport units (vw, vh, vmin, vmax).
+Vant uses `px` unit by default, you can use [postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever) to transform `px` unit to viewport units (vw, vh, vmin, vmax).
+
+[postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever) is a PostCSS 8 based plugin that transforms `px` units to `vw`/`vh` units. It supports `include`/`exclude` file matching and per-file dynamic `viewportWidth`.
+
+#### Install
+
+```bash
+npm i postcss-mobile-forever -D
+```
 
 #### PostCSS Config
 
@@ -98,11 +106,20 @@ PostCSS config example:
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: {
-    'postcss-px-to-viewport': {
-      viewportWidth: 375,
-    },
-  },
+  plugins: [require('postcss-mobile-forever')({ viewportWidth: 375 })],
+};
+```
+
+If the design width is not 375, use the `viewportWidth` function to configure it per file. The following example handles Vant components (375px design) and business code (750px design) separately:
+
+```js
+// postcss.config.js
+module.exports = {
+  plugins: [
+    require('postcss-mobile-forever')({
+      viewportWidth: (file) => (file.includes('vant') ? 375 : 750),
+    }),
+  ],
 };
 ```
 

--- a/packages/vant/docs/markdown/advanced-usage.zh-CN.md
+++ b/packages/vant/docs/markdown/advanced-usage.zh-CN.md
@@ -146,22 +146,37 @@ export default {
 
 ### Viewport 布局
 
-Vant 默认使用 `px` 作为样式单位，如果需要使用 `viewport` 单位 (vw, vh, vmin, vmax)，推荐使用 [postcss-px-to-viewport](https://github.com/evrone/postcss-px-to-viewport) 进行转换。
+Vant 默认使用 `px` 作为样式单位，如果需要使用 `viewport` 单位 (vw, vh, vmin, vmax)，推荐使用 [postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever) 进行转换。
 
-[postcss-px-to-viewport](https://github.com/evrone/postcss-px-to-viewport) 是一款 PostCSS 插件，用于将 px 单位转化为 vw/vh 单位。
+[postcss-mobile-forever](https://github.com/wswmsword/postcss-mobile-forever) 是一款基于 PostCSS 8 的插件，用于将 `px` 单位转化为 `vw`/`vh` 单位，支持 `include`/`exclude` 文件匹配，以及按文件动态配置设计稿宽度。
 
-#### PostCSS PostCSS 示例配置
+#### 安装
+
+```bash
+npm i postcss-mobile-forever -D
+```
+
+#### PostCSS 示例配置
 
 下面提供了一份基本的 PostCSS 示例配置，可以在此配置的基础上根据项目需求进行修改。
 
 ```js
 // postcss.config.js
 module.exports = {
-  plugins: {
-    'postcss-px-to-viewport': {
-      viewportWidth: 375,
-    },
-  },
+  plugins: [require('postcss-mobile-forever')({ viewportWidth: 375 })],
+};
+```
+
+如果设计稿的尺寸不是 375，而是 750 或其他大小，可以通过 `viewportWidth` 函数按文件动态配置。下面的示例将 Vant 组件（375px 设计稿）与业务代码（750px 设计稿）分开处理：
+
+```js
+// postcss.config.js
+module.exports = {
+  plugins: [
+    require('postcss-mobile-forever')({
+      viewportWidth: (file) => (file.includes('vant') ? 375 : 750),
+    }),
+  ],
 };
 ```
 


### PR DESCRIPTION
postcss-px-to-viewport 已停止维护:2020 年后无发布,使用已废弃的
postcss.plugin API(不兼容 PostCSS 8),且从未实现 include 配置。 社区 fork postcss-px-to-viewport-8-plugin 同样停更且不支持 include。

postcss-mobile-forever 持续维护(最新 5.0.0),基于 PostCSS 8 构建, 支持 include/exclude 与按文件动态配置 viewportWidth,可解决 Vant 组件 375 + 业务代码 750 混合设计稿场景。

顺带修正原文两处笔误:PostCSS PostCSS 重复词、postcss--px-to-viewport 多余连字符。

关联 issue: #11242 #10662 #10955

Before submitting a pull request, please read the [contributing guide](https://vant-ui.github.io/vant/#/en-US/contribution).

在提交 pull request 之前，请阅读 [贡献指南](https://vant-ui.github.io/vant/#/zh-CN/contribution)。
