### PR TITLE
chore: resolve Rstack config type errors

### DIFF
--- a/packages/create-vant-cli-app/tsconfig.json
+++ b/packages/create-vant-cli-app/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2019",
     "outDir": "./lib",
     "module": "commonjs",
+    "moduleResolution": "Node",
     "declaration": true
   },
   "include": ["src/**/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "compilerOptions": {
-    "baseUrl": ".",
     "jsx": "preserve",
     "jsxImportSource": "vue",
     "strict": true,
@@ -8,7 +7,7 @@
     "module": "ESNext",
     "skipLibCheck": true,
     "esModuleInterop": true,
-    "moduleResolution": "Node",
+    "moduleResolution": "bundler",
     "lib": ["esnext", "dom"]
   }
 }


### PR DESCRIPTION
This PR switches the root TypeScript configuration to Bundler module resolution so `rstack.config.ts` receives contextual types from Rstack's package exports. The CommonJS `create-vant-cli-app` package explicitly keeps Node module resolution to preserve its existing build behavior.